### PR TITLE
Bug 1808053: Define default master url for fabric8io k8s client

### DIFF
--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -290,6 +290,10 @@ func newEnvVars(nodeName, clusterName, instanceRam string, roleMap map[api.Elast
 			},
 		},
 		v1.EnvVar{
+			Name:  "KUBERNETES_MASTER",
+			Value: "https://kubernetes.default.svc",
+		},
+		v1.EnvVar{
 			Name:  "KUBERNETES_TRUST_CERT",
 			Value: "true",
 		},


### PR DESCRIPTION
To address: https://bugzilla.redhat.com/show_bug.cgi?id=1808053