### PR TITLE
Bug 1725148: Updating to not set CPU limit unless it is explicitly set

### DIFF
--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -486,7 +486,6 @@ func newResourceRequirements(nodeResRequirements, commonResRequirements v1.Resou
 				if nodeLimitCPU.IsZero() {
 					// limit is zero use request for both
 					requestCPU = nodeRequestCPU
-					limitCPU = nodeRequestCPU
 				} else {
 					// both aren't zero
 					requestCPU = nodeRequestCPU
@@ -511,9 +510,7 @@ func newResourceRequirements(nodeResRequirements, commonResRequirements v1.Resou
 
 		if nodeLimitCPU.IsZero() {
 			// no node request mem, check that common has it
-			if commonLimitCPU.IsZero() {
-				limitCPU = commonRequestCPU
-			} else {
+			if !commonLimitCPU.IsZero() {
 				limitCPU = commonLimitCPU
 			}
 		} else {


### PR DESCRIPTION
Previously we were setting the CPU limit to match the CPU request if the request was provided but the limit was not. This removes the logic to set the CPU limit for ES nodes unless it is explicitly defined.