### PR TITLE
allow logging CI to use make deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ IMAGE_BUILD=$(IMAGE_BUILDER)
 export IMAGE_TAGGER?=docker tag
 
 export APP_NAME=elasticsearch-operator
-export IMAGE_TAG=quay.io/openshift/origin-$(APP_NAME):latest
+IMAGE_TAG?=quay.io/openshift/origin-$(APP_NAME):latest
+export IMAGE_TAG
 APP_REPO=github.com/openshift/$(APP_NAME)
 TARGET=$(TARGET_DIR)/bin/$(APP_NAME)
 KUBECONFIG?=$(HOME)/.kube/config

--- a/hack/deploy-setup.sh
+++ b/hack/deploy-setup.sh
@@ -39,13 +39,6 @@ load_manifest() {
 
 load_manifest ${repo_dir} ${NAMESPACE}
 
-#hack openshift-monitoring
-pushd vendor/github.com/coreos/prometheus-operator/example/prometheus-operator-crd
-  for file in prometheusrule.crd.yaml servicemonitor.crd.yaml; do
-    oc create -n ${NAMESPACE} -f ${file} ||:
-  done
-popd
-
 oc create -f hack/prometheus-operator-crd-cluster-roles.yaml ||:
 
 oc create clusterrolebinding elasticsearch-operator-prometheus-rolebinding \

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -7,8 +7,17 @@ source "$(dirname $0)/common"
 if [ $REMOTE_REGISTRY = false ] ; then
     oc create -n ${NAMESPACE} -f manifests/05-deployment.yaml
 else
+    if [ -n "${IMAGE_OVERRIDE:-}" ] ; then
+        replace_image() {
+            sed -e "s, image:.*\$, image: ${IMAGE_OVERRIDE},"
+        }
+    else
+        replace_image() {
+            sed -e "s,${IMAGE_TAG},${registry_host}:5000/${image_tag},"
+        }
+    fi
     image_tag=$( echo "$IMAGE_TAG" | sed -e 's,quay.io/,,' )
     cat manifests/05-deployment.yaml | \
-        sed -e "s,${IMAGE_TAG},${registry_host}:5000/${image_tag}," | \
+        replace_image | \
 	    oc create -n ${NAMESPACE} -f -
 fi


### PR DESCRIPTION
Some minor fixes to allow oal logging CI to use
`make deploy`.  Use `IMAGE_OVERRIDE` to specify the exact
image to use.