### PR TITLE
Log250 rolling restart

### DIFF
--- a/pkg/apis/elasticsearch/v1alpha1/types.go
+++ b/pkg/apis/elasticsearch/v1alpha1/types.go
@@ -89,6 +89,7 @@ type ElasticsearchNodeStatus struct {
 	StatefulSetName string                  `json:"statefulSetName,omitempty"`
 	PodName         string                  `json:"podName,omitempty"`
 	Status          string                  `json:"status,omitempty"`
+	UnderUpgrade    UpgradeStatus           `json:"underUpgrade,omitempty"`
 	Roles           []ElasticsearchNodeRole `json:"roles,omitempty"`
 }
 
@@ -97,6 +98,13 @@ type ElasticsearchNodeSpec struct {
 	Image     string                  `json:"image,omitempty"`
 	Resources v1.ResourceRequirements `json:"resources"`
 }
+
+type UpgradeStatus string
+
+const (
+	UnderUpgradeTrue  UpgradeStatus = "True"
+	UnderUpgradeFalse UpgradeStatus = "False"
+)
 
 type ElasticsearchRequiredAction string
 
@@ -119,10 +127,11 @@ const (
 
 // ElasticsearchStatus represents the status of Elasticsearch cluster
 type ElasticsearchStatus struct {
-	Nodes         []ElasticsearchNodeStatus             `json:"nodes"`
-	ClusterHealth string                                `json:"clusterHealth"`
-	Pods          map[ElasticsearchNodeRole]PodStateMap `json:"pods"`
-	Conditions    []ClusterCondition                    `json:"conditions"`
+	Nodes                  []ElasticsearchNodeStatus             `json:"nodes"`
+	ClusterHealth          string                                `json:"clusterHealth"`
+	ShardAllocationEnabled bool                                  `json:"shardAllocationEnabled"`
+	Pods                   map[ElasticsearchNodeRole]PodStateMap `json:"pods"`
+	Conditions             []ClusterCondition                    `json:"conditions"`
 }
 
 type PodStateMap map[PodStateType][]string

--- a/pkg/apis/elasticsearch/v1alpha1/types.go
+++ b/pkg/apis/elasticsearch/v1alpha1/types.go
@@ -84,14 +84,31 @@ type ElasticsearchNodeStorageSource struct {
 
 // ElasticsearchNodeStatus represents the status of individual Elasticsearch node
 type ElasticsearchNodeStatus struct {
-	DeploymentName  string                  `json:"deploymentName,omitempty"`
-	ReplicaSetName  string                  `json:"replicaSetName,omitempty"`
-	StatefulSetName string                  `json:"statefulSetName,omitempty"`
-	PodName         string                  `json:"podName,omitempty"`
-	Status          string                  `json:"status,omitempty"`
-	UnderUpgrade    UpgradeStatus           `json:"underUpgrade,omitempty"`
-	Roles           []ElasticsearchNodeRole `json:"roles,omitempty"`
+	DeploymentName  string `json:"deploymentName,omitempty"`
+	ReplicaSetName  string `json:"replicaSetName,omitempty"`
+	StatefulSetName string `json:"statefulSetName,omitempty"`
+	PodName         string `json:"podName,omitempty"`
+	Status          string `json:"status,omitempty"`
+	// UnderUpgrade    UpgradeStatus              `json:"underUpgrade,omitempty"`
+	UpgradeStatus ElasticsearchNodeUpgradeStatus `json:"upgradeStatus,omitempty"`
+	Roles         []ElasticsearchNodeRole        `json:"roles,omitempty"`
 }
+
+type ElasticsearchNodeUpgradeStatus struct {
+	UnderUpgrade UpgradeStatus             `json:"underUpgrade,omitempty"`
+	UpgradePhase ElasticsearchUpgradePhase `json:"upgradePhase,omitempty"`
+}
+
+type ElasticsearchUpgradePhase string
+
+const (
+	NodeRestarting    ElasticsearchUpgradePhase = "nodeRestarting"
+	RecoveringData    ElasticsearchUpgradePhase = "recoveringData"
+	ControllerUpdated ElasticsearchUpgradePhase = "controllerUpdated"
+	// UpgradeInitializing    ElasticsearchUpgradePhase = "upgradeInitializing"
+	// NodeRejoined   ElasticsearchUpgradePhase = "nodeRejoined"
+	// ShardAllocationEnabled ElasticsearchUpgradePhase = "shardAllocationEnabled"
+)
 
 // ElasticsearchNodeSpec represents configuration of an individual Elasticsearch node
 type ElasticsearchNodeSpec struct {
@@ -125,11 +142,18 @@ const (
 	ElasticsearchRoleMaster ElasticsearchNodeRole = "master"
 )
 
+type ShardAllocationState string
+
+const (
+	ShardAllocationTrue  ShardAllocationState = "True"
+	ShardAllocationFalse ShardAllocationState = "False"
+)
+
 // ElasticsearchStatus represents the status of Elasticsearch cluster
 type ElasticsearchStatus struct {
 	Nodes                  []ElasticsearchNodeStatus             `json:"nodes"`
 	ClusterHealth          string                                `json:"clusterHealth"`
-	ShardAllocationEnabled bool                                  `json:"shardAllocationEnabled"`
+	ShardAllocationEnabled ShardAllocationState                  `json:"shardAllocationEnabled"`
 	Pods                   map[ElasticsearchNodeRole]PodStateMap `json:"pods"`
 	Conditions             []ClusterCondition                    `json:"conditions"`
 }

--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -88,6 +88,20 @@ func CreateOrUpdateElasticsearchCluster(dpl *v1alpha1.Elasticsearch, configMapNa
 	return nil
 }
 
+// func lockCluster(cState *ClusterState, isLocked bool) {
+// 	fmt.Printf("Changing cluster lock to: %t...\n", isLocked)
+// 	for _, node := range cState.Nodes {
+// 		deployment := node.Actual.Deployment
+// 		if deployment != nil {
+// 			deployment.Spec.Paused = isLocked
+// 			if err := sdk.Update(deployment); err != nil {
+// 				fmt.Printf("couldnt lock deployment: %v\n", err)
+// 			}
+// 		}
+// 	}
+
+// }
+
 // NewClusterState func generates ClusterState for the current cluster
 func NewClusterState(dpl *v1alpha1.Elasticsearch, configMapName, serviceAccountName string) (ClusterState, error) {
 	nodes := []*nodeState{}

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -111,8 +111,19 @@ func (node *deploymentNode) constructNodeResource(cfg *desiredNodeState, owner m
 
 	replicas := cfg.getReplicas()
 
-	deployment := node.resource
-	//deployment(cfg.DeployName, node.resource.ObjectMeta.Namespace)
+	fmt.Printf("creating deployment: %s\n", cfg.DeployName)
+	// deployment := node.resource
+	deployment := apps.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.DeployName,
+			Namespace: cfg.Namespace,
+		},
+	}
+
 	deployment.ObjectMeta.Labels = cfg.getLabels()
 	deployment.Spec = apps.DeploymentSpec{
 		Replicas: &replicas,

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -107,7 +107,6 @@ func (node *deploymentNode) constructNodeResource(cfg *desiredNodeState, owner m
 
 	replicas := cfg.getReplicas()
 
-	fmt.Printf("creating deployment: %s\n", cfg.DeployName)
 	// deployment := node.resource
 	deployment := apps.Deployment{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -29,17 +29,13 @@ func (node *deploymentNode) isDifferent(cfg *desiredNodeState) (bool, error) {
 	}
 
 	// Check image of Elasticsearch container
-	isImageDifferent := false
 	for _, container := range node.resource.Spec.Template.Spec.Containers {
 		if container.Name == "elasticsearch" {
 			if container.Image != cfg.ESNodeSpec.Spec.Image {
-				isImageDifferent = true
 				logrus.Debugf("Resource '%s' has different container image than desired", node.resource.Name)
+				return true, nil
 			}
 		}
-	}
-	if isImageDifferent {
-		return true, nil
 	}
 
 	// Check if labels are correct

--- a/pkg/k8shandler/status.go
+++ b/pkg/k8shandler/status.go
@@ -24,11 +24,12 @@ func (cState *ClusterState) UpdateStatus(dpl *v1alpha1.Elasticsearch) error {
 			return getErr
 		}
 		dpl.Status.ClusterHealth = clusterHealth(dpl)
-		dpl.Status.Nodes = []v1alpha1.ElasticsearchNodeStatus{}
-		for _, node := range cState.Nodes {
-			updateNodeStatus(node, &dpl.Status)
-		}
+		nodes := []v1alpha1.ElasticsearchNodeStatus{}
 
+		for _, node := range cState.Nodes {
+			nodes = append(nodes, *updateNodeStatus(node, &dpl.Status))
+		}
+		dpl.Status.Nodes = nodes
 		updateStatusConditions(&dpl.Status)
 		dpl.Status.Pods = rolePodStateMap(dpl.Namespace, dpl.Name)
 		if updateErr := sdk.Update(dpl); updateErr != nil {

--- a/pkg/k8shandler/util.go
+++ b/pkg/k8shandler/util.go
@@ -314,7 +314,16 @@ func listRunningPods(clusterName, namespace string) (*v1.PodList, error) {
 	runningPods := make([]v1.Pod, 0, len(pods.Items))
 	for _, pod := range pods.Items {
 		if pod.Status.Phase == v1.PodRunning {
-			runningPods = append(runningPods, pod)
+			podReady := true
+			for _, cs := range pod.Status.ContainerStatuses {
+				if !cs.Ready {
+					podReady = false
+					break
+				}
+			}
+			if podReady {
+				runningPods = append(runningPods, pod)
+			}
 		}
 	}
 	result := podList()

--- a/pkg/utils/exec_util.go
+++ b/pkg/utils/exec_util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/openshift/elasticsearch-operator/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 )
@@ -92,7 +93,7 @@ func PerformSyncedFlush(pod *v1.Pod) error {
 	return err
 }
 
-func SetShardAllocation(pod *v1.Pod, enabled bool) error {
+func SetShardAllocation(pod *v1.Pod, enabled v1alpha1.ShardAllocationState) error {
 	command := []string{"sh", "-c",
 		fmt.Sprintf("es_util --query=_cluster/settings -H 'Content-Type: application/json' -X PUT -d '{\"transient\":{%s}}'",
 			shardAllocationCommand(enabled))}
@@ -102,12 +103,8 @@ func SetShardAllocation(pod *v1.Pod, enabled bool) error {
 	return err
 }
 
-func shardAllocationCommand(enabled bool) string {
-	shardAllocation := "none"
-	if enabled {
-		shardAllocation = "all"
-	}
-	return fmt.Sprintf("%s:%s", strconv.Quote("cluster.routing.allocation.enable"), strconv.Quote(shardAllocation))
+func shardAllocationCommand(shardAllocation v1alpha1.ShardAllocationState) string {
+	return fmt.Sprintf("%s:%s", strconv.Quote("cluster.routing.allocation.enable"), strconv.Quote(string(shardAllocation)))
 }
 
 func minimumMasterNodesCommand(nodes int) string {

--- a/pkg/utils/exec_util.go
+++ b/pkg/utils/exec_util.go
@@ -2,7 +2,11 @@ package utils
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 )
 
@@ -26,4 +30,86 @@ func ElasticsearchExec(pod *v1.Pod, command []string) (*bytes.Buffer, *bytes.Buf
 		Tty:            false,
 	}
 	return PodExec(config)
+}
+
+func UpdateClusterSettings(pod *v1.Pod, quorum int) error {
+	command := []string{"sh", "-c",
+		fmt.Sprintf("es_util --query=_cluster/settings -H 'Content-Type: application/json' -X PUT -d '{\"persistent\":{%s}}'",
+			minimumMasterNodesCommand(quorum))}
+
+	_, _, err := ElasticsearchExec(pod, command)
+
+	return err
+}
+
+func ClusterHealth(pod *v1.Pod) (map[string]interface{}, error) {
+	command := []string{"es_util", "--query=_cluster/health?pretty=true"}
+	execOut, _, err := ElasticsearchExec(pod, command)
+	if err != nil {
+		logrus.Debug(err)
+		return nil, err
+	}
+
+	var result map[string]interface{}
+
+	err = json.Unmarshal(execOut.Bytes(), &result)
+	if err != nil {
+		logrus.Debug("could not unmarshal: %v", err)
+		return nil, err
+	}
+	return result, nil
+}
+
+func NumberOfNodes(pod *v1.Pod) int {
+	healthResponse, err := ClusterHealth(pod)
+	if err != nil {
+		// logrus.Debugf("failed to get _cluster/health: %v", err)
+		return -1
+	}
+
+	// is it present?
+	value, present := healthResponse["number_of_nodes"]
+	if !present {
+		return -1
+	}
+
+	// json numbers are represented as floats
+	// so let's convert from type interface{} to float
+	numberofNodes, ok := value.(float64)
+	if !ok {
+		return -1
+	}
+
+	// wow that's a lot of boilerplate...
+	return int(numberofNodes)
+}
+
+func PerformSyncedFlush(pod *v1.Pod) error {
+	command := []string{"sh", "-c", "es_util --query=_flush/synced -X POST"}
+
+	_, _, err := ElasticsearchExec(pod, command)
+
+	return err
+}
+
+func SetShardAllocation(pod *v1.Pod, enabled bool) error {
+	command := []string{"sh", "-c",
+		fmt.Sprintf("es_util --query=_cluster/settings -H 'Content-Type: application/json' -X PUT -d '{\"transient\":{%s}}'",
+			shardAllocationCommand(enabled))}
+
+	_, _, err := ElasticsearchExec(pod, command)
+
+	return err
+}
+
+func shardAllocationCommand(enabled bool) string {
+	shardAllocation := "none"
+	if enabled {
+		shardAllocation = "all"
+	}
+	return fmt.Sprintf("%s:%s", strconv.Quote("cluster.routing.allocation.enable"), strconv.Quote(shardAllocation))
+}
+
+func minimumMasterNodesCommand(nodes int) string {
+	return fmt.Sprintf("%s:%d", strconv.Quote("discovery.zen.minimum_master_nodes"), nodes)
 }


### PR DESCRIPTION
Support Rolling Restart on Image Change

In order to support minor releases of OpenShift logging
users will need to run rolling restart of the cluster.
This restart can be triggered bu updating
`ElasticsearchNodeSpec.Image`.

A prerequisite is that the cluster health is in green state.

This rolling restart will upgrade the cluster in a node-by-node fashion,
always one node at a time.

The operators waits for shard reallocation after every node upgrade,
thus a full upgrade procedure can take significat time to finish.

Synced flush is used to lower the total time that it takes
for the whole cluster to upgrade and reballance shards.

If the cluster restart procedure fails, a human intervention
is needed to bring the cluster back to operation.
