### PR TITLE
Bug 1707875 - Remove nodes that arent in CR

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -144,10 +144,10 @@
   version = "v0.19.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  revision = "53d776530bf78a11b03a7b52dd8a083086b045e5"
-  version = "v0.19.0"
+  revision = "b2056d62a953adee01fed8ee65a046bd8f0419d5"
 
 [[projects]]
   name = "github.com/go-openapi/swag"

--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -283,25 +283,45 @@ func (elasticsearchRequest *ElasticsearchRequest) getNodes() {
 	}
 
 	cluster := elasticsearchRequest.cluster
+	currentNodes := []NodeTypeInterface{}
 
 	// get list of client only nodes, and collapse node info into the node (self field) if needed
 	for _, node := range cluster.Spec.Nodes {
-
-		// TODO: collect UUIDs processed -- compare them against ones in status
-		//  check if someone updated a UUID of an already created node?
 
 		// build the NodeTypeInterface list
 		for _, nodeTypeInterface := range elasticsearchRequest.GetNodeTypeInterface(*node.GenUUID, node) {
 
 			nodeIndex, ok := containsNodeTypeInterface(nodeTypeInterface, nodes[nodeMapKey(cluster.Name, cluster.Namespace)])
 			if !ok {
-				nodes[nodeMapKey(cluster.Name, cluster.Namespace)] = append(nodes[nodeMapKey(cluster.Name, cluster.Namespace)], nodeTypeInterface)
+				currentNodes = append(currentNodes, nodeTypeInterface)
 			} else {
 				nodes[nodeMapKey(cluster.Name, cluster.Namespace)][nodeIndex].updateReference(nodeTypeInterface)
+				currentNodes = append(currentNodes, nodes[nodeMapKey(cluster.Name, cluster.Namespace)][nodeIndex])
 			}
 
 		}
 	}
+
+	minMasterUpdated := false
+
+	// we want to only keep nodes that were generated and purge/delete any other ones...
+	for _, node := range nodes[nodeMapKey(cluster.Name, cluster.Namespace)] {
+		if _, ok := containsNodeTypeInterface(node, currentNodes); !ok {
+			if !minMasterUpdated {
+				// if we're removing a node make sure we set a lower min masters to keep cluster functional
+				elasticsearchRequest.updateMinMasters()
+				minMasterUpdated = true
+			}
+			node.delete()
+
+			// remove from status.Nodes
+			if index, _ := getNodeStatus(node.name(), &cluster.Status); index != NOT_FOUND_INDEX {
+				cluster.Status.Nodes = append(cluster.Status.Nodes[:index], cluster.Status.Nodes[index+1:]...)
+			}
+		}
+	}
+
+	nodes[nodeMapKey(cluster.Name, cluster.Namespace)] = currentNodes
 }
 
 func getScheduledUpgradeNodes(cluster *api.Elasticsearch) []NodeTypeInterface {

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -112,6 +112,10 @@ func (node *deploymentNode) state() api.ElasticsearchNodeStatus {
 	}
 }
 
+func (node *deploymentNode) delete() {
+	node.client.Delete(context.TODO(), &node.self)
+}
+
 func (node *deploymentNode) create() error {
 
 	if node.self.ObjectMeta.ResourceVersion == "" {

--- a/pkg/k8shandler/nodetypefactory.go
+++ b/pkg/k8shandler/nodetypefactory.go
@@ -18,6 +18,7 @@ type NodeTypeInterface interface {
 	progressUnshedulableNode(upgradeStatus *api.ElasticsearchNodeStatus) error
 	name() string
 	updateReference(node NodeTypeInterface)
+	delete()
 }
 
 // NodeTypeFactory is a factory to construct either statefulset or deployment

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -303,6 +303,10 @@ func (node *statefulSetNode) restart(upgradeStatus *api.ElasticsearchNodeStatus)
 	}
 }
 
+func (node *statefulSetNode) delete() {
+	node.client.Delete(context.TODO(), &node.self)
+}
+
 func (node *statefulSetNode) create() error {
 
 	if node.self.ObjectMeta.ResourceVersion == "" {

--- a/pkg/k8shandler/util.go
+++ b/pkg/k8shandler/util.go
@@ -111,11 +111,21 @@ func getClientCount(dpl *api.Elasticsearch) int32 {
 }
 
 func isValidMasterCount(dpl *api.Elasticsearch) bool {
+
+	if len(dpl.Spec.Nodes) == 0 {
+		return true
+	}
+
 	masterCount := int(getMasterCount(dpl))
 	return (masterCount <= maxMasterCount && masterCount > 0)
 }
 
 func isValidDataCount(dpl *api.Elasticsearch) bool {
+
+	if len(dpl.Spec.Nodes) == 0 {
+		return true
+	}
+
 	dataCount := int(getDataCount(dpl))
 	return dataCount > 0
 }
@@ -151,6 +161,7 @@ func (elasticsearchRequest *ElasticsearchRequest) isValidConf() error {
 			return err
 		}
 	}
+
 	if !isValidDataCount(dpl) {
 		if err := updateConditionWithRetry(dpl, v1.ConditionTrue, updateInvalidDataCountCondition, client); err != nil {
 			return err
@@ -161,6 +172,7 @@ func (elasticsearchRequest *ElasticsearchRequest) isValidConf() error {
 			return err
 		}
 	}
+
 	if !isValidRedundancyPolicy(dpl) {
 		if err := updateConditionWithRetry(dpl, v1.ConditionTrue, updateInvalidReplicationCondition, client); err != nil {
 			return err

--- a/pkg/k8shandler/util_test.go
+++ b/pkg/k8shandler/util_test.go
@@ -153,6 +153,37 @@ func TestInvalidRedundancyPolicySpecified(t *testing.T) {
 
 }
 
+func TestValidNoNodesSpecified(t *testing.T) {
+
+	esCR := &api.Elasticsearch{
+		Spec: api.ElasticsearchSpec{
+			Nodes: []api.ElasticsearchNode{},
+		},
+	}
+
+	isValid := isValidMasterCount(esCR)
+
+	if !isValid {
+		t.Error("Expected no nodes defined to be flagged as valid, was found to be invalid master count")
+	}
+
+	isValid = isValidDataCount(esCR)
+
+	if !isValid {
+		t.Error("Expected no nodes defined to be flagged as valid, was found to be invalid data count")
+	}
+
+	isValid = isValidRedundancyPolicy(esCR)
+
+	if !isValid {
+		t.Error("Expected no nodes defined to be flagged as valid, was found to be invalid redundancy policy")
+	}
+
+	if ok, msg := hasValidUUIDs(esCR); !ok {
+		t.Errorf("Expected no nodes defined to be flagged as valid, was found to be invalid UUIDs: %v", msg)
+	}
+}
+
 func TestValidReplicaCount(t *testing.T) {
 
 	dataNodeCount := 5

--- a/vendor/github.com/go-openapi/spec/items.go
+++ b/vendor/github.com/go-openapi/spec/items.go
@@ -29,6 +29,7 @@ const (
 // SimpleSchema describe swagger simple schemas for parameters and headers
 type SimpleSchema struct {
 	Type             string      `json:"type,omitempty"`
+	Nullable         bool        `json:"nullable,omitempty"`
 	Format           string      `json:"format,omitempty"`
 	Items            *Items      `json:"items,omitempty"`
 	CollectionFormat string      `json:"collectionFormat,omitempty"`
@@ -88,6 +89,12 @@ func NewItems() *Items {
 func (i *Items) Typed(tpe, format string) *Items {
 	i.Type = tpe
 	i.Format = format
+	return i
+}
+
+// AsNullable flags this schema as nullable.
+func (i *Items) AsNullable() *Items {
+	i.Nullable = true
 	return i
 }
 

--- a/vendor/github.com/go-openapi/spec/schema.go
+++ b/vendor/github.com/go-openapi/spec/schema.go
@@ -163,6 +163,7 @@ type SchemaProps struct {
 	Schema               SchemaURL         `json:"-"`
 	Description          string            `json:"description,omitempty"`
 	Type                 StringOrArray     `json:"type,omitempty"`
+	Nullable             bool              `json:"nullable,omitempty"`
 	Format               string            `json:"format,omitempty"`
 	Title                string            `json:"title,omitempty"`
 	Default              interface{}       `json:"default,omitempty"`
@@ -299,6 +300,12 @@ func (s *Schema) AddType(tpe, format string) *Schema {
 	if format != "" {
 		s.Format = format
 	}
+	return s
+}
+
+// AsNullable flags this schema as nullable.
+func (s *Schema) AsNullable() *Schema {
+	s.Nullable = true
 	return s
 }
 


### PR DESCRIPTION
If a node has been removed from `spec.nodes` we want to no longer manage it and delete it accordingly.

NOTE: currently, when removing a node that has been established already, the operator will flag that a previously used UUID is no longer available and will mark this as an invalid config. You will also need to remove it from status.nodes as well.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1707875
ref: https://bugzilla.redhat.com/show_bug.cgi?id=1711044