### PR TITLE
Bug 1803145: Fix incorrect olm.skipRange in 4.3 CSV

### DIFF
--- a/manifests/4.3/elasticsearch-operator.v4.3.0.clusterserviceversion.yaml
+++ b/manifests/4.3/elasticsearch-operator.v4.3.0.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
     containerImage: quay.io/openshift/origin-elasticsearch-operator:latest
     createdAt: 2019-02-20T08:00:00Z
     support: AOS Cluster Logging, Jaeger
-    olm.skipRange: ">=4.2.0 <4.3.0"
+    olm.skipRange: ">=4.1.0 <4.3.0"
     alm-examples: |-
         [
             {


### PR DESCRIPTION
Fix an issue where the elasticsearch-operator couldn't be upgraded because it doesn't match the update_list defined in art.yaml nor configured in correct range.

4.3 fix https://github.com/openshift/elasticsearch-operator/pull/238

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1803145