### PR TITLE
use retry.RetryOnConflict for Get/Update cases

### DIFF
--- a/pkg/k8shandler/configmaps.go
+++ b/pkg/k8shandler/configmaps.go
@@ -51,6 +51,7 @@ func createOrUpdateConfigMap(configMapName, namespace, clusterName, kibanaIndexM
 		}
 
 		// TODO: Compare existing configMap labels, selectors and port
+		// TODO: And remember to wrap the Get/Update in a retry.RetryOnConflict
 	}
 	return nil
 }

--- a/pkg/k8shandler/persistentvolumeclaims.go
+++ b/pkg/k8shandler/persistentvolumeclaims.go
@@ -23,6 +23,7 @@ func createOrUpdatePersistentVolumeClaim(pvc v1.PersistentVolumeClaimSpec, newNa
 		}
 	} else {
 		logrus.Infof("Reusing existing PVC: %s", newName)
+		// TODO for updates, don't forget to use retry.RetryOnConflict
 	}
 	return nil
 }

--- a/pkg/k8shandler/prometheus_rule.go
+++ b/pkg/k8shandler/prometheus_rule.go
@@ -35,7 +35,7 @@ func CreateOrUpdatePrometheusRules(dpl *v1alpha1.Elasticsearch) error {
 		return err
 	}
 
-	//TODO: handle update
+	//TODO: handle update - use retry.RetryOnConflict
 
 	return nil
 }

--- a/pkg/k8shandler/service_monitor.go
+++ b/pkg/k8shandler/service_monitor.go
@@ -24,7 +24,7 @@ func CreateOrUpdateServiceMonitors(dpl *v1alpha1.Elasticsearch) error {
 		return fmt.Errorf("Failure constructing Elasticsearch ServiceMonitor: %v", err)
 	}
 
-	// TODO: handle update
+	// TODO: handle update - use retry.RetryOnConflict
 
 	return nil
 }

--- a/pkg/k8shandler/services.go
+++ b/pkg/k8shandler/services.go
@@ -47,6 +47,7 @@ func createOrUpdateService(serviceName, namespace, clusterName, targetPortName s
 		}
 
 		// TODO: Compare existing service labels, selectors and port
+		// TODO: use retry.RetryOnConflict for Updates
 	}
 	return nil
 }


### PR DESCRIPTION
Anywhere we use `sdk.Update(obj)` with an `obj` passed in
via the `Handle` method or returned from `sdk.Get`, we need
to do the `Update` using `retry.RetryOnConflict` to handle
cases where the object was modified by someone else after
the `Get`.
Fixes https://github.com/openshift/elasticsearch-operator/issues/28