### PR TITLE
Updating es manifest to allow it to watch all namespaces

### DIFF
--- a/hack/undeploy.sh
+++ b/hack/undeploy.sh
@@ -10,5 +10,3 @@ done
 
 oc delete -n openshift is elasticsearch-operator || :
 oc delete -n openshift bc elasticsearch-operator || :
-
-oc delete namespace ${NAMESPACE} ||:

--- a/manifests/02-role.yaml
+++ b/manifests/02-role.yaml
@@ -1,5 +1,5 @@
 ---
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: elasticsearch-operator

--- a/manifests/03-role-bindings.yaml
+++ b/manifests/03-role-bindings.yaml
@@ -1,12 +1,13 @@
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: elasticsearch-operator-rolebinding
 subjects:
 - kind: ServiceAccount
   name: elasticsearch-operator
+  namespace: openshift-logging
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: elasticsearch-operator
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/05-deployment.yaml
+++ b/manifests/05-deployment.yaml
@@ -25,8 +25,6 @@ spec:
             name: metrics
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: OPERATOR_NAME
               value: "elasticsearch-operator"


### PR DESCRIPTION
Part of work for ES per namespace hackfest item for Jaeger integration
Note that this is not installed via OLM in the same way so that means a normal OLM installation will not give the Elasticsearch Operator full cluster watch authz