### PR TITLE
Don't use the sdk for exposing operator's metrics

### DIFF
--- a/cmd/elasticsearch-operator/main.go
+++ b/cmd/elasticsearch-operator/main.go
@@ -107,8 +107,6 @@ func Main() int {
 	}
 	printVersion()
 
-	sdk.ExposeMetricsPort()
-
 	resource := "logging.openshift.io/v1alpha1"
 	kind := "Elasticsearch"
 	namespace, err := k8sutil.GetWatchNamespace()


### PR DESCRIPTION
sdk.ExposeMetricsPort() leaks Service and is deprecated
in future version of the sdk.

For now, we won't be exposing metrics of the operator, but we plan
to do that later. This change has no impact on exposing metrics
of the elasticsearch cluster as a whole.