### PR TITLE
construct kubeconfig from sa secret and downward api

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -17,10 +17,16 @@ popd
 
 sudo sysctl -w vm.max_map_count=262144
 
+if oc get project openshift-logging > /dev/null 2>&1 ; then
+  echo using existing project openshift-logging
+else
+  oc create namespace openshift-logging
+fi
+
 oc create -n openshift-logging -f \
-https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheusrule.crd.yaml
+https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheusrule.crd.yaml || :
 oc create -n openshift-logging -f \
-https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml
+https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml || :
 
 operator-sdk test local \
   --namespace openshift-logging \

--- a/manifests/02-role.yaml
+++ b/manifests/02-role.yaml
@@ -14,6 +14,7 @@ rules:
   - ""
   resources:
   - pods
+  - pods/exec
   - services
   - endpoints
   - persistentvolumeclaims

--- a/pkg/k8shandler/status.go
+++ b/pkg/k8shandler/status.go
@@ -68,13 +68,21 @@ func clusterHealth(dpl *v1alpha1.Elasticsearch) string {
 
 	// use arbitrary pod
 	pod := pods.Items[0]
+	// when running in a pod, use the values provided for the sa
+	// this is primarily used when testing
+	kubeConfigPath := lookupEnvWithDefault("KUBERNETES_CONFIG", "")
+	masterURL := "https://kubernetes.default.svc"
+	if kubeConfigPath == "" {
+		// ExecConfig requires both are "", or both have a real value
+		masterURL = ""
+	}
 
 	config := &ExecConfig{
 		pod:            &pod,
 		containerName:  "elasticsearch",
 		command:        []string{"es_util", "--query=_cluster/health?pretty=true"},
-		kubeConfigPath: lookupEnvWithDefault("KUBERNETES_CONFIG", "/etc/origin/master/admin.kubeconfig"),
-		masterURL:      "https://kubernetes.default.svc",
+		kubeConfigPath: kubeConfigPath,
+		masterURL:      masterURL,
 		stdOut:         true,
 		stdErr:         true,
 		tty:            false,


### PR DESCRIPTION
The operator needs to use the `oc` command and so needs a kubeconfig file.  The kubeconfig file can be constructed at startup in a manner similar to https://github.com/openshift/origin-aggregated-logging/blob/v1.2.0/deployment/run.sh#L12

- construct the `$HOME/.kubeconfig` similar to the above - overwrite if it already exists
- `SetEnv("KUBECONFIG", "$HOME/.kubeconfig")`

Then subsequent calls to `oc` will automatically use this.