### PR TITLE
Bug 1686173 - Correctly evaluate case where node previously existed

### DIFF
--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -113,6 +113,8 @@ func (node *deploymentNode) create() error {
 		if err != nil {
 			if !errors.IsAlreadyExists(err) {
 				return fmt.Errorf("Could not create node resource: %v", err)
+			} else {
+				return node.pause()
 			}
 		}
 

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -298,6 +298,9 @@ func (node *statefulSetNode) create() error {
 		if err != nil {
 			if !errors.IsAlreadyExists(err) {
 				return fmt.Errorf("Could not create node resource: %v", err)
+			} else {
+				node.scale()
+				return nil
 			}
 		}
 


### PR DESCRIPTION
We were unnecessarily falling through into logic that was reserved just for brand new nodes which was interfering with correctly evaluating if changes were required.

Ref: 
https://bugzilla.redhat.com/show_bug.cgi?id=1686173
https://bugzilla.redhat.com/show_bug.cgi?id=1691256
https://bugzilla.redhat.com/show_bug.cgi?id=1694511