### PR TITLE
Introduce gosec for security checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ RUN_PID?=elasticsearch-operator.pid
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 #.PHONY: all build clean install uninstall fmt simplify check run
-.PHONY: all build clean fmt simplify run
+.PHONY: all build clean fmt simplify run sec
 
 all: build #check install
 
@@ -74,6 +74,10 @@ test-e2e:
 
 test-unit:
 	@go test -v ./pkg/... ./cmd/...
+
+sec:
+	go get -u github.com/securego/gosec/cmd/gosec
+	gosec -severity medium -confidence medium -exclude G304 -quiet ./...
 
 fmt:
 	@gofmt -l -w cmd && \

--- a/pkg/k8shandler/elasticsearch.go
+++ b/pkg/k8shandler/elasticsearch.go
@@ -845,6 +845,7 @@ func getClient(clusterName, namespace string, client client.Client) *http.Client
 			IdleConnTimeout:       90 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
+			// #nosec
 			// we cannot rely on certificates as they may rotate and therefore would be invalid
 			// since ES listens on https and presents a server cert, we need to not verify it
 			TLSClientConfig: &tls.Config{
@@ -904,7 +905,7 @@ func extractSecret(secretName, namespace string, client client.Client) {
 
 	// make sure that the dir === secretName exists
 	if _, err := os.Stat(path.Join(certLocalPath, secretName)); os.IsNotExist(err) {
-		err = os.MkdirAll(path.Join(certLocalPath, secretName), 0755)
+		err = os.MkdirAll(path.Join(certLocalPath, secretName), 0750)
 		if err != nil {
 			logrus.Errorf("Error creating dir %v: %v", path.Join(certLocalPath, secretName), err)
 		}


### PR DESCRIPTION
gosec does static code analysis and checks for common security issues in
golang codebases.

This PR introduces the tool, and sets it up as a test target in the Makefile.

This also makes the creation of the folder with certificates/keys more
restrictive. This was one of the warnings found by gosec.