### PR TITLE
Bug 1753568: Dont restart cluster just because EO restarted

### DIFF
--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -100,10 +100,18 @@ func (node *deploymentNode) state() api.ElasticsearchNodeStatus {
 		rolloutForReload = v1.ConditionTrue
 	}*/
 
-	// check if the secretHash changed
+	// check for a case where our hash is missing -- operator restarted?
 	newSecretHash := getSecretDataHash(node.clusterName, node.self.Namespace, node.client)
-	if newSecretHash != node.secretHash {
-		rolloutForCertReload = v1.ConditionTrue
+	if node.secretHash == "" {
+		// if we were already scheduled to restart, don't worry? -- just grab
+		// the current hash -- we should have already had our upgradeStatus set if
+		// we required a restart...
+		node.secretHash = newSecretHash
+	} else {
+		// check if the secretHash changed
+		if newSecretHash != node.secretHash {
+			rolloutForCertReload = v1.ConditionTrue
+		}
 	}
 
 	return api.ElasticsearchNodeStatus{

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -93,10 +93,18 @@ func (node *statefulSetNode) state() api.ElasticsearchNodeStatus {
 		rolloutForReload = v1.ConditionTrue
 	}*/
 
-	// check if the secretHash changed
+	// check for a case where our hash is missing -- operator restarted?
 	newSecretHash := getSecretDataHash(node.clusterName, node.self.Namespace, node.client)
-	if newSecretHash != node.secretHash {
-		rolloutForCertReload = v1.ConditionTrue
+	if node.secretHash == "" {
+		// if we were already scheduled to restart, don't worry? -- just grab
+		// the current hash -- we should have already had our upgradeStatus set if
+		// we required a restart...
+		node.secretHash = newSecretHash
+	} else {
+		// check if the secretHash changed
+		if newSecretHash != node.secretHash {
+			rolloutForCertReload = v1.ConditionTrue
+		}
 	}
 
 	return api.ElasticsearchNodeStatus{


### PR DESCRIPTION
When the EO restarts it may go through and unnecessarily restart its managed clusters because it no longer has the secret hash stored for each node.

With this PR as long as the node is not in a state where it is currently scheduled to or is in the process of being restarted (denoted in the `.status` fields) we evaluate our hash when we check the state of each node.