### PR TITLE
    Updated `logs.infra` to `logs-infra`

### DIFF
--- a/hack/cr.yaml
+++ b/hack/cr.yaml
@@ -37,4 +37,4 @@ spec:
       policyRef: infra-policy
       aliases:
       - infra
-      - logs.infra
+      - logs-infra


### PR DESCRIPTION
OpenDistro security plugin parses role index patterns wrongly if it contains `.`, so using `-` instead.

 Updated `logs.infra` to `logs-infra`
