### PR TITLE
bug 1717627. bump crv to 4.1.2

### DIFF
--- a/manifests/4.1/elasticsearch-operator.v4.1.0.clusterserviceversion.yaml
+++ b/manifests/4.1/elasticsearch-operator.v4.1.0.clusterserviceversion.yaml
@@ -3,7 +3,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: elasticsearch-operator.v4.1.1
+  name: elasticsearch-operator.v4.1.2
   namespace: placeholder
   annotations:
     categories: "OpenShift Optional, Logging & Tracing"
@@ -22,7 +22,7 @@ metadata:
     containerImage: quay.io/openshift/origin-elasticsearch-operator:latest
     createdAt: 2019-02-20T08:00:00Z
     support: AOS Cluster Logging, Jaeger
-    olm.skipRange: ">=4.1.0 <4.1.1"
+    olm.skipRange: ">=4.1.0 <4.1.2"
     alm-examples: |-
         [
             {
@@ -189,7 +189,7 @@ spec:
                       value: "quay.io/openshift/origin-oauth-proxy:latest"
                     - name: ELASTICSEARCH_IMAGE
                       value: "quay.io/openshift/origin-logging-elasticsearch5:latest"
-  version: 4.1.1
+  version: 4.1.2
   customresourcedefinitions:
     owned:
     - name: elasticsearches.logging.openshift.io

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -1,0 +1,14 @@
+updates:
+  - file: "{MAJOR}.{MINOR}/elasticsearch-operator.v{MAJOR}.{MINOR}.0.clusterserviceversion.yaml" # relative to this file
+    update_list:
+    # replace metadata.name value
+    - search: "elasticsearch-operator.v{MAJOR}.{MINOR}.2"
+      replace: "elasticsearch-operator.{FULL_VER}"
+    # replace entire version line, otherwise would replace 4.1.0 anywhere
+    - search: "version: 4.1.2"
+      replace: "version: {FULL_VER}"
+  - file: "package.yaml"
+    update_list:
+    - search: "currentCSV: elasticsearch-operator.v{MAJOR}.{MINOR}.2"
+      replace: "currentCSV: elasticsearch-operator.{FULL_VER}"
+

--- a/manifests/elasticsearch-operator.package.yaml
+++ b/manifests/elasticsearch-operator.package.yaml
@@ -2,4 +2,4 @@
 packageName: elasticsearch-operator
 channels:
 - name: preview
-  currentCSV: elasticsearch-operator.v4.1.1
+  currentCSV: elasticsearch-operator.v4.1.2


### PR DESCRIPTION
This PR bumps CRV to 4.1.2 and adds art.yml file for future automation