### PR TITLE
bug 1724833: clean up 4.1 channel manifests

### DIFF
--- a/manifests/4.1/elasticsearch-operator.v4.1.0.clusterserviceversion.yaml
+++ b/manifests/4.1/elasticsearch-operator.v4.1.0.clusterserviceversion.yaml
@@ -3,7 +3,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: elasticsearch-operator.v4.1.2
+  name: elasticsearch-operator.v4.1.0
   namespace: placeholder
   annotations:
     categories: "OpenShift Optional, Logging & Tracing"
@@ -22,7 +22,7 @@ metadata:
     containerImage: quay.io/openshift/origin-elasticsearch-operator:latest
     createdAt: 2019-02-20T08:00:00Z
     support: AOS Cluster Logging, Jaeger
-    olm.skipRange: ">=4.1.0 <4.1.2"
+    olm.skipRange: ">=4.1.0 <4.1.0"
     alm-examples: |-
         [
             {
@@ -55,6 +55,7 @@ metadata:
             }
         ]
 spec:
+  version: 4.1.0
   displayName: Elasticsearch Operator
 
   description: |
@@ -189,7 +190,6 @@ spec:
                       value: "quay.io/openshift/origin-oauth-proxy:latest"
                     - name: ELASTICSEARCH_IMAGE
                       value: "quay.io/openshift/origin-logging-elasticsearch5:latest"
-  version: 4.1.2
   customresourcedefinitions:
     owned:
     - name: elasticsearches.logging.openshift.io

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -2,15 +2,15 @@ updates:
   - file: "{MAJOR}.{MINOR}/elasticsearch-operator.v{MAJOR}.{MINOR}.0.clusterserviceversion.yaml" # relative to this file
     update_list:
     # replace metadata.name value
-    - search: "elasticsearch-operator.v{MAJOR}.{MINOR}.2"
+    - search: "elasticsearch-operator.v{MAJOR}.{MINOR}.0"
       replace: "elasticsearch-operator.{FULL_VER}"
-    # replace entire version line, otherwise would replace 4.1.0 anywhere
-    - search: "version: 4.1.2"
+    # replace entire version line, otherwise would replace {MAJOR}.{MINOR}.0 anywhere
+    - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
-    - search: 'olm.skipRange: ">=4.1.0 <4.1.2"'
+    - search: 'olm.skipRange: ">=4.1.0 <{MAJOR}.{MINOR}.0"'
       replace: 'olm.skipRange: ">=4.1.0 <{FULL_VER}"'
   - file: "elasticsearch-operator.package.yaml"
     update_list:
-    - search: "currentCSV: elasticsearch-operator.v{MAJOR}.{MINOR}.2"
+    - search: "currentCSV: elasticsearch-operator.v{MAJOR}.{MINOR}.0"
       replace: "currentCSV: elasticsearch-operator.{FULL_VER}"
 

--- a/manifests/elasticsearch-operator.package.yaml
+++ b/manifests/elasticsearch-operator.package.yaml
@@ -2,4 +2,4 @@
 packageName: elasticsearch-operator
 channels:
 - name: preview
-  currentCSV: elasticsearch-operator.v4.1.2
+  currentCSV: elasticsearch-operator.v4.1.0


### PR DESCRIPTION
aligning w/ similar changes in master: https://github.com/openshift/elasticsearch-operator/pull/167

patch manager: there is no master BZ associated w/ this change because this is cleaning up issues that were specific to the 4.1 resource files.
