### PR TITLE
update package for 4.3

### DIFF
--- a/manifests/elasticsearch-operator.package.yaml
+++ b/manifests/elasticsearch-operator.package.yaml
@@ -1,5 +1,5 @@
-#! package-manifest: ./deploy/chart/catalog_resources/rh-operators/elasticsearch-operator.v4.2.0.clusterserviceversion.yaml
+#! package-manifest: ./deploy/chart/catalog_resources/rh-operators/elasticsearch-operator.v4.3.0.clusterserviceversion.yaml
 packageName: elasticsearch-operator
 channels:
-- name: "4.2"
-  currentCSV: elasticsearch-operator.v4.2.0
+- name: "4.3"
+  currentCSV: elasticsearch-operator.v4.3.0


### PR DESCRIPTION
Need to update the package for 4.3. This is causing the oal ci failure
https://github.com/openshift/origin-aggregated-logging/pull/1765
https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_origin-aggregated-logging/1765/pull-ci-openshift-origin-aggregated-logging-master-full-integ-aws/1497/build-log.txt
```
+++ curl -sOLJ https://raw.githubusercontent.com/openshift/elasticsearch-operator/master/manifests/elasticsearch-operator.package.yaml
...
https://github.com/openshift/origin-aggregated-logging/blob/master/hack/vendor/olm-test-script/e2e-olm.sh#L99
CURRENT_CSV=$(sed -nr 's,.*currentCSV: (.*),\1,p' $MANIFEST_DIR/*package.yaml)
```
so the version is in the package.yaml as well as elsewhere.

This will also need a similar change in the clo