### PR TITLE
[release-4.1] Bug 1711044: Remove nodes that arent in CR

### DIFF
--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -277,24 +277,45 @@ func getNodes(cluster *api.Elasticsearch) {
 		nodes = make(map[string][]NodeTypeInterface)
 	}
 
+	currentNodes := []NodeTypeInterface{}
+
 	// get list of client only nodes, and collapse node info into the node (self field) if needed
 	for _, node := range cluster.Spec.Nodes {
-
-		// TODO: collect UUIDs processed -- compare them against ones in status
-		//  check if someone updated a UUID of an already created node?
 
 		// build the NodeTypeInterface list
 		for _, nodeTypeInterface := range GetNodeTypeInterface(*node.GenUUID, node, cluster) {
 
 			nodeIndex, ok := containsNodeTypeInterface(nodeTypeInterface, nodes[nodeMapKey(cluster.Name, cluster.Namespace)])
 			if !ok {
-				nodes[nodeMapKey(cluster.Name, cluster.Namespace)] = append(nodes[nodeMapKey(cluster.Name, cluster.Namespace)], nodeTypeInterface)
+				currentNodes = append(currentNodes, nodeTypeInterface)
 			} else {
 				nodes[nodeMapKey(cluster.Name, cluster.Namespace)][nodeIndex].updateReference(nodeTypeInterface)
+				currentNodes = append(currentNodes, nodes[nodeMapKey(cluster.Name, cluster.Namespace)][nodeIndex])
 			}
 
 		}
 	}
+
+	minMasterUpdated := false
+
+	// we want to only keep nodes that were generated and purge/delete any other ones...
+	for _, node := range nodes[nodeMapKey(cluster.Name, cluster.Namespace)] {
+		if _, ok := containsNodeTypeInterface(node, currentNodes); !ok {
+			if !minMasterUpdated {
+				// if we're removing a node make sure we set a lower min masters to keep cluster functional
+				updateMinMasters(cluster)
+				minMasterUpdated = true
+			}
+			node.delete()
+
+			// remove from status.Nodes
+			if index, _ := getNodeStatus(node.name(), &cluster.Status); index != NOT_FOUND_INDEX {
+				cluster.Status.Nodes = append(cluster.Status.Nodes[:index], cluster.Status.Nodes[index+1:]...)
+			}
+		}
+	}
+
+	nodes[nodeMapKey(cluster.Name, cluster.Namespace)] = currentNodes
 }
 
 func getScheduledUpgradeNodes(cluster *api.Elasticsearch) []NodeTypeInterface {

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -106,6 +106,10 @@ func (node *deploymentNode) state() api.ElasticsearchNodeStatus {
 	}
 }
 
+func (node *deploymentNode) delete() {
+	sdk.Delete(&node.self)
+}
+
 func (node *deploymentNode) create() error {
 
 	if node.self.ObjectMeta.ResourceVersion == "" {

--- a/pkg/k8shandler/nodetypefactory.go
+++ b/pkg/k8shandler/nodetypefactory.go
@@ -16,6 +16,7 @@ type NodeTypeInterface interface {
 	progressUnshedulableNode(upgradeStatus *api.ElasticsearchNodeStatus) error
 	name() string
 	updateReference(node NodeTypeInterface)
+	delete()
 }
 
 // NodeTypeFactory is a factory to construct either statefulset or deployment

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -297,6 +297,10 @@ func (node *statefulSetNode) restart(upgradeStatus *api.ElasticsearchNodeStatus)
 	}
 }
 
+func (node *statefulSetNode) delete() {
+	sdk.Delete(&node.self)
+}
+
 func (node *statefulSetNode) create() error {
 
 	if node.self.ObjectMeta.ResourceVersion == "" {

--- a/pkg/k8shandler/util.go
+++ b/pkg/k8shandler/util.go
@@ -109,11 +109,21 @@ func getClientCount(dpl *api.Elasticsearch) int32 {
 }
 
 func isValidMasterCount(dpl *api.Elasticsearch) bool {
+
+	if len(dpl.Spec.Nodes) == 0 {
+		return true
+	}
+
 	masterCount := int(getMasterCount(dpl))
 	return (masterCount <= maxMasterCount && masterCount > 0)
 }
 
 func isValidDataCount(dpl *api.Elasticsearch) bool {
+
+	if len(dpl.Spec.Nodes) == 0 {
+		return true
+	}
+
 	dataCount := int(getDataCount(dpl))
 	return dataCount > 0
 }
@@ -145,6 +155,7 @@ func isValidConf(dpl *api.Elasticsearch) error {
 			return err
 		}
 	}
+
 	if !isValidDataCount(dpl) {
 		if err := updateConditionWithRetry(dpl, v1.ConditionTrue, updateInvalidDataCountCondition); err != nil {
 			return err
@@ -155,6 +166,7 @@ func isValidConf(dpl *api.Elasticsearch) error {
 			return err
 		}
 	}
+
 	if !isValidRedundancyPolicy(dpl) {
 		if err := updateConditionWithRetry(dpl, v1.ConditionTrue, updateInvalidReplicationCondition); err != nil {
 			return err

--- a/pkg/k8shandler/util_test.go
+++ b/pkg/k8shandler/util_test.go
@@ -153,6 +153,37 @@ func TestInvalidRedundancyPolicySpecified(t *testing.T) {
 
 }
 
+func TestValidNoNodesSpecified(t *testing.T) {
+
+	esCR := &api.Elasticsearch{
+		Spec: api.ElasticsearchSpec{
+			Nodes: []api.ElasticsearchNode{},
+		},
+	}
+
+	isValid := isValidMasterCount(esCR)
+
+	if !isValid {
+		t.Error("Expected no nodes defined to be flagged as valid, was found to be invalid master count")
+	}
+
+	isValid = isValidDataCount(esCR)
+
+	if !isValid {
+		t.Error("Expected no nodes defined to be flagged as valid, was found to be invalid data count")
+	}
+
+	isValid = isValidRedundancyPolicy(esCR)
+
+	if !isValid {
+		t.Error("Expected no nodes defined to be flagged as valid, was found to be invalid redundancy policy")
+	}
+
+	if ok, msg := hasValidUUIDs(esCR); !ok {
+		t.Errorf("Expected no nodes defined to be flagged as valid, was found to be invalid UUIDs: %v", msg)
+	}
+}
+
 func TestValidReplicaCount(t *testing.T) {
 
 	dataNodeCount := 5


### PR DESCRIPTION
Cherry pick of #144

If a node has been removed from spec.nodes we want to no longer manage it and delete it accordingly.

Replaces https://github.com/openshift/elasticsearch-operator/pull/149

NOTE: currently, when removing a node that has been established already, the operator will flag that a previously used UUID is no longer available and will mark this as an invalid config. You will also need to remove it from status.nodes as well.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1707875
ref: https://bugzilla.redhat.com/show_bug.cgi?id=1711044