### PR TITLE
Bug 1703546: Waiting for synced flush

### DIFF
--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -309,15 +309,15 @@ func (node *deploymentNode) restart(upgradeStatus *api.ElasticsearchNodeStatus) 
 		}
 
 		if replicas > 0 {
-			if ok, err := DoSynchronizedFlush(node.clusterName, node.self.Namespace); !ok {
-				logrus.Warnf("Unable to perform synchronized flush: %v", err)
-				return
-			}
 
 			// disable shard allocation
 			if ok, err := SetShardAllocation(node.clusterName, node.self.Namespace, api.ShardAllocationNone); !ok {
 				logrus.Warnf("Unable to disable shard allocation: %v", err)
 				return
+			}
+
+			if ok, err := DoSynchronizedFlush(node.clusterName, node.self.Namespace); !ok {
+				logrus.Warnf("Unable to perform synchronized flush: %v", err)
 			}
 
 			// check for available replicas empty
@@ -393,15 +393,14 @@ func (node *deploymentNode) update(upgradeStatus *api.ElasticsearchNodeStatus) e
 	if upgradeStatus.UpgradeStatus.UpgradePhase == "" ||
 		upgradeStatus.UpgradeStatus.UpgradePhase == api.ControllerUpdated {
 
-		if ok, err := DoSynchronizedFlush(node.clusterName, node.self.Namespace); !ok {
-			logrus.Warnf("Unable to perform synchronized flush: %v", err)
-			return err
-		}
-
 		// disable shard allocation
 		if ok, err := SetShardAllocation(node.clusterName, node.self.Namespace, api.ShardAllocationNone); !ok {
 			logrus.Warnf("Unable to disable shard allocation: %v", err)
 			return err
+		}
+
+		if ok, err := DoSynchronizedFlush(node.clusterName, node.self.Namespace); !ok {
+			logrus.Warnf("Unable to perform synchronized flush: %v", err)
 		}
 
 		if err := node.executeUpdate(); err != nil {

--- a/pkg/k8shandler/elasticsearch.go
+++ b/pkg/k8shandler/elasticsearch.go
@@ -357,7 +357,6 @@ func GetClusterNodeCount(clusterName, namespace string) (int32, error) {
 	return nodeCount, payload.Error
 }
 
-// TODO: also check that the number of shards in the response > 0?
 func DoSynchronizedFlush(clusterName, namespace string) (bool, error) {
 
 	payload := &esCurlStruct{
@@ -366,6 +365,17 @@ func DoSynchronizedFlush(clusterName, namespace string) (bool, error) {
 	}
 
 	curlESService(clusterName, namespace, payload)
+
+	failed := 0
+	if shards, ok := payload.ResponseBody["_shards"].(map[string]interface{}); ok {
+		if failedFload, ok := shards["failed"].(float64); ok {
+			failed = int(failedFload)
+		}
+	}
+
+	if payload.Error == nil && failed != 0 {
+		payload.Error = fmt.Errorf("Failed to flush %d shards in preparation for cluster restart", failed)
+	}
 
 	return (payload.StatusCode == 200), payload.Error
 }


### PR DESCRIPTION
Print out better message that informs users about how many data
shards in to be flushed.

Make sure restart steps follow official documentation:
https://www.elastic.co/guide/en/elasticsearch/reference/5.6/rolling-upgrades.html