### PR TITLE
Bug 1808986: Adding nodeSelector to operator deployment

### DIFF
--- a/manifests/4.5/elasticsearch-operator.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/elasticsearch-operator.v4.5.0.clusterserviceversion.yaml
@@ -232,6 +232,8 @@ spec:
               labels:
                 name: elasticsearch-operator
             spec:
+              nodeSelector:
+                kubernetes.io/os: linux
               serviceAccountName: elasticsearch-operator
               containers:
                 - name: elasticsearch-operator


### PR DESCRIPTION
Adds a `"kubernetes.io/os": "linux"` node selector for the ClusterLoggingOperator deployment

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1808986