### PR TITLE
Guard against array index ouf of bound error

### DIFF
--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -148,10 +148,6 @@ func (cState *ClusterState) getRequiredAction(dpl *v1alpha1.Elasticsearch) (v1al
 	// TODO: Handle failures. Maybe introduce some ElasticsearchCondition which says
 	// what action was attempted last, when, how many tries and what the result is.
 
-	// TODO: implement better logic to understand when new cluster is needed
-	// maybe RequiredAction ElasticsearchActionNewClusterNeeded should be renamed to
-	// ElasticsearchActionAddNewNodes - will blindly add new nodes to the cluster.
-
 	if dpl.Spec.ManagementState == v1alpha1.ManagementStateManaged {
 
 		for _, node := range cState.Nodes {
@@ -160,8 +156,6 @@ func (cState *ClusterState) getRequiredAction(dpl *v1alpha1.Elasticsearch) (v1al
 			}
 		}
 
-		// TODO: implement rolling restart action if any deployment/configmap actually deployed
-		// is different from the desired.
 		if node := upgradeInProgress(dpl); node != nil {
 			return v1alpha1.ElasticsearchActionRollingRestartNeeded, nil
 		}

--- a/pkg/k8shandler/desirednodestate.go
+++ b/pkg/k8shandler/desirednodestate.go
@@ -307,17 +307,7 @@ func (cfg *desiredNodeState) IsUpdateNeeded() bool {
 		// resource doesn't exist, so the update is needed
 		return true
 	}
-
-	diff, err := node.isDifferent(cfg)
-	if err != nil {
-		logrus.Errorf("Failed to obtain if there is a significant difference in resources: %v", err)
-		return false
-	}
-
-	if diff {
-		return true
-	}
-	return false
+	return node.isUpdateNeeded(cfg)
 }
 
 func (node *nodeState) setStatefulSet(statefulSet apps.StatefulSet) {

--- a/pkg/k8shandler/nodetypefactory.go
+++ b/pkg/k8shandler/nodetypefactory.go
@@ -10,6 +10,7 @@ import (
 type NodeTypeInterface interface {
 	getResource() runtime.Object
 	isDifferent(cfg *desiredNodeState) (bool, error)
+	isUpdateNeeded(cfg *desiredNodeState) bool
 	constructNodeResource(cfg *desiredNodeState, owner metav1.OwnerReference) (runtime.Object, error)
 	delete() error
 	query() error

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -29,6 +29,12 @@ func (node *statefulSetNode) isDifferent(cfg *desiredNodeState) (bool, error) {
 	return false, nil
 }
 
+// isUpdateNeeded returns true if update is needed
+func (node *statefulSetNode) isUpdateNeeded(cfg *desiredNodeState) bool {
+	// This operator doesn't update nodes managed by StatefulSets in rolling fashion
+	return false
+}
+
 func (node *statefulSetNode) query() error {
 	err := sdk.Get(&node.resource)
 	return err


### PR DESCRIPTION
Change of the number of environmental variables or labels
makes the operator crash. This patche adds checks for lengths
of the respective arrays.

https://bugzilla.redhat.com/show_bug.cgi?id=1662105