### PR TITLE
Enable log level and format selection

### DIFF
--- a/cmd/elasticsearch-operator/main.go
+++ b/cmd/elasticsearch-operator/main.go
@@ -2,15 +2,55 @@ package main
 
 import (
 	"context"
+	"flag"
+	"fmt"
+	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	stub "github.com/openshift/elasticsearch-operator/pkg/stub"
+	"github.com/openshift/elasticsearch-operator/pkg/utils"
 	sdk "github.com/operator-framework/operator-sdk/pkg/sdk"
 	k8sutil "github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 
 	"github.com/sirupsen/logrus"
+)
+
+const (
+	// supported log formats
+	logFormatLogfmt = "logfmt"
+	logFormatJSON   = "json"
+
+	// supported log levels
+	logLevelPanic = "panic"
+	logLevelFatal = "fatal"
+	logLevelError = "error"
+	logLevelWarn  = "warn"
+	logLevelInfo  = "info"
+	logLevelDebug = "debug"
+
+	// env vars
+	logLevelEnv  = "LOG_LEVEL"
+	logFormatEnv = "LOG_FORMAT"
+)
+
+var (
+	logLevel           string
+	logFormat          string
+	availableLogLevels = []string{
+		logLevelPanic,
+		logLevelFatal,
+		logLevelError,
+		logLevelWarn,
+		logLevelInfo,
+		logLevelDebug,
+	}
+	availableLogFormats = []string{
+		logFormatLogfmt,
+		logFormatJSON,
+	}
 )
 
 func printVersion() {
@@ -19,7 +59,54 @@ func printVersion() {
 	logrus.Infof("operator-sdk Version: %v", sdkVersion.Version)
 }
 
-func main() {
+func init() {
+	// default values are ""
+	// that means that if no arguments are provided env variables take precedence
+	// otherwise command-line arguments take precendence
+	flagset := flag.CommandLine
+	flagset.StringVar(&logLevel, "log-level", "", fmt.Sprintf("Log level to use. Possible values: %s", strings.Join(availableLogLevels, ", ")))
+	flagset.StringVar(&logFormat, "log-format", "", fmt.Sprintf("Log format to use. Possible values: %s", strings.Join(availableLogFormats, ", ")))
+	flagset.Parse(os.Args[1:])
+}
+
+func initLogger() error {
+	// first check cmd arguments, then environment variables
+	if logLevel == "" {
+		logLevel = utils.LookupEnvWithDefault(logLevelEnv, logLevelInfo)
+	}
+	if logFormat == "" {
+		logFormat = utils.LookupEnvWithDefault(logFormatEnv, logFormatLogfmt)
+	}
+
+	// set log level, default to info level
+	level, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		return fmt.Errorf("log level '%s' unknown, %v are possible values", logLevel, availableLogLevels)
+	}
+	logrus.SetLevel(level)
+
+	// set log format, default to text formatter
+	switch logFormat {
+	case logFormatLogfmt:
+		logrus.SetFormatter(&logrus.TextFormatter{})
+		break
+	case logFormatJSON:
+		logrus.SetFormatter(&logrus.JSONFormatter{})
+		break
+	default:
+		return fmt.Errorf("log format '%s' unknown, %v are possible values", logFormat, availableLogFormats)
+	}
+	// log to stdout; logrus defaults to stderr
+	logrus.SetOutput(os.Stdout)
+
+	return nil
+}
+
+func Main() int {
+	if err := initLogger(); err != nil {
+		fmt.Fprintf(os.Stderr, "instantiating elasticsearch controller failed: %v\n", err)
+		return 1
+	}
 	printVersion()
 
 	sdk.ExposeMetricsPort()
@@ -35,4 +122,9 @@ func main() {
 	sdk.Watch(resource, kind, namespace, resyncPeriod)
 	sdk.Handle(stub.NewHandler())
 	sdk.Run(context.TODO())
+	return 0
+}
+
+func main() {
+	os.Exit(Main())
 }

--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -9,7 +9,6 @@ import (
 
 	v1alpha1 "github.com/openshift/elasticsearch-operator/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
-	"github.com/sirupsen/logrus"
 )
 
 // ClusterState struct represents the state of the cluster
@@ -46,8 +45,6 @@ func CreateOrUpdateElasticsearchCluster(dpl *v1alpha1.Elasticsearch, configMapNa
 	if err != nil {
 		return err
 	}
-	// TODO: get rid of this message as part of LOG-206
-	logrus.Infof("cluster %s required action is: %v", dpl.Name, action)
 
 	switch {
 	case action == v1alpha1.ElasticsearchActionNewClusterNeeded:
@@ -177,7 +174,6 @@ func (cState *ClusterState) buildNewCluster(owner metav1.OwnerReference) error {
 // list existing StatefulSets and delete those unmanaged by the operator
 func (cState *ClusterState) removeStaleNodes() error {
 	for _, node := range cState.DanglingDeployments.Items {
-		//logrus.Infof("found statefulset: %v", node.getResource().ObjectMeta.Name)
 		// the returned deployment doesn't have TypeMeta, so we're adding it.
 		node.TypeMeta = metav1.TypeMeta{
 			Kind:       "Deployment",

--- a/pkg/k8shandler/configmaps.go
+++ b/pkg/k8shandler/configmaps.go
@@ -10,7 +10,6 @@ import (
 
 	v1alpha1 "github.com/openshift/elasticsearch-operator/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
-	//"github.com/sirupsen/logrus"
 )
 
 // CreateOrUpdateConfigMaps ensures the existence of ConfigMaps with Elasticsearch configuration

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -24,7 +24,7 @@ func (node *deploymentNode) isDifferent(cfg *desiredNodeState) (bool, error) {
 	// Check replicas number
 	actualReplicas := *node.resource.Spec.Replicas
 	if cfg.getReplicas() != actualReplicas {
-		logrus.Infof("Different number of replicas detected, updating deployment %v", cfg.DeployName)
+		logrus.Debugf("Different number of replicas detected, updating deployment %v", cfg.DeployName)
 		return true, nil
 	}
 
@@ -32,7 +32,7 @@ func (node *deploymentNode) isDifferent(cfg *desiredNodeState) (bool, error) {
 	for _, container := range node.resource.Spec.Template.Spec.Containers {
 		if container.Name == "elasticsearch" {
 			if container.Image != cfg.ESNodeSpec.Spec.Image {
-				logrus.Infof("Container image '%v' is different that desired, updating..", container.Image)
+				logrus.Debugf("Container image '%v' is different that desired, updating..", container.Image)
 				return true, nil
 			}
 		}
@@ -42,7 +42,7 @@ func (node *deploymentNode) isDifferent(cfg *desiredNodeState) (bool, error) {
 	for label, value := range cfg.Labels {
 		val, ok := node.resource.Labels[label]
 		if !ok || val != value {
-			logrus.Infof("Labels on deployment '%v' need updating..", node.resource.GetName())
+			logrus.Debugf("Labels on deployment '%v' need updating..", node.resource.GetName())
 			return true, nil
 		}
 	}
@@ -53,12 +53,12 @@ func (node *deploymentNode) isDifferent(cfg *desiredNodeState) (bool, error) {
 	for index, value := range envVars {
 		if value.ValueFrom == nil {
 			if desiredVars[index] != value {
-				logrus.Infof("Env vars are different for %q", node.resource.GetName())
+				logrus.Debugf("Env vars are different for %q", node.resource.GetName())
 				return true, nil
 			}
 		} else {
 			if desiredVars[index].ValueFrom.FieldRef.FieldPath != value.ValueFrom.FieldRef.FieldPath {
-				logrus.Infof("Env vars are different for %q", node.resource.GetName())
+				logrus.Debugf("Env vars are different for %q", node.resource.GetName())
 				return true, nil
 			}
 		}
@@ -85,7 +85,7 @@ func (node *deploymentNode) isDifferent(cfg *desiredNodeState) (bool, error) {
 			case volume.EmptyDir != nil && (cfg.ESNodeSpec.Storage.EmptyDir != nil || cfg.ESNodeSpec.Storage == v1alpha1.ElasticsearchNodeStorageSource{}):
 				return false, nil
 			default:
-				logrus.Infof("Detected change in storage")
+				logrus.Warn("Detected change in storage")
 				return true, nil
 			}
 		}
@@ -129,7 +129,6 @@ func (node *deploymentNode) constructNodeResource(cfg *desiredNodeState, owner m
 	// sset, _ := json.Marshal(deployment)
 	// s := string(sset[:])
 
-	// logrus.Infof(s)
 	addOwnerRefToObject(&deployment, owner)
 
 	return &deployment, nil

--- a/pkg/k8shandler/desirednodestate.go
+++ b/pkg/k8shandler/desirednodestate.go
@@ -19,7 +19,7 @@ import (
 const (
 	elasticsearchCertsPath    = "/etc/openshift/elasticsearch/secret"
 	elasticsearchConfigPath   = "/usr/share/java/elasticsearch/config"
-	elasticsearchDefaultImage = "quay.io/openshift/logging-elasticsearch5"
+	elasticsearchDefaultImage = "docker.io/openshift/origin-logging-elasticsearch5"
 	heapDumpLocation          = "/elasticsearch/persistent/heapdump.hprof"
 )
 
@@ -494,7 +494,7 @@ func (cfg *desiredNodeState) generatePersistentStorage() v1.VolumeSource {
 		volSource.PersistentVolumeClaim = specVol.PersistentVolumeClaim
 	default:
 		// TODO: assume EmptyDir/update to emptyDir?
-		logrus.Infof("Unknown volume source: %s", specVol)
+		logrus.Warn("Unknown volume source: %s", specVol)
 	}
 	return volSource
 }

--- a/pkg/k8shandler/services.go
+++ b/pkg/k8shandler/services.go
@@ -10,7 +10,6 @@ import (
 	v1alpha1 "github.com/openshift/elasticsearch-operator/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	//"github.com/sirupsen/logrus"
 )
 
 // CreateOrUpdateServices ensures the existence of the services for Elasticsearch cluster

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/openshift/elasticsearch-operator/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/openshift/elasticsearch-operator/pkg/k8shandler"
-	"github.com/sirupsen/logrus"
 
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
 )
@@ -33,9 +32,6 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 
 // Reconcile reconciles the cluster's state to the spec specified
 func Reconcile(es *v1alpha1.Elasticsearch) (err error) {
-	// TODO: get rid of this message as part of LOG-206
-	logrus.Info("Started reconciliation")
-
 	// Ensure existence of services
 	err = k8shandler.CreateOrUpdateServices(es)
 	if err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,8 +1,10 @@
 package utils
 
 import (
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
+	"os"
+
+	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -30,4 +32,11 @@ func Secret(secretName string, namespace string, data map[string][]byte) *v1.Sec
 		Type: "Opaque",
 		Data: data,
 	}
+}
+
+func LookupEnvWithDefault(envName, defaultValue string) string {
+	if value, ok := os.LookupEnv(envName); ok {
+		return value
+	}
+	return defaultValue
 }


### PR DESCRIPTION
Enable log level and format selection and change verbosity of existing log statements.

I'm assuming that the log level in production
will be 'warn' and for development 'debug' or 'info'