### PR TITLE
more cleanup - better integration with cluster-logging-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ IMAGE_TAG?=docker tag
 APP_NAME=elasticsearch-operator
 APP_REPO=github.com/openshift/$(APP_NAME)
 TARGET=$(TARGET_DIR)/bin/$(APP_NAME)
-IMAGE_TAG=quay.io/openshift/$(APP_NAME)
+IMAGE_TAG=openshift/$(APP_NAME)
 MAIN_PKG=cmd/$(APP_NAME)/main.go
 RUN_LOG?=elasticsearch-operator.log
 RUN_PID?=elasticsearch-operator.pid
@@ -88,7 +88,6 @@ deploy-setup:
 .PHONY: deploy-setup
 
 go-run: deploy deploy-example
-	@sudo sysctl -w vm.max_map_count=262144
 	@ALERTS_FILE_PATH=files/prometheus_alerts.yml \
 	RULES_FILE_PATH=files/prometheus_rules.yml \
 	OPERATOR_NAME=elasticsearch-operator WATCH_NAMESPACE=openshift-logging \

--- a/deploy/examples/onenode-emptydir-es.yaml
+++ b/deploy/examples/onenode-emptydir-es.yaml
@@ -4,7 +4,7 @@ metadata:
   name: elastic1
 spec:
   nodeSpec:
-    image: quay.io/openshift/logging-elasticsearch5:latest
+    image: openshift/logging-elasticsearch5:latest
   nodes:
   - nodeSpec: {}
     roles:

--- a/deploy/examples/onenode-hostmounted-es.yaml
+++ b/deploy/examples/onenode-hostmounted-es.yaml
@@ -4,7 +4,7 @@ metadata:
   name: elastic1
 spec:
   nodeSpec:
-    image: quay.io/openshift/logging-elasticsearch5:latest
+    image: openshift/logging-elasticsearch5:latest
   nodes:
   - nodeSpec: {}
     roles:

--- a/deploy/examples/onenode-pvc-es.yaml
+++ b/deploy/examples/onenode-pvc-es.yaml
@@ -4,7 +4,7 @@ metadata:
   name: elastic1
 spec:
   nodeSpec:
-    image: quay.io/openshift/logging-elasticsearch5:latest
+    image: openshift/logging-elasticsearch5:latest
   nodes:
   - nodeSpec: {}
     roles:

--- a/deploy/openshift/elasticsearch-template.yaml
+++ b/deploy/openshift/elasticsearch-template.yaml
@@ -26,7 +26,7 @@ objects:
         serviceAccountName: elasticsearch-operator
         containers:
           - name: elasticsearch-operator
-            image: quay.io/openshift/elasticsearch-operator:latest
+            image: openshift/elasticsearch-operator:latest
             imagePullPolicy: IfNotPresent
             command:
             - elasticsearch-operator
@@ -47,7 +47,7 @@ objects:
     namespace: ${NAMESPACE}
   spec:
     nodeSpec:
-      image: quay.io/openshift/logging-elasticsearch5:latest
+      image: openshift/origin-logging-elasticsearch5:latest
     nodes:
       - roles:
         - client

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: elasticsearch-operator
       containers:
         - name: elasticsearch-operator
-          image: quay.io/openshift/elasticsearch-operator:latest
+          image: openshift/elasticsearch-operator:latest
           imagePullPolicy: IfNotPresent
           command:
           - elasticsearch-operator

--- a/hack/common
+++ b/hack/common
@@ -7,7 +7,7 @@ alias oc=${OC:-oc}
 
 repo_dir="$(dirname $0)/.."
 
-IMAGE_TAG=${IMAGE_TAG:-"quay.io/openshift/elasticsearch-operator:latest"}
+IMAGE_TAG=${IMAGE_TAG:-"openshift/elasticsearch-operator:latest"}
 
 # probably needs some work for contexts which have '-' in the name and are not IPs
 context=$(oc config current-context)

--- a/hack/deploy-setup.sh
+++ b/hack/deploy-setup.sh
@@ -39,17 +39,21 @@ oc create clusterrolebinding elasticsearch-operator-prometheus-rolebinding \
     --serviceaccount=${NAMESPACE}:elasticsearch-operator \
     --clusterrole=prometheus-crd-edit ||:
 
-# This is necessary for running the operator with go run
-if [ ! -d /tmp/_working_dir ] ; then
- mkdir /tmp/_working_dir
-fi
+sudo sysctl -w vm.max_map_count=262144
 
-oc create secret generic elasticsearch -n ${NAMESPACE} \
-    --from-file=admin-key=test/files/system.admin.key \
-    --from-file=admin-cert=test/files/system.admin.crt \
-    --from-file=admin-ca=test/files/ca.crt \
-    --from-file=test/files/elasticsearch.crt \
-    --from-file=test/files/logging-es.key \
-    --from-file=test/files/logging-es.crt \
-    --from-file=test/files/elasticsearch.key \
-    ||:
+if [ "${CREATE_ES_SECRET:-true}" = true ] ; then
+  # This is necessary for running the operator with go run
+  if [ ! -d /tmp/_working_dir ] ; then
+    mkdir /tmp/_working_dir
+  fi
+
+  oc create secret generic elasticsearch -n ${NAMESPACE} \
+      --from-file=admin-key=test/files/system.admin.key \
+      --from-file=admin-cert=test/files/system.admin.crt \
+      --from-file=admin-ca=test/files/ca.crt \
+      --from-file=test/files/elasticsearch.crt \
+      --from-file=test/files/logging-es.key \
+      --from-file=test/files/logging-es.crt \
+      --from-file=test/files/elasticsearch.key \
+      ||:
+fi

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-if [ "${REMOTE_REGISTRY:-false}" = false ] ; then
-    exit 0
-fi
-
 set -euxo pipefail
 
 source "$(dirname $0)/common"
 
-registry_ip=$(oc get service docker-registry -n default -o jsonpath={.spec.clusterIP})
-cat manifests/05-deployment.yaml | \
-    sed -e "s,${IMAGE_TAG},${registry_ip}:5000/openshift/elasticsearch-operator:latest," | \
-	oc create -n ${NAMESPACE} -f -
+if [ "${REMOTE_REGISTRY:-false}" = true ] ; then
+    registry_ip=$(oc get service docker-registry -n default -o jsonpath={.spec.clusterIP})
+    cat manifests/05-deployment.yaml | \
+        sed -e "s,${IMAGE_TAG},${registry_ip}:5000/openshift/elasticsearch-operator:latest," | \
+	    oc create -n ${NAMESPACE} -f -
+else
+    oc create -n ${NAMESPACE} -f manifests/05-deployment.yaml
+fi

--- a/manifests/05-deployment.yaml
+++ b/manifests/05-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: elasticsearch-operator
       containers:
         - name: elasticsearch-operator
-          image: quay.io/openshift/elasticsearch-operator:latest
+          image: openshift/elasticsearch-operator:latest
           imagePullPolicy: IfNotPresent
           command:
           - elasticsearch-operator

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openshift/elasticsearch-operator/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/openshift/elasticsearch-operator/pkg/k8shandler"
+	"github.com/sirupsen/logrus"
 
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
 )
@@ -33,6 +34,7 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 // Reconcile reconciles the cluster's state to the spec specified
 func Reconcile(es *v1alpha1.Elasticsearch) (err error) {
 	// Ensure existence of services
+	logrus.Debugf("Begin Reconcile of Elasticsearch cluster %v", es.ClusterName)
 	err = k8shandler.CreateOrUpdateServices(es)
 	if err != nil {
 		return fmt.Errorf("Failed to reconcile Services for Elasticsearch cluster: %v", err)
@@ -68,6 +70,6 @@ func Reconcile(es *v1alpha1.Elasticsearch) (err error) {
 		return fmt.Errorf("Failed to reconcile Elasticsearch deployment spec: %v", err)
 	}
 
+	logrus.Debugf("End Reconcile of Elasticsearch cluster %v", es.ClusterName)
 	return nil
-
 }


### PR DESCRIPTION
This allows better integration with cluster-logging-operator -
from cluster-logging-operator can do things like `make deploy-setup`
and it will call `make -C ${ES_OP_DIR} deploy-setup` to also
setup elasticsearch.
This also removes the `quay.io/` prefix from images to make
it easier to use the locally built images.