### PR TITLE
Fixing skopeo auth issue in deploy-image.sh

### DIFF
--- a/hack/common
+++ b/hack/common
@@ -167,10 +167,16 @@ function login_to_registry() {
         fi
     fi
     podman login --tls-verify=false -u "$username" -p "$token" "$1" > /dev/null
+    echo "${username}:${token}"
 }
 
 function push_image() {
-    skopeo copy --dest-tls-verify=false docker-daemon:"$1" docker://"$2"
+    creds="$3"
+    if [ -z "$creds" ]; then
+        skopeo copy --dest-tls-verify=false docker-daemon:"$1" docker://"$2"
+    else
+        skopeo --debug copy --dest-creds "$creds" --dest-tls-verify=false docker-daemon:"$1" docker://"$2"
+    fi
 }
 
 if [ $REMOTE_REGISTRY = false ] ; then

--- a/hack/deploy-image.sh
+++ b/hack/deploy-image.sh
@@ -55,11 +55,11 @@ if [ $ii = 10 ] ; then
     exit 1
 fi
 
-login_to_registry "127.0.0.1:${LOCAL_PORT}"
+creds=$( login_to_registry "127.0.0.1:${LOCAL_PORT}" )
 echo "Pushing image ${IMAGE_TAG} to ${tag} ..."
 rc=0
 for ii in $( seq 1 5 ) ; do
-    if push_image ${IMAGE_TAG} ${tag} ; then
+    if push_image ${IMAGE_TAG} ${tag} ${creds} ; then
         rc=0
         break
     fi

--- a/pkg/k8shandler/elasticsearch_helper.go
+++ b/pkg/k8shandler/elasticsearch_helper.go
@@ -158,7 +158,7 @@ func updateAllIndexTemplateReplicas(clusterName, namespace string, client client
 
 						templateJson, _ := json.Marshal(template)
 
-						logrus.Debugf("Updating template %v from %d replicas to %d", templateName, currentReplicas, replicaCount)
+						logrus.Debugf("Updating template %v from %s replicas to %d", templateName, currentReplicas, replicaCount)
 
 						payload := &esCurlStruct{
 							Method:      http.MethodPut,


### PR DESCRIPTION
[ERROR]
+++ dirname hack/deploy-image.sh
+ skopeo copy --dest-tls-verify=false docker-daemon:quay.io/openshift/origin-cluster-logging-operator:latest docker://127.0.0.1:5000/openshift/origin-cluster-logging-operator:latest
time="..." level=fatal msg="Error trying to reuse blob sha256:... at destination: unable to retrieve auth token: invalid username/password"