### PR TITLE
Bug 1794801: [IPv6] Application should service on Address [::]:port 

### DIFF
--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -247,9 +247,10 @@ func newProxyContainer(imageName, clusterName string) (v1.Container, error) {
 			},
 		},
 		Args: []string{
+			"--http-address=:4180",
 			"--https-address=:60000",
 			"--provider=openshift",
-			"--upstream=https://127.0.0.1:9200",
+			"--upstream=https://localhost:9200",
 			"--tls-cert=/etc/proxy/secrets/tls.crt",
 			"--tls-key=/etc/proxy/secrets/tls.key",
 			"--upstream-ca=/etc/proxy/elasticsearch/admin-ca",


### PR DESCRIPTION
(cherry picked from commit 07b717e7ad932c345e159c658ebde572f7fdf8d3)

https://bugzilla.redhat.com/show_bug.cgi?id=1794801