### PR TITLE
fix unexported env. vars. and remote registry integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ BUILD_GOPATH=$(TARGET_DIR):$(TARGET_DIR)/vendor:$(CURPATH)/cmd
 IMAGE_BUILDER_OPTS=
 IMAGE_BUILDER?=imagebuilder
 IMAGE_BUILD=$(IMAGE_BUILDER)
-IMAGE_TAG?=docker tag
+export IMAGE_TAGGER?=docker tag
 
-APP_NAME=elasticsearch-operator
+export APP_NAME=elasticsearch-operator
 APP_REPO=github.com/openshift/$(APP_NAME)
 TARGET=$(TARGET_DIR)/bin/$(APP_NAME)
-IMAGE_TAG=openshift/$(APP_NAME)
+export IMAGE_TAG=openshift/$(APP_NAME):latest
 MAIN_PKG=cmd/$(APP_NAME)/main.go
 RUN_LOG?=elasticsearch-operator.log
 RUN_PID?=elasticsearch-operator.pid
@@ -71,15 +71,15 @@ fmt:
 simplify:
 	@gofmt -s -l -w $(SRC)
 
-deploy: deploy-setup image deploy-image
+deploy: deploy-setup deploy-image
 	hack/deploy.sh
 .PHONY: deploy
 
-deploy-image:
+deploy-image: image
 	hack/deploy-image.sh
 .PHONY: deploy-image
 
-deploy-example:
+deploy-example: deploy
 	@oc create -n openshift-logging -f hack/cr.yaml
 .PHONY: deploy-example
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ If you are using an image built in a different node, you can specify to use a re
 the environment variable `REMOTE_REGISTRY=true` before running any of the targets below.  See `hack/deploy-image.sh`
 and `hack/deploy.sh` for more details.
 
+*  `REMOTE_REGISTRY` Set to `true` if you are running the cluster on a different machine
+    than the one you are developing on. For example, if you are running a cluster in a
+    local libvirt or minishift environment, you may want to build the image on the host
+    and push them to the cluster running in the VM.
+    You will need a username with a password (i.e. not the default `system:admin` user).
+    If your cluster was deployed with the `allow_all` identity provider, you can create
+    a user like this: `oc login --username=admin --password=admin`, then assign it rights:
+    `oc login --username=system:admin`
+    `oc adm policy add-cluster-role-to-user cluster-admin admin`
+    If you used the new `openshift-installer`, it created a user named `kubeadmin`
+    with the password in the file `installer/auth/kubeadmin_password`.
+    `oc login --username=kubeadmin --password=$( cat ../installer/auth/kubeadmin_password )`
+    The user should already have `cluster-admin` rights.
+
 It is additionally possible to deploy the operator to an Openshift cluster using the provided make targets.  These
 targets assume you have cluster admin access. Following are a few of these targets:
 
@@ -152,8 +166,11 @@ Kubernetes TBD+ and OpenShift TBD+ are supported.
 In a real deployment OpenShift monitoring will be installed.  However
 for testing purposes, you should install the monitoring CRDs:
 ```
-make deploy-setup
+[REMOTE_REGISTRY=true] make deploy-setup
 ```
+
+Use `REMOTE_REGISTRY=true make deploy-image` to build the image and copy it
+to the remote registry.
 
 ### E2E Testing
 To run the e2e tests, install the above CRDs and from the repo directory, run:
@@ -169,8 +186,8 @@ To set up your local environment based on what will be provided by OLM, run:
 ```
 sudo sysctl -w vm.max_map_count=262144
 ELASTICSEARCH_OPERATOR=$GOPATH/src/github.com/openshift/elasticsearch-operator
-make deploy-setup
-make deploy-example
+[REMOTE_REGISTRY=true] make deploy-setup
+[REMOTE_REGISTRY=true] make deploy-example
 ```
 
 To test on an OCP cluster, you can run:

--- a/hack/common
+++ b/hack/common
@@ -17,3 +17,27 @@ API_SERVER=$(python -c \
 ADMIN_USER=${ADMIN_USER:-admin}
 ADMIN_PSWD=${ADMIN_USER:-admin123}
 NAMESPACE=${NAMESPACE:-openshift-logging}
+REMOTE_REGISTRY=${REMOTE_REGISTRY:-false}
+
+if [ $REMOTE_REGISTRY = false ] ; then
+    : # skip
+else
+    registry_namespace=openshift-image-registry
+    registry_svc=image-registry
+    registry_host=$registry_svc.$registry_namespace.svc
+    if ! oc get namespace $registry_namespace ; then
+        registry_namespace=default
+        registry_svc=docker-registry
+        # use ip instead
+        registry_host=$(oc get svc $registry_svc -n $registry_namespace -o jsonpath={.spec.clusterIP})
+    fi
+
+    registry_port=$(oc get svc $registry_svc -n $registry_namespace -o jsonpath={.spec.ports[0].port})
+    if [ $registry_namespace = openshift-image-registry ] ; then
+        # takes pod name in 4.0
+        port_fwd_obj=$( oc get pods -n $registry_namespace | awk '/^image-registry-/ {print $1}' )
+    else
+        # takes service in 3.11
+        port_fwd_obj="service/$registry_svc"
+    fi
+fi

--- a/hack/deploy-image.sh
+++ b/hack/deploy-image.sh
@@ -11,13 +11,12 @@ source "$(dirname $0)/common"
 IMAGE_TAGGER=${IMAGE_TAGGER:-docker tag}
 LOCAL_PORT=${LOCAL_PORT:-5000}
 
-registry_port=$(oc get service docker-registry -n default -o jsonpath={.spec.ports[0].port})
-tag="127.0.0.1:${registry_port}/openshift/elasticsearch-operator:latest"
+tag="127.0.0.1:${registry_port}/${IMAGE_TAG}"
 
 ${IMAGE_TAGGER} ${IMAGE_TAG} ${tag}
 
-echo "Setting up port-forwarding to remote docker-registry..."
-oc port-forward service/docker-registry -n default ${LOCAL_PORT}:${registry_port} &
+echo "Setting up port-forwarding to remote $registry_svc ..."
+oc port-forward $port_fwd_obj -n $registry_namespace ${LOCAL_PORT}:${registry_port} &
 forwarding_pid=$!
 
 trap "kill -15 ${forwarding_pid}" EXIT

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -4,11 +4,10 @@ set -euxo pipefail
 
 source "$(dirname $0)/common"
 
-if [ "${REMOTE_REGISTRY:-false}" = true ] ; then
-    registry_ip=$(oc get service docker-registry -n default -o jsonpath={.spec.clusterIP})
-    cat manifests/05-deployment.yaml | \
-        sed -e "s,${IMAGE_TAG},${registry_ip}:5000/openshift/elasticsearch-operator:latest," | \
-	    oc create -n ${NAMESPACE} -f -
-else
+if [ $REMOTE_REGISTRY = false ] ; then
     oc create -n ${NAMESPACE} -f manifests/05-deployment.yaml
+else
+    cat manifests/05-deployment.yaml | \
+        sed -e "s,${IMAGE_TAG},${registry_host}:5000/${IMAGE_TAG}," | \
+	    oc create -n ${NAMESPACE} -f -
 fi


### PR DESCRIPTION
Make it so that setting Makefile vars exports the key ones
as env. vars for the scripts.
Fix use of `REMOTE_REGISTRY=true` so that it works in older
i.e. minishift environments as well as newer `openshift-install`
environments