### PR TITLE
Bug 1707465: Adding disk-pressure toleration for elasticsearch

### DIFF
--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -357,6 +357,13 @@ func newPodTemplateSpec(nodeName, clusterName, namespace string, node api.Elasti
 			NodeSelector:       mergeSelectors(node.NodeSelector, commonSpec.NodeSelector),
 			ServiceAccountName: clusterName,
 			Volumes:            newVolumes(clusterName, nodeName, namespace, node),
+			Tolerations: []v1.Toleration{
+				v1.Toleration{
+					Key:      "node.kubernetes.io/disk-pressure",
+					Operator: v1.TolerationOpExists,
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
 		},
 	}
 }

--- a/pkg/k8shandler/common_test.go
+++ b/pkg/k8shandler/common_test.go
@@ -1,10 +1,13 @@
 package k8shandler
 
 import (
+	"reflect"
 	"testing"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	api "github.com/openshift/elasticsearch-operator/pkg/apis/elasticsearch/v1"
 )
 
 var (
@@ -350,6 +353,23 @@ func TestResourcesCommonResourceAndNodeLimitDefined(t *testing.T) {
 
 	if !areResourcesSame(actual, expected) {
 		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+func TestPodSpecHasTaintTolerations(t *testing.T) {
+
+	expectedTolerations := []v1.Toleration{
+		v1.Toleration{
+			Key:      "node.kubernetes.io/disk-pressure",
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		},
+	}
+
+	podTemplateSpec := newPodTemplateSpec("test-node-name", "test-cluster-name", "test-namespace-name", api.ElasticsearchNode{}, api.ElasticsearchNodeSpec{}, map[string]string{}, map[api.ElasticsearchNodeRole]bool{})
+
+	if !reflect.DeepEqual(podTemplateSpec.Spec.Tolerations, expectedTolerations) {
+		t.Errorf("Exp. the tolerations to be %q but was %q", expectedTolerations, podTemplateSpec.Spec.Tolerations)
 	}
 }
 


### PR DESCRIPTION
To address elasticsearch not being scheduled to nodes where fluentd may have left buffer files causing disk-pressure, allow elasticsearch to be scheduled on nodes where that taint has been applied so it can be available for fluentd to attempt to clear its buffer files.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1707465