### PR TITLE
Bug 1741350: Set resource limits if they are greater then 0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ RUN_PID?=elasticsearch-operator.pid
 # go source files, ignore vendor directory
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
-#.PHONY: all build clean install uninstall fmt simplify check run
-.PHONY: all build clean fmt simplify run
+#.PHONY: all build clean install uninstall fmt simplify check 
+.PHONY: all build clean fmt simplify
 
 all: build #check install
 
@@ -108,6 +108,14 @@ go-run: deploy deploy-example
 	OPERATOR_NAME=elasticsearch-operator WATCH_NAMESPACE=openshift-logging \
 	KUBERNETES_CONFIG=/etc/origin/master/admin.kubeconfig \
 	go run cmd/elasticsearch-operator/main.go > $(RUN_LOG) 2>&1 & echo $$! > $(RUN_PID)
+
+run-local:
+	@ALERTS_FILE_PATH=files/prometheus_alerts.yml \
+	RULES_FILE_PATH=files/prometheus_rules.yml \
+	OPERATOR_NAME=elasticsearch-operator WATCH_NAMESPACE=openshift-logging \
+	KUBERNETES_CONFIG=$(KUBECONFIG) \
+	go run ${MAIN_PKG} LOG_LEVEL=debug
+.PHONY: run-local
 
 undeploy:
 	hack/undeploy.sh

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -1,6 +1,7 @@
 package k8shandler
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -466,6 +467,13 @@ func (node *deploymentNode) executeUpdate() error {
 		// isChanged() will get the latest revision from the apiserver
 		// and return false if there is nothing to change and will update the node object if required
 		if node.isChanged() {
+			if logrus.GetLevel() == logrus.DebugLevel {
+				pretty, err := json.MarshalIndent(node.self, "", "  ")
+				if err != nil {
+					logrus.Debugf("Error marshalling node deployment for debug log: %v", err)
+				}
+				logrus.Debugf("Attempting to update node deployment: %+v", string(pretty))
+			}
 			if updateErr := sdk.Update(&node.self); updateErr != nil {
 				logrus.Debugf("Failed to update node resource %v: %v", node.self.Name, updateErr)
 				return updateErr
@@ -542,6 +550,12 @@ func (node *deploymentNode) isChanged() bool {
 		nodeContainer := node.self.Spec.Template.Spec.Containers[index]
 		desiredContainer := desired.Spec.Template.Spec.Containers[index]
 
+		if nodeContainer.Image != desiredContainer.Image {
+			logrus.Debugf("Resource '%s' has different container image than desired", node.self.Name)
+			nodeContainer.Image = desiredContainer.Image
+			changed = true
+		}
+
 		if nodeContainer.Resources.Requests == nil {
 			nodeContainer.Resources.Requests = v1.ResourceList{}
 		}
@@ -550,40 +564,65 @@ func (node *deploymentNode) isChanged() bool {
 			nodeContainer.Resources.Limits = v1.ResourceList{}
 		}
 
-		// check that both exist
-
-		if nodeContainer.Image != desiredContainer.Image {
-			logrus.Debugf("Resource '%s' has different container image than desired", node.self.Name)
-			nodeContainer.Image = desiredContainer.Image
+		var updatedContainer v1.Container
+		var resourceUpdated bool
+		if updatedContainer, resourceUpdated = updateResources(node, nodeContainer, desiredContainer); resourceUpdated {
 			changed = true
 		}
 
-		if desiredContainer.Resources.Limits.Cpu().Cmp(*nodeContainer.Resources.Limits.Cpu()) != 0 {
-			logrus.Debugf("Resource '%s' has different CPU limit than desired", node.self.Name)
-			nodeContainer.Resources.Limits[v1.ResourceCPU] = *desiredContainer.Resources.Limits.Cpu()
-			changed = true
-		}
-		// Check memory limits
-		if desiredContainer.Resources.Limits.Memory().Cmp(*nodeContainer.Resources.Limits.Memory()) != 0 {
-			logrus.Debugf("Resource '%s' has different Memory limit than desired", node.self.Name)
-			nodeContainer.Resources.Limits[v1.ResourceMemory] = *desiredContainer.Resources.Limits.Memory()
-			changed = true
-		}
-		// Check CPU requests
-		if desiredContainer.Resources.Requests.Cpu().Cmp(*nodeContainer.Resources.Requests.Cpu()) != 0 {
-			logrus.Debugf("Resource '%s' has different CPU Request than desired", node.self.Name)
-			nodeContainer.Resources.Requests[v1.ResourceCPU] = *desiredContainer.Resources.Requests.Cpu()
-			changed = true
-		}
-		// Check memory requests
-		if desiredContainer.Resources.Requests.Memory().Cmp(*nodeContainer.Resources.Requests.Memory()) != 0 {
-			logrus.Debugf("Resource '%s' has different Memory Request than desired", node.self.Name)
-			nodeContainer.Resources.Requests[v1.ResourceMemory] = *desiredContainer.Resources.Requests.Memory()
-			changed = true
-		}
-
-		node.self.Spec.Template.Spec.Containers[index] = nodeContainer
+		node.self.Spec.Template.Spec.Containers[index] = updatedContainer
 	}
 
 	return changed
+}
+
+//updateResources for the node; return true if an actual change is made
+func updateResources(node *deploymentNode, nodeContainer, desiredContainer v1.Container) (v1.Container, bool) {
+	changed := false
+	if nodeContainer.Resources.Requests == nil {
+		nodeContainer.Resources.Requests = v1.ResourceList{}
+	}
+
+	if nodeContainer.Resources.Limits == nil {
+		nodeContainer.Resources.Limits = v1.ResourceList{}
+	}
+
+	// Check CPU limits
+	if desiredContainer.Resources.Limits.Cpu().Cmp(*nodeContainer.Resources.Limits.Cpu()) != 0 {
+		logrus.Debugf("Resource '%s' has different CPU (%+v) limit than desired (%+v)", node.self.Name, *nodeContainer.Resources.Limits.Cpu(), desiredContainer.Resources.Limits.Cpu())
+		nodeContainer.Resources.Limits[v1.ResourceCPU] = *desiredContainer.Resources.Limits.Cpu()
+		if nodeContainer.Resources.Limits.Cpu().IsZero() {
+			delete(nodeContainer.Resources.Limits, v1.ResourceCPU)
+		}
+		changed = true
+	}
+	// Check memory limits
+	if desiredContainer.Resources.Limits.Memory().Cmp(*nodeContainer.Resources.Limits.Memory()) != 0 {
+		logrus.Debugf("Resource '%s' has different Memory limit than desired", node.self.Name)
+		nodeContainer.Resources.Limits[v1.ResourceMemory] = *desiredContainer.Resources.Limits.Memory()
+		if nodeContainer.Resources.Limits.Memory().IsZero() {
+			delete(nodeContainer.Resources.Limits, v1.ResourceMemory)
+		}
+		changed = true
+	}
+	// Check CPU requests
+	if desiredContainer.Resources.Requests.Cpu().Cmp(*nodeContainer.Resources.Requests.Cpu()) != 0 {
+		logrus.Debugf("Resource '%s' has different CPU Request than desired", node.self.Name)
+		nodeContainer.Resources.Requests[v1.ResourceCPU] = *desiredContainer.Resources.Requests.Cpu()
+		if nodeContainer.Resources.Requests.Cpu().IsZero() {
+			delete(nodeContainer.Resources.Requests, v1.ResourceCPU)
+		}
+		changed = true
+	}
+	// Check memory requests
+	if desiredContainer.Resources.Requests.Memory().Cmp(*nodeContainer.Resources.Requests.Memory()) != 0 {
+		logrus.Debugf("Resource '%s' has different Memory Request than desired", node.self.Name)
+		nodeContainer.Resources.Requests[v1.ResourceMemory] = *desiredContainer.Resources.Requests.Memory()
+		if nodeContainer.Resources.Requests.Memory().IsZero() {
+			delete(nodeContainer.Resources.Requests, v1.ResourceMemory)
+		}
+		changed = true
+	}
+
+	return nodeContainer, changed
 }

--- a/pkg/k8shandler/deployment_test.go
+++ b/pkg/k8shandler/deployment_test.go
@@ -1,0 +1,134 @@
+package k8shandler
+
+import (
+	"testing"
+
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	deployment                      apps.Deployment
+	nodeContainer, desiredContainer v1.Container
+	node                            *deploymentNode
+)
+
+func setUp() {
+	nodeContainer = v1.Container{
+		Resources: v1.ResourceRequirements{
+			Limits: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				v1.ResourceCPU:    resource.MustParse("600m"),
+			},
+			Requests: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				v1.ResourceCPU:    resource.MustParse("600m"),
+			},
+		},
+	}
+
+	desiredContainer = v1.Container{
+		Resources: v1.ResourceRequirements{
+			Limits:   v1.ResourceList{},
+			Requests: v1.ResourceList{},
+		},
+	}
+	deployment = apps.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: apps.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						nodeContainer,
+					},
+				},
+			},
+		},
+	}
+	node = &deploymentNode{
+		self: deployment,
+	}
+}
+
+func TestUpdateResourcesWhenDesiredCPULimitIsZero(t *testing.T) {
+	setUp()
+	desiredContainer.Resources.Limits = v1.ResourceList{
+		v1.ResourceMemory: resource.MustParse("2Gi"),
+	}
+
+	desiredContainer.Resources.Requests = v1.ResourceList{
+		v1.ResourceMemory: resource.MustParse("2Gi"),
+		v1.ResourceCPU:    resource.MustParse("600m"),
+	}
+
+	actual, changed := updateResources(node, nodeContainer, desiredContainer)
+
+	if !changed {
+		t.Error("Expected updating the resources would recognized as changed, but it was not")
+	}
+	if !areResourcesSame(actual.Resources, desiredContainer.Resources) {
+		t.Errorf("Expected %v but got %v", printResource(desiredContainer.Resources), printResource(actual.Resources))
+	}
+}
+func TestUpdateResourcesWhenDesiredMemoryLimitIsZero(t *testing.T) {
+	setUp()
+	desiredContainer.Resources.Limits = v1.ResourceList{
+		v1.ResourceCPU: resource.MustParse("600m"),
+	}
+
+	desiredContainer.Resources.Requests = v1.ResourceList{
+		v1.ResourceMemory: resource.MustParse("2Gi"),
+		v1.ResourceCPU:    resource.MustParse("600m"),
+	}
+	actual, changed := updateResources(node, nodeContainer, desiredContainer)
+
+	if !changed {
+		t.Error("Expected updating the resources would recognized as changed, but it was not")
+	}
+	if !areResourcesSame(actual.Resources, desiredContainer.Resources) {
+		t.Errorf("Expected %v but got %v", printResource(desiredContainer.Resources), printResource(actual.Resources))
+	}
+}
+func TestUpdateResourcesWhenDesiredCPURequestIsZero(t *testing.T) {
+	setUp()
+	desiredContainer.Resources.Limits = v1.ResourceList{
+		v1.ResourceMemory: resource.MustParse("2Gi"),
+		v1.ResourceCPU:    resource.MustParse("600m"),
+	}
+
+	desiredContainer.Resources.Requests = v1.ResourceList{
+		v1.ResourceMemory: resource.MustParse("2Gi"),
+	}
+
+	actual, changed := updateResources(node, nodeContainer, desiredContainer)
+
+	if !changed {
+		t.Error("Expected updating the resources would recognized as changed, but it was not")
+	}
+	if !areResourcesSame(actual.Resources, desiredContainer.Resources) {
+		t.Errorf("Expected %v but got %v", printResource(desiredContainer.Resources), printResource(actual.Resources))
+	}
+}
+func TestUpdateResourcesWhenDesiredMemoryRequestIsZero(t *testing.T) {
+	setUp()
+	desiredContainer.Resources.Limits = v1.ResourceList{
+		v1.ResourceCPU:    resource.MustParse("600m"),
+		v1.ResourceMemory: resource.MustParse("2Gi"),
+	}
+
+	desiredContainer.Resources.Requests = v1.ResourceList{
+		v1.ResourceCPU: resource.MustParse("600m"),
+	}
+	actual, changed := updateResources(node, nodeContainer, desiredContainer)
+
+	if !changed {
+		t.Error("Expected updating the resources would recognized as changed, but it was not")
+	}
+	if !areResourcesSame(actual.Resources, desiredContainer.Resources) {
+		t.Errorf("Expected %v but got %v", printResource(desiredContainer.Resources), printResource(actual.Resources))
+	}
+}


### PR DESCRIPTION
This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1741350 by:

Only update the cpu/memory resources if they are greater then zero

blocked by https://github.com/openshift/elasticsearch-operator/pull/181