### PR TITLE
revert ES logs to console

### DIFF
--- a/pkg/k8shandler/defaults.go
+++ b/pkg/k8shandler/defaults.go
@@ -43,10 +43,10 @@ func esUnicastHost(clusterName, namespace string) string {
 }
 
 func rootLogger(cluster *api.Elasticsearch) string {
-	if value, ok := cluster.GetAnnotations()[log4jConfig]; ok {
+	if value, ok := cluster.GetAnnotations()[logAppenderAnnotation]; ok {
 		return value
 	}
-	return "rolling"
+	return "console"
 }
 
 func calculateReplicaCount(dpl *api.Elasticsearch) int {


### PR DESCRIPTION
This PR reverts logs to the console in order to avert filling up disk with stray logs that are not properly rotated