### PR TITLE
Improved status conditions

### DIFF
--- a/pkg/apis/elasticsearch/v1alpha1/types.go
+++ b/pkg/apis/elasticsearch/v1alpha1/types.go
@@ -77,6 +77,7 @@ type ElasticsearchNodeStatus struct {
 	Status          string                         `json:"status,omitempty"`
 	UpgradeStatus   ElasticsearchNodeUpgradeStatus `json:"upgradeStatus,omitempty"`
 	Roles           []ElasticsearchNodeRole        `json:"roles,omitempty"`
+	Conditions      []ClusterCondition             `json:"conditions,omitempty"`
 }
 
 type ElasticsearchNodeUpgradeStatus struct {
@@ -179,6 +180,17 @@ const (
 	ScalingUp        ClusterConditionType = "ScalingUp"
 	ScalingDown      ClusterConditionType = "ScalingDown"
 	Restarting       ClusterConditionType = "Restarting"
+
+	InvalidMasters    ClusterConditionType = "InvalidMasters"
+	InvalidData       ClusterConditionType = "InvalidData"
+	InvalidRedundancy ClusterConditionType = "InvalidRedundancy"
+
+	ESContainerWaiting       ClusterConditionType = "ElasticsearchContainerWaiting"
+	ESContainerTerminated    ClusterConditionType = "ElasticsearchContainerTerminated"
+	ProxyContainerWaiting    ClusterConditionType = "ProxyContainerWaiting"
+	ProxyContainerTerminated ClusterConditionType = "ProxyContainerTerminated"
+	Unschedulable            ClusterConditionType = "Unschedulable"
+	NodeStorage              ClusterConditionType = "NodeStorage"
 )
 
 type ClusterEvent string

--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -251,7 +251,8 @@ func getScheduledRedeployOnlyNodes(cluster *v1alpha1.Elasticsearch) []NodeTypeIn
 
 	for _, node := range cluster.Status.Nodes {
 		if node.UpgradeStatus.ScheduledForRedeploy == v1.ConditionTrue &&
-			node.UpgradeStatus.ScheduledForUpgrade == v1.ConditionFalse {
+			(node.UpgradeStatus.ScheduledForUpgrade == v1.ConditionFalse ||
+				node.UpgradeStatus.ScheduledForUpgrade == "") {
 			for _, nodeTypeInterface := range nodes[nodeMapKey(cluster.Name, cluster.Namespace)] {
 				if node.DeploymentName == nodeTypeInterface.name() ||
 					node.StatefulSetName == nodeTypeInterface.name() {

--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -308,7 +308,8 @@ func newEnvVars(nodeName, clusterName, instanceRam string, roleMap map[api.Elast
 	}
 }
 
-func newLabels(clusterName string, roleMap map[api.ElasticsearchNodeRole]bool) map[string]string {
+// TODO: add isChanged check for labels and label selector
+func newLabels(clusterName, nodeName string, roleMap map[api.ElasticsearchNodeRole]bool) map[string]string {
 
 	return map[string]string{
 		"es-node-client":                   strconv.FormatBool(roleMap[api.ElasticsearchRoleClient]),
@@ -317,16 +318,18 @@ func newLabels(clusterName string, roleMap map[api.ElasticsearchNodeRole]bool) m
 		"cluster-name":                     clusterName,
 		"component":                        clusterName,
 		"tuned.openshift.io/elasticsearch": "true",
+		"node-name":                        nodeName,
 	}
 }
 
-func newLabelSelector(clusterName string, roleMap map[api.ElasticsearchNodeRole]bool) map[string]string {
+func newLabelSelector(clusterName, nodeName string, roleMap map[api.ElasticsearchNodeRole]bool) map[string]string {
 
 	return map[string]string{
 		"es-node-client": strconv.FormatBool(roleMap[api.ElasticsearchRoleClient]),
 		"es-node-data":   strconv.FormatBool(roleMap[api.ElasticsearchRoleData]),
 		"es-node-master": strconv.FormatBool(roleMap[api.ElasticsearchRoleMaster]),
 		"cluster-name":   clusterName,
+		"node-name":      nodeName,
 	}
 }
 

--- a/pkg/k8shandler/configmaps.go
+++ b/pkg/k8shandler/configmaps.go
@@ -98,6 +98,10 @@ func CreateOrUpdateConfigMaps(dpl *v1alpha1.Elasticsearch) (err error) {
 					}
 					return nil
 				})
+			} else {
+				if err := updateConditionWithRetry(dpl, v1.ConditionFalse, updateUpdatingSettingsCondition); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -32,7 +32,7 @@ type deploymentNode struct {
 
 func (deploymentNode *deploymentNode) populateReference(nodeName string, node v1alpha1.ElasticsearchNode, cluster *v1alpha1.Elasticsearch, roleMap map[v1alpha1.ElasticsearchNodeRole]bool, replicas int32) {
 
-	labels := newLabels(cluster.Name, roleMap)
+	labels := newLabels(cluster.Name, nodeName, roleMap)
 
 	deployment := apps.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -51,7 +51,7 @@ func (deploymentNode *deploymentNode) populateReference(nodeName string, node v1
 	deployment.Spec = apps.DeploymentSpec{
 		Replicas: &replicas,
 		Selector: &metav1.LabelSelector{
-			MatchLabels: newLabelSelector(cluster.Name, roleMap),
+			MatchLabels: newLabelSelector(cluster.Name, nodeName, roleMap),
 		},
 		Strategy: apps.DeploymentStrategy{
 			Type: "Recreate",
@@ -77,8 +77,8 @@ func (node *deploymentNode) name() string {
 
 func (node *deploymentNode) state() v1alpha1.ElasticsearchNodeStatus {
 
-	rolloutForReload := v1.ConditionFalse
-	rolloutForUpdate := v1.ConditionFalse
+	var rolloutForReload v1.ConditionStatus
+	var rolloutForUpdate v1.ConditionStatus
 
 	// see if we need to update the deployment object
 	if node.isChanged() {
@@ -362,7 +362,7 @@ func (node *deploymentNode) restart(upgradeStatus *v1alpha1.ElasticsearchNodeSta
 		}
 
 		upgradeStatus.UpgradeStatus.UpgradePhase = v1alpha1.ControllerUpdated
-		upgradeStatus.UpgradeStatus.UnderUpgrade = v1.ConditionFalse
+		upgradeStatus.UpgradeStatus.UnderUpgrade = ""
 	}
 }
 
@@ -462,7 +462,7 @@ func (node *deploymentNode) update(upgradeStatus *v1alpha1.ElasticsearchNodeStat
 		}
 
 		upgradeStatus.UpgradeStatus.UpgradePhase = v1alpha1.ControllerUpdated
-		upgradeStatus.UpgradeStatus.UnderUpgrade = v1.ConditionFalse
+		upgradeStatus.UpgradeStatus.UnderUpgrade = ""
 	}
 
 	return nil

--- a/pkg/k8shandler/elasticsearch.go
+++ b/pkg/k8shandler/elasticsearch.go
@@ -12,6 +12,8 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strconv"
+	"strings"
 
 	"github.com/openshift/elasticsearch-operator/pkg/apis/elasticsearch/v1alpha1"
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
@@ -62,23 +64,206 @@ func GetShardAllocation(clusterName, namespace string) (string, error) {
 	curlESService(clusterName, namespace, payload)
 
 	allocation := ""
-	if payload.ResponseBody["transient"] != nil {
-		transientBody := payload.ResponseBody["transient"].(map[string]interface{})
-		if transientBody["cluster"] != nil {
-			clusterBody := transientBody["cluster"].(map[string]interface{})
-			if clusterBody["routing"] != nil {
-				routingBody := clusterBody["routing"].(map[string]interface{})
-				if routingBody["allocation"] != nil {
-					allocationBody := routingBody["allocation"].(map[string]interface{})
-					if allocationBody["enable"] != nil {
-						allocation = allocationBody["enable"].(string)
-					}
-				}
+	value := walkInterfaceMap("transient.cluster.routing.allocation.enable", payload.ResponseBody)
+
+	if value != nil {
+		allocation = value.(string)
+	}
+
+	return allocation, payload.Error
+}
+
+func GetNodeDiskUsage(clusterName, namespace, nodeName string) (string, float64, error) {
+
+	payload := &esCurlStruct{
+		Method: http.MethodGet,
+		Uri:    "_cat/nodes?h=name,du,dup",
+	}
+
+	curlESService(clusterName, namespace, payload)
+
+	usage := ""
+	percentUsage := float64(-1)
+
+	if payload.ResponseBody["results"] != nil {
+		response := parseNodeDiskUsage(payload.ResponseBody["results"].(string))
+		if nodeResponse, ok := response[nodeName]; ok {
+			nodeResponseBody := nodeResponse.(map[string]interface{})
+
+			if nodeResponseBody["used"] != nil {
+				usage = nodeResponseBody["used"].(string)
+			}
+
+			if nodeResponseBody["used_percent"] != nil {
+				percentUsage = nodeResponseBody["used_percent"].(float64)
 			}
 		}
 	}
 
-	return allocation, payload.Error
+	return usage, percentUsage, payload.Error
+}
+
+func GetThresholdEnabled(clusterName, namespace string) (bool, error) {
+
+	payload := &esCurlStruct{
+		Method: http.MethodGet,
+		Uri:    "_cluster/settings?include_defaults=true&filter_path=defaults.cluster.routing.allocation.disk",
+	}
+
+	curlESService(clusterName, namespace, payload)
+
+	var enabled interface{}
+
+	if value := walkInterfaceMap(
+		"defaults.cluster.routing.allocation.disk.threshold_enabled",
+		payload.ResponseBody); enabled != nil {
+
+		enabled = value
+	}
+
+	if value := walkInterfaceMap(
+		"persistent.cluster.routing.allocation.disk.threshold_enabled",
+		payload.ResponseBody); value != nil {
+
+		enabled = value
+	}
+
+	if value := walkInterfaceMap(
+		"transient.cluster.routing.allocation.disk.threshold_enabled",
+		payload.ResponseBody); value != nil {
+
+		enabled = value
+	}
+
+	if enabled != nil {
+		enabled, _ = strconv.ParseBool(enabled.(string))
+	} else {
+		enabled = false
+	}
+
+	return enabled.(bool), payload.Error
+}
+
+func GetDiskWatermarks(clusterName, namespace string) (interface{}, interface{}, error) {
+
+	payload := &esCurlStruct{
+		Method: http.MethodGet,
+		Uri:    "_cluster/settings?include_defaults=true&filter_path=defaults.cluster.routing.allocation.disk",
+	}
+
+	curlESService(clusterName, namespace, payload)
+
+	var low interface{}
+	var high interface{}
+
+	if value := walkInterfaceMap(
+		"defaults.cluster.routing.allocation.disk.watermark.low",
+		payload.ResponseBody); value != nil {
+
+		low = value
+	}
+
+	if value := walkInterfaceMap(
+		"defaults.cluster.routing.allocation.disk.watermark.high",
+		payload.ResponseBody); value != nil {
+
+		high = value
+	}
+
+	if value := walkInterfaceMap(
+		"persistent.cluster.routing.allocation.disk.watermark.low",
+		payload.ResponseBody); value != nil {
+
+		low = value
+	}
+
+	if value := walkInterfaceMap(
+		"persistent.cluster.routing.allocation.disk.watermark.high",
+		payload.ResponseBody); value != nil {
+
+		high = value
+	}
+
+	if value := walkInterfaceMap(
+		"transient.cluster.routing.allocation.disk.watermark.low",
+		payload.ResponseBody); value != nil {
+
+		low = value
+	}
+
+	if value := walkInterfaceMap(
+		"transient.cluster.routing.allocation.disk.watermark.high",
+		payload.ResponseBody); value != nil {
+
+		high = value
+	}
+
+	if low != nil {
+		if strings.HasSuffix(low.(string), "%") {
+			low, _ = strconv.ParseFloat(strings.TrimSuffix(low.(string), "%"), 64)
+		} else {
+			if strings.HasSuffix(low.(string), "b") {
+				low = strings.TrimSuffix(low.(string), "b")
+			}
+		}
+	}
+
+	if high != nil {
+		if strings.HasSuffix(high.(string), "%") {
+			high, _ = strconv.ParseFloat(strings.TrimSuffix(high.(string), "%"), 64)
+		} else {
+			if strings.HasSuffix(high.(string), "b") {
+				high = strings.TrimSuffix(high.(string), "b")
+			}
+		}
+	}
+
+	return low, high, payload.Error
+}
+
+func walkInterfaceMap(path string, interfaceMap map[string]interface{}) interface{} {
+
+	current := interfaceMap
+	keys := strings.Split(path, ".")
+	keyCount := len(keys)
+
+	for index, key := range keys {
+		if current[key] != nil {
+			if index+1 < keyCount {
+				current = current[key].(map[string]interface{})
+			} else {
+				return current[key]
+			}
+		} else {
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func parseNodeDiskUsage(results string) map[string]interface{} {
+
+	nodeDiskUsage := make(map[string]interface{})
+
+	for _, result := range strings.Split(results, "\n") {
+		fields := strings.Split(result, " ")
+
+		if len(fields) == 3 {
+
+			percent, err := strconv.ParseFloat(fields[2], 64)
+			if err != nil {
+				percent = float64(-1)
+			}
+
+			nodeDiskUsage[fields[0]] = map[string]interface{}{
+				"used":         strings.ToUpper(strings.TrimSuffix(fields[1], "b")),
+				"used_percent": percent,
+			}
+		}
+	}
+
+	return nodeDiskUsage
 }
 
 func SetMinMasterNodes(clusterName, namespace string, numberMasters int32) (bool, error) {
@@ -245,7 +430,8 @@ func getMapFromBody(body io.ReadCloser) map[string]interface{} {
 	var results map[string]interface{}
 	err := json.Unmarshal([]byte(buf.String()), &results)
 	if err != nil {
-
+		results = make(map[string]interface{})
+		results["results"] = buf.String()
 	}
 
 	return results

--- a/pkg/k8shandler/util.go
+++ b/pkg/k8shandler/util.go
@@ -90,19 +90,42 @@ func isValidDataCount(dpl *api.Elasticsearch) bool {
 
 func isValidRedundancyPolicy(dpl *api.Elasticsearch) bool {
 	dataCount := int(getDataCount(dpl))
+
 	return !(dataCount == 1 && dpl.Spec.RedundancyPolicy == api.SingleRedundancy)
 }
 
 func isValidConf(dpl *api.Elasticsearch) error {
 	if !isValidMasterCount(dpl) {
+		if err := updateConditionWithRetry(dpl, v1.ConditionTrue, updateInvalidMasterCountCondition); err != nil {
+			return err
+		}
 		return fmt.Errorf("Invalid master nodes count. Please ensure there are no more than %v total nodes with master roles", maxMasterCount)
+	} else {
+		if err := updateConditionWithRetry(dpl, v1.ConditionFalse, updateInvalidMasterCountCondition); err != nil {
+			return err
+		}
 	}
 	if !isValidDataCount(dpl) {
+		if err := updateConditionWithRetry(dpl, v1.ConditionTrue, updateInvalidDataCountCondition); err != nil {
+			return err
+		}
 		return fmt.Errorf("No data nodes requested. Please ensure there is at least 1 node with data roles")
+	} else {
+		if err := updateConditionWithRetry(dpl, v1.ConditionFalse, updateInvalidDataCountCondition); err != nil {
+			return err
+		}
 	}
 	if !isValidRedundancyPolicy(dpl) {
+		if err := updateConditionWithRetry(dpl, v1.ConditionTrue, updateInvalidReplicationCondition); err != nil {
+			return err
+		}
 		return fmt.Errorf("Wrong RedundancyPolicy selected. Choose different RedundancyPolicy or add more nodes with data roles")
+	} else {
+		if err := updateConditionWithRetry(dpl, v1.ConditionFalse, updateInvalidReplicationCondition); err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -11,9 +11,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	goctx "context"
-	v1 "k8s.io/api/core/v1"
 	elasticsearch "github.com/openshift/elasticsearch-operator/pkg/apis/elasticsearch/v1alpha1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -126,7 +126,8 @@ func elasticsearchFullClusterTest(t *testing.T, f *framework.Framework, ctx *fra
 			Nodes: []elasticsearch.ElasticsearchNode{
 				esDataNode,
 			},
-			ManagementState: elasticsearch.ManagementStateManaged,
+			ManagementState:  elasticsearch.ManagementStateManaged,
+			RedundancyPolicy: elasticsearch.ZeroRedundancy,
 		},
 	}
 	err = f.Client.Create(goctx.TODO(), exampleElasticsearch, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
@@ -203,6 +204,19 @@ func elasticsearchFullClusterTest(t *testing.T, f *framework.Framework, ctx *fra
 	err = utils.WaitForStatefulset(t, f.KubeClient, namespace, "example-elasticsearch-clientmaster-1", 2, retryInterval, time.Second*30)
 	if err == nil {
 		return fmt.Errorf("unexpected statefulset replica count for example-elasticsearch-clientmaster-1 found")
+	}
+
+	if err = f.Client.Get(goctx.TODO(), exampleName, exampleElasticsearch); err != nil {
+		return fmt.Errorf("failed to get exampleElasticsearch: %v", err)
+	}
+
+	for _, condition := range exampleElasticsearch.Status.Conditions {
+		if condition.Type == elasticsearch.InvalidMasters {
+			if condition.Status == v1.ConditionFalse ||
+		 			condition.Status == "" {
+				return fmt.Errorf("unexpected status condition for example-elasticsearch found: %v", condition.Status)
+			}
+		}
 	}
 
 	t.Log("Finished successfully")

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -2,7 +2,7 @@ package e2e
 
 import (
 	"testing"
-	
+
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 )
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func GetFileContents(filePath string) []byte {


### PR DESCRIPTION
Adding conditions for invalid settings so they aren't just displayed in the operator logs to address part of https://jira.coreos.com/browse/LOG-339

```
  conditions:
  - lastTransitionTime: 2019-03-06T23:33:00Z
    message: Invalid master nodes count. Please ensure there are no more than 3 total
      nodes with master roles
    reason: Invalid Settings
    status: "True"
    type: InvalidMasters
  - lastTransitionTime: 2019-03-06T23:28:37Z
    status: "False"
    type: InvalidData
  - lastTransitionTime: 2019-03-06T23:28:38Z
    status: "False"
    type: InvalidRedundancy
  - lastTransitionTime: 2019-03-06T23:30:35Z
    message: Config Map is different
    reason: ConfigChange
    status: "True"
    type: UpdatingSettings
  - lastTransitionTime: 2019-03-06T23:28:52Z
    status: "False"
    type: ScalingUp
  - lastTransitionTime: 2019-03-06T23:28:52Z
    status: "False"
    type: ScalingDown
  - lastTransitionTime: 2019-03-06T23:28:52Z
    status: "False"
    type: Restarting
```