### PR TITLE
allow to specify imagePullPolicy in CR

### DIFF
--- a/manifests/05-deployment.yaml
+++ b/manifests/05-deployment.yaml
@@ -30,6 +30,8 @@ spec:
               value: "elasticsearch-operator"
             - name: PROXY_IMAGE
               value: "quay.io/openshift/origin-oauth-proxy:v4.0.0"
+            - name: PROXY_IMAGE_PULL_POLICY
+              value: IfNotPresent
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/manifests/4.2/elasticsearch-operator.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/4.2/elasticsearch-operator.v4.2.0.clusterserviceversion.yaml
@@ -192,6 +192,8 @@ spec:
                       value: "elasticsearch-operator"
                     - name: PROXY_IMAGE
                       value: "quay.io/openshift/origin-oauth-proxy:latest"
+                    - name: PROXY_IMAGE_PULL_POLICY
+                      value: IfNotPresent
                     - name: ELASTICSEARCH_IMAGE
                       value: "quay.io/openshift/origin-logging-elasticsearch5:latest"
   customresourcedefinitions:

--- a/pkg/apis/logging/v1/elasticsearch_types.go
+++ b/pkg/apis/logging/v1/elasticsearch_types.go
@@ -91,10 +91,11 @@ type ElasticsearchNode struct {
 
 // ElasticsearchNodeSpec represents configuration of an individual Elasticsearch node
 type ElasticsearchNodeSpec struct {
-	Image        string                  `json:"image,omitempty"`
-	Resources    v1.ResourceRequirements `json:"resources"`
-	NodeSelector map[string]string       `json:"nodeSelector,omitempty"`
-	Tolerations  []v1.Toleration         `json:"tolerations,omitempty"`
+	Image           string                  `json:"image,omitempty"`
+	Resources       v1.ResourceRequirements `json:"resources"`
+	NodeSelector    map[string]string       `json:"nodeSelector,omitempty"`
+	Tolerations     []v1.Toleration         `json:"tolerations,omitempty"`
+	ImagePullPolicy v1.PullPolicy           `json:"imagePullPolicy,omitempty"`
 }
 
 type ElasticsearchStorageSpec struct {

--- a/pkg/k8shandler/elasticsearch.go
+++ b/pkg/k8shandler/elasticsearch.go
@@ -584,7 +584,7 @@ func updateIndexTemplateReplicas(clusterName, namespace string, client client.Cl
 
 					templateJson, _ := json.Marshal(template)
 
-					logrus.Debugf("Updating template %v from %d replicas to %d", templateName, currentReplicas, replicaCount)
+					logrus.Debugf("Updating template %v from %s replicas to %d", templateName, currentReplicas, replicaCount)
 
 					payload = &esCurlStruct{
 						Method:      http.MethodPut,


### PR DESCRIPTION
allow to specify imagePullPolicy in CR - this is very useful for
dev purposes, especially when doing interactive development, to
ensure that you are using the very latest image rather than an
image cached on the local node.  Yes, you can change the deployment
post-install, but it is much nicer and smoother to do the
initial deployment with the correct pull policy.

By default, the proxy image will use the same pull policy used by
the Elasticsearch image, but you can override this by setting
the env. var. `PROXY_IMAGE_PULL_POLICY`.