### PR TITLE
Updating storageclass to be inline for json formatting

### DIFF
--- a/pkg/apis/elasticsearch/v1alpha1/types.go
+++ b/pkg/apis/elasticsearch/v1alpha1/types.go
@@ -58,7 +58,7 @@ type ElasticsearchNode struct {
 }
 
 type ElasticsearchStorageSpec struct {
-	StorageClass *ElasticsearchStorageClassSpec `json:"storageClass,omitempty"`
+	StorageClass *ElasticsearchStorageClassSpec `json:",inline,omitempty"`
 
 	// PersistentVolumeClaim will NOT try to regenerate PVC, it will be used
 	// as-is. You may want to use it instead of VolumeClaimTemplate in case


### PR DESCRIPTION
this will update our json formatting for storage from:
```
storage:
  storageClass:
    storageClassName: "gp2"
    size: "20G"
```
to:
```
storage:
  storageClassName: "gp2"
  size: "20G"
```

Internally this does not affect code