### PR TITLE
fixing required deployment env var in manifest

### DIFF
--- a/controller-manifests/elasticsearch-operator.v4.1.0.clusterserviceversion.yaml
+++ b/controller-manifests/elasticsearch-operator.v4.1.0.clusterserviceversion.yaml
@@ -182,6 +182,10 @@ spec:
                       valueFrom:
                         fieldRef:
                           fieldPath: metadata.annotations['olm.targetNamespaces']
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
                     - name: OPERATOR_NAME
                       value: "elasticsearch-operator"
                     - name: PROXY_IMAGE


### PR DESCRIPTION
This env var is required be made available with the latest SDK, CI didn't catch this because we are deploying from artifacts in `manifests` instead of `controller-manifests` like we do for clo.