### PR TITLE
Bug 1809511: block creation of indices with the write suffix for index management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 tmp/_output
 tmp/_test
 _output
+pf.log
 
 # GoLand
 .idea

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -9,8 +9,14 @@ current_dir=$(dirname "${BASH_SOURCE[0]}" )
 source "${current_dir}/lib/init.sh"
 source "${current_dir}/lib/util/logs.sh"
 
-# TODO Re-enable test-200-verify-es-metrics-access.sh when es-proxy provides a separate listener
-for test in $( find "${current_dir}/testing" -type f -name 'test-001*.sh' | sort); do
+EXCLUDES="verify-es-metrics"
+for test in $( find "${current_dir}/testing" -type f -name 'test-*.sh' | sort); do
+	if [[ ${test} =~ .*${EXCLUDES}.* ]] ; then
+		os::log::info "==============================================================="
+		os::log::info "skipping e2e that was excluded $test "
+		os::log::info "==============================================================="
+		continue
+	fi
 	os::log::info "==============================================================="
 	os::log::info "running e2e $test "
 	os::log::info "==============================================================="

--- a/hack/testing/test-200-verify-es-metrics-access.sh
+++ b/hack/testing/test-200-verify-es-metrics-access.sh
@@ -11,7 +11,6 @@ repo_dir="$(dirname $0)/../.."
 source "${repo_dir}/hack/testing/utils"
 
 ARTIFACT_DIR=${ARTIFACT_DIR:-"$(pwd)/_output"}/$(basename ${BASH_SOURCE[0]})
-
 if [ ! -d $ARTIFACT_DIR ] ; then
   mkdir -p $ARTIFACT_DIR
 fi

--- a/hack/testing/test-657-im-block-autocreate-for-write-suffix.sh
+++ b/hack/testing/test-657-im-block-autocreate-for-write-suffix.sh
@@ -1,0 +1,71 @@
+set -euo pipefail
+
+if [ -n "${DEBUG:-}" ]; then
+    set -x
+fi
+
+KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config}
+
+repo_dir="$(dirname $0)/../.."
+source "${repo_dir}/hack/testing/utils"
+ARTIFACT_DIR=${ARTIFACT_DIR:-"$(pwd)/_output"}
+test_artifact_dir=$ARTIFACT_DIR/$(basename ${BASH_SOURCE[0]})
+if [ ! -d $test_artifact_dir ] ; then
+  mkdir -p $test_artifact_dir
+fi
+
+TEST_NAMESPACE="${TEST_NAMESPACE:-e2e-test-${RANDOM}}"
+
+start_seconds=$(date +%s)
+cleanup(){
+  local return_code="$?"
+  set +e
+  log::info "Running cleanup"
+  end_seconds=$(date +%s)
+  runtime="$(($end_seconds - $start_seconds))s"
+  
+  if [ "${DO_CLEANUP:-true}" == "true" ] ; then
+    gather_logging_resources ${TEST_NAMESPACE} $test_artifact_dir
+    for item in "ns/${TEST_NAMESPACE}" "ns/openshift-operators-redhat"; do
+      oc delete $item --wait=true --ignore-not-found --force --grace-period=0
+    done
+  fi
+  
+  set -e
+  exit ${return_code}
+}
+trap cleanup exit
+
+if [ "${DO_SETUP:-true}" == "true" ] ; then
+  for item in "${TEST_NAMESPACE}" "openshift-operators-redhat" ; do
+    if oc get project ${item} > /dev/null 2>&1 ; then
+      echo using existing project ${item}
+    else
+      oc create namespace ${item}
+    fi
+  done
+
+  deploy_elasticsearch_operator
+  #deploy elasticsearch cluster
+  expect_success "${repo_dir}/hack/deploy-example-secrets.sh  ${TEST_NAMESPACE}"
+  expect_success "oc -n ${TEST_NAMESPACE} create -f ${repo_dir}/hack/cr.yaml"
+
+  log::info "Waiting for elasticsearch-operator to deploy the cluster..."
+  try_until_success "oc -n ${TEST_NAMESPACE} get deployment -l component=elasticsearch -o jsonpath={.items[0].metadata.name}) --ignore-not-found" $((2 * $minute))
+
+fi
+#wait for pod
+log::info "Waiting for elasticsearch deployment to be ready..."
+wait_for_deployment_to_be_ready ${TEST_NAMESPACE} $(oc -n ${TEST_NAMESPACE} get deployment -l component=elasticsearch -o jsonpath={.items[0].metadata.name}) $((2 * $minute))
+
+pod=$(oc -n $TEST_NAMESPACE get pod -l component=elasticsearch -o jsonpath={.items[0].metadata.name})
+log::info Attempt to autocreate an index without a '-write' suffix...
+expect_success_and_text "oc -n $TEST_NAMESPACE exec $pod -c elasticsearch -- es_util --query=foo/_doc/1 -d {\"key\":\"value\"} -XPUT -w %{http_code}" ".*201"
+
+log::info Attempt to autocreate an index with a '-write' suffix...
+expect_success_and_text "oc -n $TEST_NAMESPACE exec $pod -c elasticsearch -- es_util --query=foo-write/_doc/1 -d {\"key\":\"value\"} -XPUT -w %{http_code}" ".*404"
+
+log::info Explicitly creating an index with a '-write' suffix...
+expect_success_and_text "oc -n $TEST_NAMESPACE exec $pod -c elasticsearch -- es_util --query=foo-write -XPUT -w %{http_code}" ".*200"
+log::info Verifying can write to index with a '-write' suffix...
+expect_success_and_text "oc -n $TEST_NAMESPACE exec $pod -c elasticsearch -- es_util --query=foo-write/_doc/1 -d {\"key\":\"value\"} -XPUT  -w %{http_code}" ".*201"

--- a/hack/testing/utils
+++ b/hack/testing/utils
@@ -29,15 +29,19 @@ expect_success(){
   fi  
   return 1
 }
+
 expect_success_and_text(){
   local cmd=$1
   local expected=$2
-  log::debug "Running '$cmd'"
+  log::info "Running '$cmd'"
   response=$($cmd)
-  log::debug "Response '${response}'" 
-  if [[ "${response}" == "${expected}" ]] ; then
+  result=$?
+  log::info "Response '${response}'" 
+  if [ $result == 0 ] && [[ ${response} =~ ${expected} ]] ; then
+    log::info "Passed"
     return 0
   fi  
+  log::info "Fail: Expected response to rematch $expected"
   return 1
 }
 
@@ -49,11 +53,13 @@ try_until_failure() {
   local expire=$(($now + $timeout))
   while [ $now -lt $expire ]; do
     if ! $cmd ; then
+      log::info "Passed"
       return 0
     fi  
     sleep $interval
     now=$(date +%s%3N)
   done
+  log::info "Fail"
   return 1
 }
 try_until_success() {
@@ -64,11 +70,13 @@ try_until_success() {
   local expire=$(($now + $timeout))
   while [ $now -lt $expire ]; do
     if $cmd ; then
+      log::info "Passed"
       return 0
     fi  
     sleep $interval
     now=$(date +%s%3N)
   done
+  log::info "Fail"
   return 1
 }
 
@@ -79,11 +87,13 @@ try_until_text() {
   local now=$(date +%s%3N)
   local expire=$(($now + $timeout))
   while [ $now -lt $expire ]; do
-      if [[ "$($cmd)" == "${expected}" ]] ; then
+    if [[ "$($cmd)" == "${expected}" ]] ; then
+      log::info "Passed"
       return 0
     fi  
     now=$(date +%s%3N)
   done
+  log::info "Fail"
   return 1
 }
 
@@ -101,7 +111,7 @@ gather_logging_resources() {
   oc -n ${LOGGING_NS} extract secret/elasticsearch --to=$outdir ||:
   oc -n ${LOGGING_NS} extract configmap/fluentd --to=$outdir ||:
 
-  get_all_logging_pod_logs $@
+  get_all_logging_pod_logs ${LOGGING_NS} $outdir
   set -e
 }
 
@@ -111,14 +121,15 @@ get_all_logging_pod_logs() {
   local outdir=${2:-$ARTIFACT_DIR}
   local p
   local container
-  oc get pods -n ${LOGGING_NS} -o wide > $outdir/pods.txt 2>&1
-  for p in $(oc get pods -n ${LOGGING_NS} -o jsonpath='{.items[*].metadata.name}') ; do
+  oc -n ${LOGGING_NS} get pods -o wide > $outdir/pods.txt 2>&1
+
+  for p in $(oc  -n ${LOGGING_NS} get pods -o jsonpath='{.items[*].metadata.name}') ; do
     oc -n ${LOGGING_NS} describe pod $p > $outdir/$p.describe 2>&1 || :
     oc -n ${LOGGING_NS} get pod $p -o yaml > $outdir/$p.yaml 2>&1 || :
     for container in $(oc -n ${LOGGING_NS} get po $p -o jsonpath='{.spec.containers[*].name}') ; do
       oc logs -n ${LOGGING_NS} -c $container $p > $outdir/$p.$container.log 2>&1
       case "$container" in
-        elasticsearch*) oc exec -n ${LOGGING_NS} -c elasticsearch $p  -- logs > $outdir/$p.$container.exec.log 2>&1 ;;
+        elasticsearch*) oc -n ${LOGGING_NS} exec -c elasticsearch $p  -- logs > $outdir/$p.$container.exec.log 2>&1 ;;
         *) continue ;;
       esac
     done
@@ -267,7 +278,7 @@ EOF
 }
 
 function deploy_elasticsearch_operator() {
-    OPERAND_IMAGES="ELASTICSEARCH_IMAGE=$(format_image logging-elasticsearch6) ELASTICSEARCH_PROXY=$(format_image elasticsearch-proxy)"
+    OPERAND_IMAGES="ELASTICSEARCH_IMAGE=${ELASTICSEARCH_IMAGE:-$(format_image logging-elasticsearch6)} ELASTICSEARCH_PROXY=${ELASTICSEARCH_PROXY:-$(format_image elasticsearch-proxy)}"
     IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-$(format_image elasticsearch-operator)}
     manifest=${repo_dir}/manifests
     OPERAND_IMAGES=$OPERAND_IMAGES GLOBAL=true deploy_operator "openshift-operators-redhat" "elasticsearch-operator" $manifest $IMAGE_ELASTICSEARCH_OPERATOR $((2 * $minute))

--- a/pkg/k8shandler/configuration_tmpl.go
+++ b/pkg/k8shandler/configuration_tmpl.go
@@ -10,6 +10,8 @@ node:
   data: ${HAS_DATA}
   max_local_storage_nodes: 1
 
+action.auto_create_index: "-*-write,+*"
+
 network:
   host: 0.0.0.0
 


### PR DESCRIPTION
Block auto index creation for indices that end in `-write` to avoid a race condition between fluent writing logs and EO setting up index management

cc @QiaolingTang @ewolinetz 

https://bugzilla.redhat.com/show_bug.cgi?id=1809511