### PR TITLE
Rename go-run target to run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ deploy-setup:
 	EXCLUSIONS="05-deployment.yaml image-references" hack/deploy-setup.sh
 .PHONY: deploy-setup
 
-go-run: deploy deploy-example
+run: deploy deploy-example
 	@ALERTS_FILE_PATH=files/prometheus_alerts.yml \
 	RULES_FILE_PATH=files/prometheus_rules.yml \
 	OPERATOR_NAME=elasticsearch-operator WATCH_NAMESPACE=openshift-logging \

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Deploy an example custom resource for a single node Elasticsearch cluster
 #### deploy-undeploy
 Remove all deployed resources
 
-#### go-run
+#### run
 Deploy the example cluster and start running the operator.  The end result is that there will be an
 `elasticsearch` custom resource, and an elasticsearch pod running.  You can view the operator log by
 looking at the log file specified by `$(RUN_LOG)` (default `elasticsearch-operator.log`).  The command
@@ -214,7 +214,7 @@ ELASTICSEARCH_OPERATOR=$GOPATH/src/github.com/openshift/elasticsearch-operator
 
 To test on an OKD cluster, you can run:
 
-    make go-run
+    make run
 
 To remove created API objects:
 ```


### PR DESCRIPTION
This is to stick to same naming conventions as in Cluster Logging Operator Makefile.

See [openshift/cluster-logging-operator/Makefile](https://github.com/openshift/cluster-logging-operator/blob/62fe437dabf602ca6a3cea7b8f3119e4c08672ec/Makefile#L65).