### PR TITLE
support buildconfigs and no image build deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ operator-sdk: get-dep
 	fi
 
 imagebuilder:
-	@if ! type -p imagebuilder ; \
+	@if [ $${USE_IMAGE_STREAM:-false} = false ] && ! type -p imagebuilder ; \
 	then go get -u github.com/openshift/imagebuilder/cmd/imagebuilder ; \
 	fi
 
@@ -60,7 +60,9 @@ clean:
 	@rm -rf $(TARGET_DIR)
 
 image: imagebuilder
-	$(IMAGE_BUILDER) -t $(IMAGE_TAG) . $(IMAGE_BUILDER_OPTS)
+	@if [ $${USE_IMAGE_STREAM:-false} = false ] ; \
+	then $(IMAGE_BUILDER) -t $(IMAGE_TAG) . $(IMAGE_BUILDER_OPTS) ; \
+	fi
 
 test-e2e: image operator-sdk
 	hack/test-e2e.sh
@@ -74,6 +76,10 @@ simplify:
 	@gofmt -s -l -w $(SRC)
 
 deploy: deploy-setup deploy-image
+	hack/deploy.sh
+.PHONY: deploy
+
+deploy-no-build: deploy-setup
 	hack/deploy.sh
 .PHONY: deploy
 

--- a/hack/common
+++ b/hack/common
@@ -9,15 +9,13 @@ repo_dir="$(dirname $0)/.."
 
 IMAGE_TAG=${IMAGE_TAG:-"openshift/origin-elasticsearch-operator:latest"}
 
-# probably needs some work for contexts which have '-' in the name and are not IPs
-context=$(oc config current-context)
-API_SERVER=$(python -c \
-    "import re; m=re.match('.*/(.*)/.*',\"${context}\"); print m.group(1).replace('-','.')")
-
 ADMIN_USER=${ADMIN_USER:-admin}
 ADMIN_PSWD=${ADMIN_USER:-admin123}
 NAMESPACE=${NAMESPACE:-openshift-logging}
 REMOTE_REGISTRY=${REMOTE_REGISTRY:-false}
+# set to true if you are not running this on the same machine where
+# elasticsearch is running
+REMOTE_CLUSTER=${REMOTE_CLUSTER:-false}
 
 if [ $REMOTE_REGISTRY = false ] ; then
     : # skip

--- a/hack/deploy-image.sh
+++ b/hack/deploy-image.sh
@@ -8,6 +8,29 @@ fi
 
 source "$(dirname $0)/common"
 
+if [ "${USE_IMAGE_STREAM:-false}" = true ] ; then
+    oc process \
+        -p ES_OP_GITHUB_URL=https://github.com/${ES_OP_GITHUB_REPO:-openshift}/elasticsearch-operator \
+        -p ES_OP_GITHUB_BRANCH=${ES_OP_GITHUB_BRANCH:-master} \
+        -f hack/image-stream-build-config-template.yaml | \
+      oc -n openshift create -f -
+    # wait for is and bc
+    for ii in $(seq 1 10) ; do
+        if oc -n openshift get bc elasticsearch-operator > /dev/null 2>&1 && \
+           oc -n openshift get is elasticsearch-operator > /dev/null 2>&1 ; then
+            break
+        fi
+        sleep 1
+    done
+    if [ $ii = 10 ] ; then
+        echo ERROR: timeout waiting for elasticsearch-operator buildconfig and imagestream to be available
+        exit 1
+    fi
+    # wait
+    oc -n openshift logs -f bc/elasticsearch-operator
+    exit 0
+fi
+
 IMAGE_TAGGER=${IMAGE_TAGGER:-docker tag}
 LOCAL_PORT=${LOCAL_PORT:-5000}
 

--- a/hack/deploy-setup.sh
+++ b/hack/deploy-setup.sh
@@ -39,7 +39,9 @@ oc create clusterrolebinding elasticsearch-operator-prometheus-rolebinding \
     --serviceaccount=${NAMESPACE}:elasticsearch-operator \
     --clusterrole=prometheus-crd-edit ||:
 
-sudo sysctl -w vm.max_map_count=262144
+if [ "${REMOTE_CLUSTER:-false}" = false ] ; then
+  sudo sysctl -w vm.max_map_count=262144
+fi
 
 if [ "${CREATE_ES_SECRET:-true}" = true ] ; then
   # This is necessary for running the operator with go run

--- a/hack/image-stream-build-config-template.yaml
+++ b/hack/image-stream-build-config-template.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: "Template"
+metadata:
+  name: elasticsearch-dev-build-template
+  annotations:
+    description: "Template for creating local builds of logging components from source."
+    tags: "infrastructure"
+labels:
+  logging-infra: development
+  provider: openshift
+  component: development
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      build: elasticsearch-operator
+    name: elasticsearch-operator
+  spec: {}
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    labels:
+      app: elasticsearch-operator
+    name: elasticsearch-operator
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: elasticsearch-operator:latest
+    resources: {}
+    source:
+      git:
+        uri: ${ES_OP_GITHUB_URL}
+        ref: ${ES_OP_GITHUB_BRANCH}
+      type: Git
+    strategy:
+      dockerStrategy:
+        dockerfilePath: Dockerfile
+      type: Docker
+parameters:
+-
+  description: 'URL for elasticsearch-operator fork'
+  name: ES_OP_GITHUB_URL
+  value: https://github.com/openshift/elasticsearch-operator
+-
+  description: 'branch for elasticsearch-operator fork'
+  name: ES_OP_GITHUB_BRANCH
+  value: master

--- a/hack/undeploy.sh
+++ b/hack/undeploy.sh
@@ -8,4 +8,7 @@ for repo in ${repo_dir}; do
   oc delete -f ${repo}/manifests --ignore-not-found
 done
 
+oc delete -n openshift is elasticsearch-operator || :
+oc delete -n openshift bc elasticsearch-operator || :
+
 oc delete namespace ${NAMESPACE} ||:


### PR DESCRIPTION
If USE_IMAGE_STREAM=true, setup a buildconfig and an
image stream in the remote repo, and build the operator image
there from the github source.  This may save a lot of time
as opposed to building the image locally and pushing the image
into the remote registry.
Also allow deploying without first building the image.  This
assumes something like a CI environment where the previous
CI stage builds the images needed to deploy and test.