### PR TITLE
Fix 1662273 - cant find es metrics

### DIFF
--- a/pkg/k8shandler/service.go
+++ b/pkg/k8shandler/service.go
@@ -28,6 +28,7 @@ func CreateOrUpdateServices(dpl *api.Elasticsearch) error {
 		annotations,
 		true,
 		ownerRef,
+		map[string]string{},
 	)
 	if err != nil {
 		return fmt.Errorf("Failure creating service %v", err)
@@ -43,6 +44,7 @@ func CreateOrUpdateServices(dpl *api.Elasticsearch) error {
 		annotations,
 		false,
 		ownerRef,
+		map[string]string{},
 	)
 	if err != nil {
 		return fmt.Errorf("Failure creating service %v", err)
@@ -54,11 +56,14 @@ func CreateOrUpdateServices(dpl *api.Elasticsearch) error {
 		dpl.Namespace,
 		dpl.Name,
 		"metrics",
-		9200,
+		60000,
 		selectorForES("es-node-client", dpl.Name),
 		annotations,
 		false,
 		ownerRef,
+		map[string]string{
+			"scrape-metrics": "enabled",
+		},
 	)
 	if err != nil {
 		return fmt.Errorf("Failure creating service %v", err)
@@ -66,9 +71,9 @@ func CreateOrUpdateServices(dpl *api.Elasticsearch) error {
 	return nil
 }
 
-func createOrUpdateService(serviceName, namespace, clusterName, targetPortName string, port int32, selector, annotations map[string]string, publishNotReady bool, owner metav1.OwnerReference) error {
+func createOrUpdateService(serviceName, namespace, clusterName, targetPortName string, port int32, selector, annotations map[string]string, publishNotReady bool, owner metav1.OwnerReference, labels map[string]string) error {
 
-	labels := appendDefaultLabel(clusterName, map[string]string{})
+	labels = appendDefaultLabel(clusterName, labels)
 
 	service := newService(
 		serviceName,

--- a/pkg/k8shandler/service_monitor.go
+++ b/pkg/k8shandler/service_monitor.go
@@ -21,6 +21,7 @@ func CreateOrUpdateServiceMonitors(dpl *v1.Elasticsearch) error {
 	owner := getOwnerRef(dpl)
 
 	labelsWithDefault := appendDefaultLabel(dpl.Name, dpl.Labels)
+	labelsWithDefault["scrape-metrics"] = "enabled"
 
 	elasticsearchScMonitor := createServiceMonitor(serviceMonitorName, dpl.Name, dpl.Namespace, labelsWithDefault)
 	addOwnerRefToObject(elasticsearchScMonitor, owner)
@@ -45,7 +46,7 @@ func createServiceMonitor(serviceMonitorName, clusterName, namespace string, lab
 		// ServerName can be e.g. elasticsearch-metrics.openshift-logging.svc
 	}
 	endpoint := monitoringv1.Endpoint{
-		Port:            fmt.Sprintf("%s-%s", clusterName, "metrics"),
+		Port:            clusterName,
 		Path:            "/_prometheus/metrics",
 		Scheme:          "https",
 		BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",


### PR DESCRIPTION
There was a mismatch between labels and port name in metrics svc and service monitor.