### PR TITLE
Updating services to publish not ready and updating readiness probe

### DIFF
--- a/pkg/k8shandler/util.go
+++ b/pkg/k8shandler/util.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -83,10 +82,12 @@ func getReadinessProbe() v1.Probe {
 	return v1.Probe{
 		TimeoutSeconds:      30,
 		InitialDelaySeconds: 10,
-		FailureThreshold:    15,
+		PeriodSeconds:       5,
 		Handler: v1.Handler{
-			TCPSocket: &v1.TCPSocketAction{
-				Port: intstr.FromInt(9300),
+			Exec: &v1.ExecAction{
+				Command: []string{
+					"/usr/share/elasticsearch/probe/readiness.sh",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
... to call readiness script.

This fixes a regression previously resolved in our ansible installation.

Noticed this while dev testing:
```
$ oc exec elasticsearch-clientdatamaster-0-1-76578dc89c-99hvr -- check
Thu Dec  6 22:07:56 UTC 2018
epoch      timestamp cluster       status node.total node.data shards pri relo init unassign pending_tasks max_task_wait_time active_shards_percent
1544134076 22:07:56  elasticsearch yellow          1         1      9   9    0    0        6             0                  -                 60.0%
ip           heap.percent ram.percent cpu load_1m load_5m load_15m node.role master name
10.128.0.126           13          99  23    0.17    0.56     1.04 mdi       *      elasticsearch-clientdatamaster-0-1
health status index                  uuid                   pri rep docs.count docs.deleted store.size pri.store.size
yellow open   .kibana                LVLJlFr0T5eyR_j13__a5A   1   1          1            0      3.2kb          3.2kb
yellow open   .operations.2018.12.06 oKtMJrQQTW2jTmeGZUUDNw   5   1      85112            0    114.9mb        114.9mb
green  open   .searchguard           mHWuNxxeQca5eaDGxOX0Ow   1   0          5            0     32.8kb         32.8kb
```
```
[2018-12-06T21:52:06,378][WARN ][c.f.s.c.PrivilegesEvaluator] .operations.2018.12.06 does not exist in cluster metadata
[2018-12-06T21:52:06,383][INFO ][o.e.c.m.MetaDataCreateIndexService] [elasticsearch-clientdatamaster-0-1] [.operations.2018.12.06] creating index, cause [auto(bulk api)], templates [], shards [5]/[1], mappings []
[2018-12-06T21:52:06,591][INFO ][o.e.c.m.MetaDataMappingService] [elasticsearch-clientdatamaster-0-1] [.operations.2018.12.06/oKtMJrQQTW2jTmeGZUUDNw] create_mapping [com.redhat.viaq.common]
[2018-12-06T21:52:07,111][INFO ][o.e.c.m.MetaDataMappingService] [elasticsearch-clientdatamaster-0-1] [.operations.2018.12.06/oKtMJrQQTW2jTmeGZUUDNw] update_mapping [com.redhat.viaq.common]
```

After change:
```
$ oc exec elasticsearch-clientdatamaster-0-1-84d764899d-x9tnw -- check
Thu Dec  6 23:08:02 UTC 2018
epoch      timestamp cluster       status node.total node.data shards pri relo init unassign pending_tasks max_task_wait_time active_shards_percent
1544137682 23:08:02  elasticsearch green           1         1      3   3    0    0        0             0                  -                100.0%
ip           heap.percent ram.percent cpu load_1m load_5m load_15m node.role master name
10.128.0.131            8          94  48    4.77    3.41     2.49 mdi       *      elasticsearch-clientdatamaster-0-1
health status index                  uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   .searchguard           3z0lGAJPR3ufradzMgeJ7g   1   0          5            0     32.7kb         32.7kb
```