### PR TITLE
Use tagged image 4.1 instead of latest

### DIFF
--- a/manifests/05-deployment.yaml
+++ b/manifests/05-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: elasticsearch-operator
       containers:
         - name: elasticsearch-operator
-          image: quay.io/openshift/origin-elasticsearch-operator:latest
+          image: quay.io/openshift/origin-elasticsearch-operator:4.1
           imagePullPolicy: IfNotPresent
           command:
           - elasticsearch-operator


### PR DESCRIPTION
The latest image in 4.1 branch does not work. The branch should be using 4.1 tag instead.

https://quay.io/repository/openshift/origin-elasticsearch-operator?tab=tags

Signed-off-by: Pavol Loffay <ploffay@redhat.com>