### PR TITLE
use absolute paths for COPY commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ ENV ALERTS_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_alerts.yml"
 ENV RULES_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_rules.yml"
 
 COPY --from=builder /go/src/github.com/openshift/elasticsearch-operator/_output/bin/elasticsearch-operator /usr/bin/
-COPY --from=builder files/ /etc/elasticsearch-operator/files/
-COPY --from=builder manifests/$CSV /manifests/$CSV
-COPY --from=builder manifests/elasticsearch-operator.package.yaml /manifests/
+COPY --from=builder /go/src/github.com/openshift/elasticsearch-operator/files/ /etc/elasticsearch-operator/files/
+COPY --from=builder /go/src/github.com/openshift/elasticsearch-operator/manifests/$CSV /manifests/$CSV
+COPY --from=builder /go/src/github.com/openshift/elasticsearch-operator/manifests/elasticsearch-operator.package.yaml /manifests/
 
 WORKDIR /usr/bin
 ENTRYPOINT ["elasticsearch-operator"]

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -10,9 +10,9 @@ ENV ALERTS_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_alerts.yml"
 ENV RULES_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_rules.yml"
 
 COPY --from=builder /go/src/github.com/openshift/elasticsearch-operator/_output/bin/elasticsearch-operator /usr/bin/
-COPY --from=builder files/ /etc/elasticsearch-operator/files/
-COPY --from=builder manifests/$CSV /manifests/$CSV
-COPY --from=builder manifests/elasticsearch-operator.package.yaml /manifests/
+COPY --from=builder /go/src/github.com/openshift/elasticsearch-operator/files/ /etc/elasticsearch-operator/files/
+COPY --from=builder /go/src/github.com/openshift/elasticsearch-operator/manifests/$CSV /manifests/$CSV
+COPY --from=builder /go/src/github.com/openshift/elasticsearch-operator/manifests/elasticsearch-operator.package.yaml /manifests/
 
 WORKDIR /usr/bin
 ENTRYPOINT ["elasticsearch-operator"]


### PR DESCRIPTION
while imagebuilder allowed this, docker+buildah do not seem to recognize the WORKDIR as a context for the `COPY --from` so it fails.
