### PR TITLE
Bug 1765808: Add subject per ES instance to es-proxy cluster role binding

### DIFF
--- a/pkg/k8shandler/elasticsearch_helper.go
+++ b/pkg/k8shandler/elasticsearch_helper.go
@@ -158,7 +158,7 @@ func updateAllIndexTemplateReplicas(clusterName, namespace string, client client
 
 						templateJson, _ := json.Marshal(template)
 
-						logrus.Debugf("Updating template %v from %d replicas to %d", templateName, currentReplicas, replicaCount)
+						logrus.Debugf("Updating template %v from %v replicas to %d", templateName, currentReplicas, replicaCount)
 
 						payload := &esCurlStruct{
 							Method:      http.MethodPut,

--- a/pkg/k8shandler/rbac.go
+++ b/pkg/k8shandler/rbac.go
@@ -9,8 +9,9 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
 	rbac "k8s.io/api/rbac/v1"
-	errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -95,19 +96,28 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateRBAC() error {
 		return err
 	}
 
-	subject = newSubject(
-		"ServiceAccount",
-		dpl.Name,
-		dpl.Namespace,
-	)
-	subject.APIGroup = ""
+	// Cluster role elasticsearch-proxy has to contain subjects for all ES instances
+	esList := &v1.ElasticsearchList{}
+	err := elasticsearchRequest.client.List(context.TODO(), &client.ListOptions{}, esList)
+	if err != nil {
+		return err
+	}
+
+	subjects := []rbac.Subject{}
+	for _, es := range esList.Items {
+		subject = newSubject(
+			"ServiceAccount",
+			es.Name,
+			es.Namespace,
+		)
+		subject.APIGroup = ""
+		subjects = append(subjects, subject)
+	}
 
 	proxyRoleBinding := newClusterRoleBinding(
 		"elasticsearch-proxy",
 		"elasticsearch-proxy",
-		newSubjects(
-			subject,
-		),
+		subjects,
 	)
 
 	addOwnerRefToObject(proxyRoleBinding, owner)

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -208,17 +208,17 @@ func elasticsearchFullClusterTest(t *testing.T, f *framework.Framework, ctx *fra
 	}
 
 	/*
-	FIXME: this is commented out as we currently do not run our e2e tests in a container on the test cluster
-	 to be added back in as a follow up
-	err = utils.WaitForIndexTemplateReplicas(t, f.KubeClient, namespace, "example-elasticsearch", 1, retryInterval, timeout)
-	if err != nil {
-		return fmt.Errorf("timed out waiting for all index templates to have correct replica count")
-	}
+		FIXME: this is commented out as we currently do not run our e2e tests in a container on the test cluster
+		 to be added back in as a follow up
+		err = utils.WaitForIndexTemplateReplicas(t, f.KubeClient, namespace, "example-elasticsearch", 1, retryInterval, timeout)
+		if err != nil {
+			return fmt.Errorf("timed out waiting for all index templates to have correct replica count")
+		}
 
-	err = utils.WaitForIndexReplicas(t, f.KubeClient, namespace, "example-elasticsearch", 1, retryInterval, timeout)
-	if err != nil {
-		return fmt.Errorf("timed out waiting for all indices to have correct replica count")
-	}
+		err = utils.WaitForIndexReplicas(t, f.KubeClient, namespace, "example-elasticsearch", 1, retryInterval, timeout)
+		if err != nil {
+			return fmt.Errorf("timed out waiting for all indices to have correct replica count")
+		}
 	*/
 
 	// Incorrect scale up and verify we don't see a 4th master created


### PR DESCRIPTION
Port of https://github.com/openshift/elasticsearch-operator/pull/193 for 4.2

https://bugzilla.redhat.com/show_bug.cgi?id=1765808
https://issues.jboss.org/browse/OSSM-100

Signed-off-by: Pavol Loffay <ploffay@redhat.com>