### PR TITLE
Bug 1718731:  elasticsearch operator fails to install due to missing specDescriptor

### DIFF
--- a/manifests/4.1/elasticsearch-operator.v4.1.0.clusterserviceversion.yaml
+++ b/manifests/4.1/elasticsearch-operator.v4.1.0.clusterserviceversion.yaml
@@ -3,7 +3,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: elasticsearch-operator.v4.1.0
+  name: elasticsearch-operator.v4.1.1
   namespace: placeholder
   annotations:
     categories: "OpenShift Optional, Logging & Tracing"
@@ -22,6 +22,7 @@ metadata:
     containerImage: quay.io/openshift/origin-elasticsearch-operator:latest
     createdAt: 2019-02-20T08:00:00Z
     support: AOS Cluster Logging, Jaeger
+    olm.skipRange: ">=4.1.0 <4.1.1"
     alm-examples: |-
         [
             {
@@ -188,7 +189,7 @@ spec:
                       value: "quay.io/openshift/origin-oauth-proxy:latest"
                     - name: ELASTICSEARCH_IMAGE
                       value: "quay.io/openshift/origin-logging-elasticsearch5:latest"
-  version: 4.1.0
+  version: 4.1.1
   customresourcedefinitions:
     owned:
     - name: elasticsearches.logging.openshift.io

--- a/manifests/4.1/elasticsearch-operator.v4.1.0.clusterserviceversion.yaml
+++ b/manifests/4.1/elasticsearch-operator.v4.1.0.clusterserviceversion.yaml
@@ -3,7 +3,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: elasticsearch-operator.v4.1.1
+  name: elasticsearch-operator.v4.1.0
   namespace: placeholder
   annotations:
     categories: "OpenShift Optional, Logging & Tracing"
@@ -22,7 +22,6 @@ metadata:
     containerImage: quay.io/openshift/origin-elasticsearch-operator:latest
     createdAt: 2019-02-20T08:00:00Z
     support: AOS Cluster Logging, Jaeger
-    olm.skipRange: ">=4.1.0 <4.1.1"
     alm-examples: |-
         [
             {
@@ -34,6 +33,7 @@ metadata:
                 "spec": {
                   "managementState": "Managed",
                   "nodeSpec": {
+                    "image": "quay.io/openshift/origin-logging-elasticsearch5:latest",
                     "resources": {
                       "limits": {
                         "memory": "1Gi"
@@ -188,7 +188,7 @@ spec:
                       value: "quay.io/openshift/origin-oauth-proxy:latest"
                     - name: ELASTICSEARCH_IMAGE
                       value: "quay.io/openshift/origin-logging-elasticsearch5:latest"
-  version: 4.1.1
+  version: 4.1.0
   customresourcedefinitions:
     owned:
     - name: elasticsearches.logging.openshift.io
@@ -212,25 +212,32 @@ spec:
       - kind: Route
         version: v1
       specDescriptors:
+      - description: The name of the serviceaccount used by the Elasticsearch pods
+        displayName: Service Account
+        path: serviceAccountName
+        x-descriptors:
+          - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+      - description: The name of the configmap used by the Elasticsearch pods
+        displayName: Config Map
+        path: configMapName
+        x-descriptors:
+          - 'urn:alm:descriptor:io.kubernetes:ConfigMap'
+      - description: The name of the secret used by the Elasticsearch pods
+        displayName: Secret
+        path: secretName
+        x-descriptors:
+          - 'urn:alm:descriptor:io.kubernetes:Secret'
       - description: Limits describes the minimum/maximum amount of compute resources required/allowed
         displayName: Resource Requirements
         path: nodeSpec.resources
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
-      - description:
-        displayName: Elasticsearch Image
-        path: nodeSpec.image
-      - description:
-        displayName: Elasticsearch NodeSelector
-        path: nodeSpec.nodeSelector
-        x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:selector'
       statusDescriptors:
       - description: The current health of Elasticsearch Cluster
         displayName: Elasticsearch Cluster Health
         path: clusterHealth
         x-descriptors:
-          - 'urn:alm:descriptor:text'
+          - 'urn:alm:descriptor:io.kubernetes.phase'
       - description: The status for each of the Elasticsearch pods with the Client role
         displayName: Elasticsearch Client Status
         path: pods.client
@@ -246,8 +253,3 @@ spec:
         path: pods.master
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
-      - description: The conditions for the Elasticsearch CR
-        displayName: Elasticsearch Conditions
-        path: conditions
-        x-descriptors:
-        - 'urn:alm:descriptor:io.kubernetes.conditions'

--- a/manifests/elasticsearch-operator.package.yaml
+++ b/manifests/elasticsearch-operator.package.yaml
@@ -2,4 +2,4 @@
 packageName: elasticsearch-operator
 channels:
 - name: preview
-  currentCSV: elasticsearch-operator.v4.1.1
+  currentCSV: elasticsearch-operator.v4.1.0

--- a/manifests/elasticsearch-operator.package.yaml
+++ b/manifests/elasticsearch-operator.package.yaml
@@ -2,4 +2,4 @@
 packageName: elasticsearch-operator
 channels:
 - name: preview
-  currentCSV: elasticsearch-operator.v4.1.0
+  currentCSV: elasticsearch-operator.v4.1.1


### PR DESCRIPTION
This PR fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1718731 by reverting #151 