### PR TITLE
bug LOG-353 - oauth proxy doesnt start when deployed into different namespace

### DIFF
--- a/pkg/k8shandler/rbac.go
+++ b/pkg/k8shandler/rbac.go
@@ -94,7 +94,7 @@ func CreateOrUpdateRBAC(dpl *v1alpha1.Elasticsearch) error {
 	subject = utils.NewSubject(
 		"ServiceAccount",
 		"elasticsearch",
-		"openshift-logging",
+		dpl.Namespace,
 	)
 	subject.APIGroup = ""
 


### PR DESCRIPTION
fixes jira.coreos.com/browse/LOG-353