### PR TITLE
Set Resources on the proxy container

### DIFF
--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -213,6 +213,17 @@ func newProxyContainer(imageName, clusterName string) (v1.Container, error) {
 	if err != nil {
 		return v1.Container{}, err
 	}
+
+	cpuLimit, err := resource.ParseQuantity("100m")
+	if err != nil {
+		return v1.Container{}, err
+	}
+
+	memoryLimit, err := resource.ParseQuantity("64Mi")
+	if err != nil {
+		return v1.Container{}, err
+	}
+
 	container := v1.Container{
 		Name:            "proxy",
 		Image:           imageName,
@@ -246,6 +257,15 @@ func newProxyContainer(imageName, clusterName string) (v1.Container, error) {
 			`-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}`,
 			"--pass-user-bearer-token",
 			fmt.Sprintf("--cookie-secret=%s", proxyCookieSecret),
+		},
+		Resources: v1.ResourceRequirements{
+			Limits: v1.ResourceList{
+				"memory": memoryLimit,
+			},
+			Requests: v1.ResourceList{
+				"cpu":    cpuLimit,
+				"memory": memoryLimit,
+			},
 		},
 	}
 	return container, nil

--- a/pkg/k8shandler/common_test.go
+++ b/pkg/k8shandler/common_test.go
@@ -373,6 +373,45 @@ func TestPodSpecHasTaintTolerations(t *testing.T) {
 	}
 }
 
+func TestProxyContainerResourcesDefined(t *testing.T) {
+
+	imageName := "openshift/oauth-proxy:1.1"
+	clusterName := "elasticsearch"
+
+	expectedCPU, _ := resource.ParseQuantity("100m")
+	expectedMemory, _ := resource.ParseQuantity("64Mi")
+
+	proxyContainer, err := newProxyContainer(imageName, clusterName)
+	if err != nil {
+		t.Errorf("Failed to populate Proxy container: %v", err)
+	}
+
+	if memoryLimit, ok := proxyContainer.Resources.Limits["memory"]; ok {
+		if memoryLimit.Cmp(expectedMemory) != 0 {
+			t.Errorf("Expected CPU limit %s but got %s", expectedMemory.String(), memoryLimit.String())
+		}
+	} else {
+		t.Errorf("Proxy container is missing CPU limit. Expected limit %s", expectedMemory.String())
+	}
+
+	if cpuRequest, ok := proxyContainer.Resources.Requests["cpu"]; ok {
+		if cpuRequest.Cmp(expectedCPU) != 0 {
+			t.Errorf("Expected CPU request %s but got %s", expectedCPU.String(), cpuRequest.String())
+		}
+	} else {
+		t.Errorf("Proxy container is missing CPU request. Expected request %s", expectedCPU.String())
+	}
+
+	if memoryLimit, ok := proxyContainer.Resources.Limits["memory"]; ok {
+		if memoryLimit.Cmp(expectedMemory) != 0 {
+			t.Errorf("Expected memory limit %s but got %s", expectedMemory.String(), memoryLimit.String())
+		}
+	} else {
+		t.Errorf("Proxy container is missing memory limit. Expected limit %s", expectedMemory.String())
+	}
+
+}
+
 func buildResource(cpuLimit, cpuRequest, memLimit, memRequest resource.Quantity) v1.ResourceRequirements {
 	return v1.ResourceRequirements{
 		Limits: v1.ResourceList{


### PR DESCRIPTION
Oauth proxy container should have resources limits and requests.

We give 64 MB of RAM and 100 milli of CPU
https://github.com/openshift/openshift-ansible/blob/release-3.11/roles/openshift_logging_elasticsearch/defaults/main.yml#L43-L44