### PR TITLE
Bug 1791231: Make addresses ipv6 compatible

### DIFF
--- a/hack/cert_generation.sh
+++ b/hack/cert_generation.sh
@@ -226,7 +226,7 @@ function generate_extensions() {
   local use_comma=0
 
   if [ "$add_localhost" == "true" ]; then
-    extension_names="IP.1:127.0.0.1,DNS.1:localhost"
+    extension_names="IP.1:127.0.0.1,IP.2:0:0:0:0:0:0:0:1,DNS.1:localhost"
     extension_index=2
     use_comma=1
   fi

--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -247,9 +247,10 @@ func newProxyContainer(imageName, clusterName string) (v1.Container, error) {
 			},
 		},
 		Args: []string{
+			"--http-address=:4180",
 			"--https-address=:60000",
 			"--provider=openshift",
-			"--upstream=https://127.0.0.1:9200",
+			"--upstream=https://localhost:9200",
 			"--tls-cert=/etc/proxy/secrets/tls.crt",
 			"--tls-key=/etc/proxy/secrets/tls.key",
 			"--upstream-ca=/etc/proxy/elasticsearch/admin-ca",


### PR DESCRIPTION
Make ES config ipv6 compatible to resolve: 

* [Bug 1791231](https://bugzilla.redhat.com/show_bug.cgi?id=1791231)
* [Bug 1791349](https://bugzilla.redhat.com/show_bug.cgi?id=1791349)