### PR TITLE
Update operator to expect ESv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ file `$(RUN_PID)` (default `elasticsearch-operator.pid`) e.g. `kill $(cat elasti
 
 ### Image customization
 
-The operator is designed to work with `quay.io/openshift/origin-logging-elasticsearch5` image.  To use
+The operator is designed to work with `quay.io/openshift/origin-logging-elasticsearch6` image.  To use
 a different image, edit `manifests/image-references` before deployment, or edit the elasticsearch
 cr after deployment e.g. `oc edit elasticsearch elasticsearch`.
 

--- a/hack/cr.yaml
+++ b/hack/cr.yaml
@@ -6,10 +6,9 @@ metadata:
 spec:
   managementState: "Managed"
   nodeSpec:
-    image: quay.io/openshift/origin-logging-elasticsearch5:latest
+    image: quay.io/openshift/origin-logging-elasticsearch6:latest
     resources:
       limits:
-        cpu: 500m
         memory: 1Gi
       requests:
         cpu: 500m

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -10,6 +10,7 @@ IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-quay.io/openshift/o
 if [ -n "${IMAGE_FORMAT:-}" ] ; then
   IMAGE_ELASTICSEARCH_OPERATOR=$(sed -e "s,\${component},elasticsearch-operator," <(echo $IMAGE_FORMAT))
 fi
+ELASTICSEARCH_IMAGE=${ELASTICSEARCH_IMAGE:-registry.svc.ci.openshift.org/ocp/feature-es6x:logging-elasticsearch6}
 
 KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config}
 
@@ -24,6 +25,7 @@ pushd manifests;
 popd
 # update the manifest with the image built by ci
 sed -i "s,quay.io/openshift/origin-elasticsearch-operator:latest,${IMAGE_ELASTICSEARCH_OPERATOR}," ${manifest}
+sed -i "s,quay.io/openshift/origin-logging-elasticsearch6:latest,${ELASTICSEARCH_IMAGE}," ${manifest}
 
 if [ "${REMOTE_CLUSTER:-false}" = false ] ; then
   sudo sysctl -w vm.max_map_count=262144 ||:

--- a/manifests/05-deployment.yaml
+++ b/manifests/05-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: elasticsearch-operator
           image: quay.io/openshift/origin-elasticsearch-operator:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command:
           - elasticsearch-operator
           ports:
@@ -30,6 +30,8 @@ spec:
               value: "elasticsearch-operator"
             - name: PROXY_IMAGE
               value: "quay.io/openshift/origin-oauth-proxy:v4.0.0"
+            - name: ELASTICSEARCH_IMAGE
+              value: "quay.io/openshift/origin-logging-elasticsearch6:latest"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/manifests/4.4/elasticsearch-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/elasticsearch-operator.v4.4.0.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
                 "spec": {
                   "managementState": "Managed",
                   "nodeSpec": {
-                    "image": "quay.io/openshift/origin-logging-elasticsearch5:latest",
+                    "image": "quay.io/openshift/origin-logging-elasticsearch6:latest",
                     "resources": {
                       "limits": {
                         "memory": "1Gi"
@@ -194,7 +194,7 @@ spec:
                     - name: PROXY_IMAGE
                       value: "quay.io/openshift/origin-oauth-proxy:latest"
                     - name: ELASTICSEARCH_IMAGE
-                      value: "quay.io/openshift/origin-logging-elasticsearch5:latest"
+                      value: "quay.io/openshift/origin-logging-elasticsearch6:latest"
   customresourcedefinitions:
     owned:
     - name: elasticsearches.logging.openshift.io

--- a/manifests/4.4/image-references
+++ b/manifests/4.4/image-references
@@ -7,10 +7,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-elasticsearch-operator:latest
-  - name: logging-elasticsearch5
+  - name: logging-elasticsearch6
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-logging-elasticsearch5:latest
+      name: quay.io/openshift/origin-logging-elasticsearch6:latest
   - name: oauth-proxy
     from:
       kind: DockerImage

--- a/pkg/k8shandler/defaults.go
+++ b/pkg/k8shandler/defaults.go
@@ -9,13 +9,13 @@ import (
 const (
 	modeUnique    = "unique"
 	modeSharedOps = "shared_ops"
-	defaultMode   = modeSharedOps
 
+	defaultMode               = modeSharedOps
 	defaultMasterCPURequest   = "100m"
 	defaultCPURequest         = "100m"
 	defaultMemoryLimit        = "4Gi"
 	defaultMemoryRequest      = "1Gi"
-	elasticsearchDefaultImage = "quay.io/openshift/origin-logging-elasticsearch5"
+	elasticsearchDefaultImage = "quay.io/openshift/origin-logging-elasticsearch6"
 
 	maxMasterCount = 3
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -29,6 +29,11 @@ func Errorf(format string, objects ...interface{}) {
 	logrus.Errorf(format, objects...)
 }
 
+//Error logs messages at level error
+func Error(message string) {
+	logrus.Error(message)
+}
+
 //Infof logs messages at level info
 func Infof(format string, objects ...interface{}) {
 	logrus.Infof(format, objects...)

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	goctx "context"
+
 	elasticsearch "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	v1 "k8s.io/api/core/v1"
@@ -109,7 +110,7 @@ func elasticsearchFullClusterTest(t *testing.T, f *framework.Framework, ctx *fra
 		return fmt.Errorf("Could not get namespace: %v", err)
 	}
 
-	cpuValue, _ := resource.ParseQuantity("500m")
+	cpuValue, _ := resource.ParseQuantity("100m")
 	memValue, _ := resource.ParseQuantity("2Gi")
 
 	dataUUID := utils.GenerateUUID()
@@ -152,7 +153,6 @@ func elasticsearchFullClusterTest(t *testing.T, f *framework.Framework, ctx *fra
 				Image: "",
 				Resources: v1.ResourceRequirements{
 					Limits: v1.ResourceList{
-						v1.ResourceCPU:    cpuValue,
 						v1.ResourceMemory: memValue,
 					},
 					Requests: v1.ResourceList{


### PR DESCRIPTION
This PR updates the operator to expect ESv6 and relies on images provided by:

* https://github.com/openshift/origin-aggregated-logging/pull/1817