### PR TITLE
Use test namespace for e2e tests

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -24,18 +24,22 @@ if [ "${REMOTE_CLUSTER:-false}" = false ] ; then
   sudo sysctl -w vm.max_map_count=262144 ||:
 fi
 
-if oc get project openshift-logging > /dev/null 2>&1 ; then
-  echo using existing project openshift-logging
+TEST_NAMESPACE="${TEST_NAMESPACE:-e2e-test-${RANDOM}}"
+
+if oc get project ${TEST_NAMESPACE} > /dev/null 2>&1 ; then
+  echo using existing project ${TEST_NAMESPACE}
 else
-  oc create namespace openshift-logging
+  oc create namespace ${TEST_NAMESPACE}
 fi
 
-oc create -n openshift-logging -f \
+sed -i "s/namespace: openshift-logging/namespace: ${TEST_NAMESPACE}/g" ${manifest}
+
+oc create -n ${TEST_NAMESPACE} -f \
 https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheusrule.crd.yaml || :
-oc create -n openshift-logging -f \
+oc create -n ${TEST_NAMESPACE} -f \
 https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml || :
 
-TEST_NAMESPACE=openshift-logging go test ./test/e2e/... \
+TEST_NAMESPACE=${TEST_NAMESPACE} go test ./test/e2e/... \
   -root=$(pwd) \
   -kubeconfig=${KUBECONFIG} \
   -globalMan manifests/04-crd.yaml \
@@ -43,3 +47,5 @@ TEST_NAMESPACE=openshift-logging go test ./test/e2e/... \
   -v \
   -parallel=1 \
   -singleNamespace
+
+oc delete namespace ${TEST_NAMESPACE}


### PR DESCRIPTION
The tests should be run in a different namespace that `openshift-logging` to ensure that the operator can be deployed in a different namespace e.g. for Jaeger. 


Signed-off-by: Pavol Loffay <ploffay@redhat.com>