### PR TITLE
Bug 1686173 - Use request or limit if other is not provided for resource requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ MAIN_PKG=cmd/$(APP_NAME)/main.go
 RUN_LOG?=elasticsearch-operator.log
 RUN_PID?=elasticsearch-operator.pid
 
-
 # go source files, ignore vendor directory
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
@@ -36,10 +35,10 @@ operator-sdk: get-dep
 	  make dep ; \
 	  make install || sudo make install || cd commands/operator-sdk && sudo go install ; \
 	fi
-	
+
 gendeepcopy: operator-sdk
 	@operator-sdk generate k8s
-	
+
 imagebuilder:
 	@if [ $${USE_IMAGE_STREAM:-false} = false ] && ! type -p imagebuilder ; \
 	then go get -u github.com/openshift/imagebuilder/cmd/imagebuilder ; \
@@ -71,6 +70,9 @@ image: imagebuilder
 
 test-e2e:
 	hack/test-e2e.sh
+
+test-unit:
+	@go test -v ./pkg/... ./cmd/...
 
 fmt:
 	@gofmt -l -w cmd && \

--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -362,41 +362,132 @@ func newPodTemplateSpec(nodeName, clusterName, namespace string, node api.Elasti
 }
 
 func newResourceRequirements(nodeResRequirements, commonResRequirements v1.ResourceRequirements) v1.ResourceRequirements {
-	limitCPU := nodeResRequirements.Limits.Cpu()
-	if limitCPU.IsZero() {
-		if commonResRequirements.Limits.Cpu().IsZero() {
-			CPU, _ := resource.ParseQuantity(defaultCPULimit)
-			limitCPU = &CPU
+	// if only one resource (cpu or memory) is specified as a limit/request use it for the other value as well instead of
+	//  using the defaults.
+
+	var requestMem *resource.Quantity
+	var limitMem *resource.Quantity
+	var requestCPU *resource.Quantity
+	var limitCPU *resource.Quantity
+
+	// first check if either limit or resource is left off
+	// Mem
+	nodeLimitMem := nodeResRequirements.Limits.Memory()
+	nodeRequestMem := nodeResRequirements.Requests.Memory()
+	commonLimitMem := commonResRequirements.Limits.Memory()
+	commonRequestMem := commonResRequirements.Requests.Memory()
+
+	if commonRequestMem.IsZero() && commonLimitMem.IsZero() {
+		// no common memory settings
+		if nodeRequestMem.IsZero() && nodeLimitMem.IsZero() {
+			// no node settings, use defaults
+			lMem, _ := resource.ParseQuantity(defaultMemoryLimit)
+			limitMem = &lMem
+
+			rMem, _ := resource.ParseQuantity(defaultMemoryRequest)
+			requestMem = &rMem
 		} else {
-			limitCPU = commonResRequirements.Limits.Cpu()
+			// either one is not zero or both aren't zero but common is empty
+			if nodeRequestMem.IsZero() {
+				// request is zero use limit for both
+				requestMem = nodeLimitMem
+				limitMem = nodeLimitMem
+			} else {
+				if nodeLimitMem.IsZero() {
+					// limit is zero use request for both
+					requestMem = nodeRequestMem
+					limitMem = nodeRequestMem
+				} else {
+					// both aren't zero
+					requestMem = nodeRequestMem
+					limitMem = nodeLimitMem
+				}
+			}
 		}
-	}
-	limitMem := nodeResRequirements.Limits.Memory()
-	if limitMem.IsZero() {
-		if commonResRequirements.Limits.Memory().IsZero() {
-			Mem, _ := resource.ParseQuantity(defaultMemoryLimit)
-			limitMem = &Mem
+	} else {
+		// either one is not zero or both aren't zero (common)
+
+		//check node for override
+		if nodeRequestMem.IsZero() {
+			// no node request mem, check that common has it
+			if commonRequestMem.IsZero() {
+				requestMem = commonLimitMem
+			} else {
+				requestMem = commonRequestMem
+			}
 		} else {
-			limitMem = commonResRequirements.Limits.Memory()
+			requestMem = nodeRequestMem
 		}
 
-	}
-	requestCPU := nodeResRequirements.Requests.Cpu()
-	if requestCPU.IsZero() {
-		if commonResRequirements.Requests.Cpu().IsZero() {
-			CPU, _ := resource.ParseQuantity(defaultCPURequest)
-			requestCPU = &CPU
+		if nodeLimitMem.IsZero() {
+			// no node request mem, check that common has it
+			if commonLimitMem.IsZero() {
+				limitMem = commonRequestMem
+			} else {
+				limitMem = commonLimitMem
+			}
 		} else {
-			requestCPU = commonResRequirements.Requests.Cpu()
+			limitMem = nodeLimitMem
 		}
 	}
-	requestMem := nodeResRequirements.Requests.Memory()
-	if requestMem.IsZero() {
-		if commonResRequirements.Requests.Memory().IsZero() {
-			Mem, _ := resource.ParseQuantity(defaultMemoryRequest)
-			requestMem = &Mem
+
+	// CPU
+	nodeLimitCPU := nodeResRequirements.Limits.Cpu()
+	nodeRequestCPU := nodeResRequirements.Requests.Cpu()
+	commonLimitCPU := commonResRequirements.Limits.Cpu()
+	commonRequestCPU := commonResRequirements.Requests.Cpu()
+
+	if commonRequestCPU.IsZero() && commonLimitCPU.IsZero() {
+		// no common memory settings
+		if nodeRequestCPU.IsZero() && nodeLimitCPU.IsZero() {
+			// no node settings, use defaults
+			lCPU, _ := resource.ParseQuantity(defaultCPULimit)
+			limitCPU = &lCPU
+
+			rCPU, _ := resource.ParseQuantity(defaultCPURequest)
+			requestCPU = &rCPU
 		} else {
-			requestMem = commonResRequirements.Requests.Memory()
+			// either one is not zero or both aren't zero but common is empty
+			if nodeRequestCPU.IsZero() {
+				// request is zero use limit for both
+				requestCPU = nodeLimitCPU
+				limitCPU = nodeLimitCPU
+			} else {
+				if nodeLimitCPU.IsZero() {
+					// limit is zero use request for both
+					requestCPU = nodeRequestCPU
+					limitCPU = nodeRequestCPU
+				} else {
+					// both aren't zero
+					requestCPU = nodeRequestCPU
+					limitCPU = nodeLimitCPU
+				}
+			}
+		}
+	} else {
+		// either one is not zero or both aren't zero (common)
+
+		//check node for override
+		if nodeRequestCPU.IsZero() {
+			// no node request mem, check that common has it
+			if commonRequestCPU.IsZero() {
+				requestCPU = commonLimitCPU
+			} else {
+				requestCPU = commonRequestCPU
+			}
+		} else {
+			requestCPU = nodeRequestCPU
+		}
+
+		if nodeLimitCPU.IsZero() {
+			// no node request mem, check that common has it
+			if commonLimitCPU.IsZero() {
+				limitCPU = commonRequestCPU
+			} else {
+				limitCPU = commonLimitCPU
+			}
+		} else {
+			limitCPU = nodeLimitCPU
 		}
 	}
 

--- a/pkg/k8shandler/common_test.go
+++ b/pkg/k8shandler/common_test.go
@@ -1,0 +1,410 @@
+package k8shandler
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var (
+	commonCpuValue = resource.MustParse("500m")
+	commonMemValue = resource.MustParse("2Gi")
+
+	nodeCpuValue = resource.MustParse("600m")
+	nodeMemValue = resource.MustParse("3Gi")
+
+	defaultTestCpuLimit   = resource.MustParse(defaultCPULimit)
+	defaultTestCpuRequest = resource.MustParse(defaultCPURequest)
+	defaultTestMemLimit   = resource.MustParse(defaultMemoryLimit)
+	defaultTestMemRequest = resource.MustParse(defaultMemoryRequest)
+)
+
+/*
+  Resource scenarios:
+  1. common has a limit and request
+     node sets new request and limit
+     -> use node settings
+
+  2. common has limit and request
+     node has no settings
+     -> use common settings
+
+  3. common has no settings
+     node has no settings
+     -> use defaults
+
+  4. common has limit and request
+     node sets request only
+     -> use common limit and node request
+
+  5. common has limit and request
+     node sets limt only
+     -> use common request and node limit
+
+  6. common has request only
+     node has no settings
+     -> request and limit set to be same and use common settings
+
+  7. common has limit only
+     node has no settings
+     -> request and limit set to be same and use common settings
+
+  8. common has no settings
+     node only has request
+     -> request and limit set to be same and use node settings
+
+  9. common has no settings
+     node only has limit
+     -> request and limit set to be same and use node settings
+
+ 10. common has limit
+     node has request
+     -> use common limit and node request
+
+ 11. common has request
+     node has limit
+     -> use common request and node limit
+*/
+
+// 1
+func TestResourcesCommonAndNodeDefined(t *testing.T) {
+
+	commonRequirements := buildResource(
+		commonCpuValue,
+		commonCpuValue,
+		commonMemValue,
+		commonMemValue,
+	)
+
+	nodeRequirements := buildResource(
+		nodeCpuValue,
+		nodeCpuValue,
+		nodeMemValue,
+		nodeMemValue,
+	)
+
+	expected := buildResource(
+		nodeCpuValue,
+		nodeCpuValue,
+		nodeMemValue,
+		nodeMemValue,
+	)
+
+	actual := newResourceRequirements(nodeRequirements, commonRequirements)
+
+	if !areResourcesSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+// 2
+func TestResourcesNoNodeDefined(t *testing.T) {
+
+	commonRequirements := buildResource(
+		commonCpuValue,
+		commonCpuValue,
+		nodeMemValue,
+		nodeMemValue,
+	)
+
+	nodeRequirements := v1.ResourceRequirements{}
+
+	expected := buildResource(
+		commonCpuValue,
+		commonCpuValue,
+		nodeMemValue,
+		nodeMemValue,
+	)
+
+	actual := newResourceRequirements(nodeRequirements, commonRequirements)
+
+	if !areResourcesSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+// 3
+func TestResourcesNoCommonNoNodeDefined(t *testing.T) {
+
+	commonRequirements := v1.ResourceRequirements{}
+
+	nodeRequirements := v1.ResourceRequirements{}
+
+	expected := buildResource(
+		defaultTestCpuLimit,
+		defaultTestCpuRequest,
+		defaultTestMemLimit,
+		defaultTestMemRequest,
+	)
+
+	actual := newResourceRequirements(nodeRequirements, commonRequirements)
+
+	if !areResourcesSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+// 4
+func TestResourcesCommonAndNodeRequestDefined(t *testing.T) {
+
+	commonRequirements := buildResource(
+		commonCpuValue,
+		commonCpuValue,
+		commonMemValue,
+		commonMemValue,
+	)
+
+	nodeRequirements := buildResourceOnlyRequests(
+		nodeCpuValue,
+		nodeMemValue,
+	)
+
+	expected := buildResource(
+		commonCpuValue,
+		nodeCpuValue,
+		commonMemValue,
+		nodeMemValue,
+	)
+
+	actual := newResourceRequirements(nodeRequirements, commonRequirements)
+
+	if !areResourcesSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+// 5
+func TestResourcesCommonAndNodeLimitDefined(t *testing.T) {
+
+	commonRequirements := buildResource(
+		commonCpuValue,
+		commonCpuValue,
+		commonMemValue,
+		commonMemValue,
+	)
+
+	nodeRequirements := buildResourceOnlyLimits(
+		nodeCpuValue,
+		nodeMemValue,
+	)
+
+	expected := buildResource(
+		nodeCpuValue,
+		commonCpuValue,
+		nodeMemValue,
+		commonMemValue,
+	)
+
+	actual := newResourceRequirements(nodeRequirements, commonRequirements)
+
+	if !areResourcesSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+// 6
+func TestResourcesCommonRequestAndNoNodeDefined(t *testing.T) {
+
+	commonRequirements := buildResourceOnlyRequests(
+		commonCpuValue,
+		commonMemValue,
+	)
+
+	nodeRequirements := v1.ResourceRequirements{}
+
+	expected := buildResource(
+		commonCpuValue,
+		commonCpuValue,
+		commonMemValue,
+		commonMemValue,
+	)
+
+	actual := newResourceRequirements(nodeRequirements, commonRequirements)
+
+	if !areResourcesSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+// 7
+func TestResourcesCommonLimitAndNoNodeDefined(t *testing.T) {
+
+	commonRequirements := buildResourceOnlyLimits(
+		commonCpuValue,
+		commonMemValue,
+	)
+
+	nodeRequirements := v1.ResourceRequirements{}
+
+	expected := buildResource(
+		commonCpuValue,
+		commonCpuValue,
+		commonMemValue,
+		commonMemValue,
+	)
+
+	actual := newResourceRequirements(nodeRequirements, commonRequirements)
+
+	if !areResourcesSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+// 8
+func TestResourcesNoCommonAndNodeRequestDefined(t *testing.T) {
+
+	commonRequirements := v1.ResourceRequirements{}
+
+	nodeRequirements := buildResourceOnlyRequests(
+		nodeCpuValue,
+		nodeMemValue,
+	)
+
+	expected := buildResource(
+		nodeCpuValue,
+		nodeCpuValue,
+		nodeMemValue,
+		nodeMemValue,
+	)
+
+	actual := newResourceRequirements(nodeRequirements, commonRequirements)
+
+	if !areResourcesSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+// 9
+func TestResourcesNoCommonAndNodeLimitDefined(t *testing.T) {
+
+	commonRequirements := v1.ResourceRequirements{}
+
+	nodeRequirements := buildResourceOnlyLimits(
+		nodeCpuValue,
+		nodeMemValue,
+	)
+
+	expected := buildResource(
+		nodeCpuValue,
+		nodeCpuValue,
+		nodeMemValue,
+		nodeMemValue,
+	)
+
+	actual := newResourceRequirements(nodeRequirements, commonRequirements)
+
+	if !areResourcesSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+// 10
+func TestResourcesCommonLimitAndNodeResourceDefined(t *testing.T) {
+
+	commonRequirements := buildResourceOnlyLimits(
+		commonCpuValue,
+		commonMemValue,
+	)
+
+	nodeRequirements := buildResourceOnlyRequests(
+		nodeCpuValue,
+		nodeMemValue,
+	)
+
+	expected := buildResource(
+		commonCpuValue,
+		nodeCpuValue,
+		commonMemValue,
+		nodeMemValue,
+	)
+
+	actual := newResourceRequirements(nodeRequirements, commonRequirements)
+
+	if !areResourcesSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+// 11
+func TestResourcesCommonResourceAndNodeLimitDefined(t *testing.T) {
+
+	commonRequirements := buildResourceOnlyRequests(
+		commonCpuValue,
+		commonMemValue,
+	)
+
+	nodeRequirements := buildResourceOnlyLimits(
+		nodeCpuValue,
+		nodeMemValue,
+	)
+
+	expected := buildResource(
+		nodeCpuValue,
+		commonCpuValue,
+		nodeMemValue,
+		commonMemValue,
+	)
+
+	actual := newResourceRequirements(nodeRequirements, commonRequirements)
+
+	if !areResourcesSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+func buildResource(cpuLimit, cpuRequest, memLimit, memRequest resource.Quantity) v1.ResourceRequirements {
+	return v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    cpuLimit,
+			v1.ResourceMemory: memLimit,
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    cpuRequest,
+			v1.ResourceMemory: memRequest,
+		},
+	}
+}
+
+func buildResourceOnlyRequests(cpuRequest, memRequest resource.Quantity) v1.ResourceRequirements {
+	return v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    cpuRequest,
+			v1.ResourceMemory: memRequest,
+		},
+	}
+}
+
+func buildResourceOnlyLimits(cpuLimit, memLimit resource.Quantity) v1.ResourceRequirements {
+	return v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    cpuLimit,
+			v1.ResourceMemory: memLimit,
+		},
+	}
+}
+
+func areResourcesSame(lhs, rhs v1.ResourceRequirements) bool {
+
+	if !areQuantitiesSame(lhs.Limits.Cpu(), rhs.Limits.Cpu()) {
+		return false
+	}
+
+	if !areQuantitiesSame(lhs.Requests.Cpu(), rhs.Requests.Cpu()) {
+		return false
+	}
+
+	if !areQuantitiesSame(lhs.Limits.Memory(), rhs.Limits.Memory()) {
+		return false
+	}
+
+	if !areQuantitiesSame(lhs.Requests.Memory(), rhs.Requests.Memory()) {
+		return false
+	}
+
+	return true
+}
+
+func areQuantitiesSame(lhs, rhs *resource.Quantity) bool {
+	return lhs.Cmp(*rhs) == 0
+}


### PR DESCRIPTION
This is instead of just using default for missing value as is currently done.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1686173