### PR TITLE
Bug 1694097 - Check if nodeselectors have changed

### DIFF
--- a/pkg/apis/elasticsearch/v1/types.go
+++ b/pkg/apis/elasticsearch/v1/types.go
@@ -99,8 +99,9 @@ const (
 
 // ElasticsearchNodeSpec represents configuration of an individual Elasticsearch node
 type ElasticsearchNodeSpec struct {
-	Image     string                  `json:"image,omitempty"`
-	Resources v1.ResourceRequirements `json:"resources"`
+	Image        string                  `json:"image,omitempty"`
+	Resources    v1.ResourceRequirements `json:"resources"`
+	NodeSelector map[string]string       `json:"nodeSelector,omitempty"`
 }
 
 type ElasticsearchRequiredAction string

--- a/pkg/apis/elasticsearch/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/elasticsearch/v1/zz_generated.deepcopy.go
@@ -103,6 +103,11 @@ func (in *ElasticsearchNode) DeepCopyInto(out *ElasticsearchNode) {
 		}
 	}
 	in.Storage.DeepCopyInto(&out.Storage)
+	if in.GenUUID != nil {
+		in, out := &in.GenUUID, &out.GenUUID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -120,6 +125,13 @@ func (in *ElasticsearchNode) DeepCopy() *ElasticsearchNode {
 func (in *ElasticsearchNodeSpec) DeepCopyInto(out *ElasticsearchNodeSpec) {
 	*out = *in
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -354,7 +354,7 @@ func newPodTemplateSpec(nodeName, clusterName, namespace string, node api.Elasti
 				),
 				proxyContainer,
 			},
-			NodeSelector:       node.NodeSelector,
+			NodeSelector:       mergeSelectors(node.NodeSelector, commonSpec.NodeSelector),
 			ServiceAccountName: clusterName,
 			Volumes:            newVolumes(clusterName, nodeName, namespace, node),
 		},

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -487,11 +487,22 @@ func (node *deploymentNode) isChanged() bool {
 	changed := false
 
 	desired := node.self.DeepCopy()
+
+	// we want to blank this out before a get to ensure we get the correct information back (possible sdk issue with maps?)
+	node.self.Spec = apps.DeploymentSpec{}
+
 	err := sdk.Get(&node.self)
 	// error check that it exists, etc
 	if err != nil {
 		// if it doesn't exist, return true
 		return false
+	}
+
+	// check the pod's nodeselector
+	if !areSelectorsSame(node.self.Spec.Template.Spec.NodeSelector, desired.Spec.Template.Spec.NodeSelector) {
+		logrus.Debugf("Resource '%s' has different nodeSelector than desired", node.self.Name)
+		node.self.Spec.Template.Spec.NodeSelector = desired.Spec.Template.Spec.NodeSelector
+		changed = true
 	}
 
 	// Only Image and Resources (CPU & memory) differences trigger rolling restart

--- a/pkg/k8shandler/util.go
+++ b/pkg/k8shandler/util.go
@@ -37,6 +37,35 @@ func appendDefaultLabel(clusterName string, labels map[string]string) map[string
 	return labels
 }
 
+func areSelectorsSame(lhs, rhs map[string]string) bool {
+
+	if len(lhs) != len(rhs) {
+		return false
+	}
+
+	for lhsKey, lhsVal := range lhs {
+		rhsVal, ok := rhs[lhsKey]
+		if !ok || lhsVal != rhsVal {
+			return false
+		}
+	}
+
+	return true
+}
+
+func mergeSelectors(nodeSelectors, commonSelectors map[string]string) map[string]string {
+
+	if commonSelectors == nil {
+		commonSelectors = make(map[string]string)
+	}
+
+	for k, v := range nodeSelectors {
+		commonSelectors[k] = v
+	}
+
+	return commonSelectors
+}
+
 // getPodNames returns the pod names of the array of pods passed in
 func getPodNames(pods []v1.Pod) []string {
 	var podNames []string

--- a/pkg/k8shandler/util_test.go
+++ b/pkg/k8shandler/util_test.go
@@ -1,0 +1,106 @@
+package k8shandler
+
+import (
+	"testing"
+)
+
+func TestSelectorsBothUndefined(t *testing.T) {
+
+	commonSelector := map[string]string{}
+
+	nodeSelector := map[string]string{}
+
+	expected := map[string]string{}
+
+	actual := mergeSelectors(nodeSelector, commonSelector)
+
+	if !areSelectorsSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+func TestSelectorsCommonDefined(t *testing.T) {
+
+	commonSelector := map[string]string{
+		"common": "test",
+	}
+
+	nodeSelector := map[string]string{}
+
+	expected := map[string]string{
+		"common": "test",
+	}
+
+	actual := mergeSelectors(nodeSelector, commonSelector)
+
+	if !areSelectorsSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+func TestSelectorsNodeDefined(t *testing.T) {
+
+	commonSelector := map[string]string{}
+
+	nodeSelector := map[string]string{
+		"node": "test",
+	}
+
+	expected := map[string]string{
+		"node": "test",
+	}
+
+	actual := mergeSelectors(nodeSelector, commonSelector)
+
+	if !areSelectorsSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+func TestSelectorsCommonAndNodeDefined(t *testing.T) {
+
+	commonSelector := map[string]string{
+		"common": "test",
+	}
+
+	nodeSelector := map[string]string{
+		"node": "test",
+	}
+
+	expected := map[string]string{
+		"common": "test",
+		"node":   "test",
+	}
+
+	actual := mergeSelectors(nodeSelector, commonSelector)
+
+	if !areSelectorsSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+func TestSelectorsCommonOverwritten(t *testing.T) {
+
+	commonSelector := map[string]string{
+		"common": "test",
+		"node":   "test",
+		"test":   "common",
+	}
+
+	nodeSelector := map[string]string{
+		"common": "node",
+		"test":   "node",
+	}
+
+	expected := map[string]string{
+		"common": "node",
+		"node":   "test",
+		"test":   "node",
+	}
+
+	actual := mergeSelectors(nodeSelector, commonSelector)
+
+	if !areSelectorsSame(actual, expected) {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}


### PR DESCRIPTION
If node selectors have changed for Elasticsearch nodes then we should recognize this change and perform a rolling restart with the changes.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1694097