### PR TITLE
remove build info from ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ MAIN_PKG=cmd/$(APP_NAME)/main.go
 
 # These will be provided to the target
 #VERSION := 1.0.0
-BUILD := `git rev-parse HEAD`
+#BUILD := `git rev-parse HEAD`
 
 # Use linker flags to provide version/build settings to the target
 #LDFLAGS=-ldflags "-X=main.Version=$(VERSION) -X=main.Build=$(BUILD)"
-LDFLAGS=-ldflags "-X=main.Build=$(BUILD)"
+#LDFLAGS=-ldflags "-X=main.Build=$(BUILD)"
 
 # go source files, ignore vendor directory
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")


### PR DESCRIPTION
This PR removes build info from compile to resolve downstream issue