### PR TITLE
Bug 1691230 - Removing unnecessary output regarding pvc

### DIFF
--- a/pkg/k8shandler/persistentvolumeclaims.go
+++ b/pkg/k8shandler/persistentvolumeclaims.go
@@ -4,27 +4,22 @@ import (
 	"fmt"
 
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
-	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func createOrUpdatePersistentVolumeClaim(pvc v1.PersistentVolumeClaimSpec, newName string, namespace string) error {
-	claim := persistentVolumeClaim(newName, namespace)
-	err := sdk.Get(claim)
+
+	claim := createPersistentVolumeClaim(newName, namespace, pvc)
+	err := sdk.Create(claim)
 	if err != nil {
-		// PVC doesn't exists, needs to be created.
-		claim = createPersistentVolumeClaim(newName, namespace, pvc)
-		logrus.Infof("Creating new PVC: %v", newName)
-		err = sdk.Create(claim)
-		if err != nil {
+		if !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("Unable to create PVC: %v", err)
 		}
-	} else {
-		logrus.Infof("Reusing existing PVC: %s", newName)
-		// TODO for updates, don't forget to use retry.RetryOnConflict
 	}
+
 	return nil
 }
 

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -428,8 +428,6 @@ func (node *statefulSetNode) scale() {
 		return
 	}
 
-	logrus.Infof("Replica for desired: %d ; replica for current: %d", *desired.Spec.Replicas, *node.self.Spec.Replicas)
-
 	if *desired.Spec.Replicas != *node.self.Spec.Replicas {
 		node.self.Spec.Replicas = desired.Spec.Replicas
 		logrus.Infof("Resource '%s' has different container replicas than desired", node.self.Name)


### PR DESCRIPTION
Removing unnecessary output when creating PVCs in the elasticsearch operator

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1691230