### PR TITLE
Reduce deploy-example verbosity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ MAIN_PKG=cmd/manager/main.go
 RUN_LOG?=elasticsearch-operator.log
 RUN_PID?=elasticsearch-operator.pid
 OPERATOR_NAMESPACE=openshift-operators-redhat
-DEPLOYMENT_NAMESPACE=openshift-logging
+DEPLOYMENT_NAMESPACE?=openshift-logging
 
 # go source files, ignore vendor directory
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
@@ -101,7 +101,7 @@ deploy-image: image
 	hack/deploy-image.sh
 .PHONY: deploy-image
 
-deploy-example: deploy
+deploy-example: deploy deploy-example-secret
 	@oc create -n $(DEPLOYMENT_NAMESPACE) -f hack/cr.yaml
 .PHONY: deploy-example
 

--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-set -euxo pipefail
+if [ "${DEBUG:-}" = "true" ]; then
+  set -x
+fi
+set -euo pipefail
 
 source "$(dirname $0)/common"
 

--- a/hack/cert_generation.sh
+++ b/hack/cert_generation.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+if [ "${DEBUG:-}" = "true" ]; then
+  set -x
+fi
 set -e
 
 WORKING_DIR=$1

--- a/hack/deploy-image.sh
+++ b/hack/deploy-image.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-set -euxo pipefail
+if [ "${DEBUG:-}" = "true" ]; then
+  set -x
+fi
+set -euo pipefail
 
 if [ "${REMOTE_REGISTRY:-true}" = false ] ; then
     exit 0

--- a/hack/deploy-setup.sh
+++ b/hack/deploy-setup.sh
@@ -3,7 +3,10 @@
 # to deploy an Elasticsearch cluster.  It assumes it is capable of login as a
 # user who has the cluster-admin role
 
-set -euxo pipefail
+if [ "${DEBUG:-}" = "true" ]; then
+  set -x
+fi
+set -euo pipefail
 
 source "$(dirname $0)/common"
 

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+if [ "${DEBUG:-}" = "true" ]; then
+  set -x
+fi
 set -euo pipefail
 
 source "$(dirname $0)/common"

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ "${DEBUG:-}" = "true" ]; then
+  set -x
+fi
+set -euo pipefail
+
 current_dir=$(dirname "${BASH_SOURCE[0]}" )
 source "${current_dir}/lib/init.sh"
 source "${current_dir}/lib/util/logs.sh"

--- a/hack/undeploy.sh
+++ b/hack/undeploy.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-set -euxo pipefail
+if [ "${DEBUG:-}" = "true" ]; then
+  set -x
+fi
+set -euo pipefail
 
 oc delete ns $NAMESPACE --force --grace-period=1 ||:
 oc delete -n openshift is origin-elasticsearch-operator || :


### PR DESCRIPTION
This PR disables default `set -x` for the EO deploy scripts and replaces it with the configuration env var `DEBUG`