### PR TITLE
Provide proxy configuration for metrics TLS listener

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -9,7 +9,7 @@ current_dir=$(dirname "${BASH_SOURCE[0]}" )
 source "${current_dir}/lib/init.sh"
 source "${current_dir}/lib/util/logs.sh"
 
-EXCLUDES="verify-es-metrics"
+EXCLUDES=""
 for test in $( find "${current_dir}/testing" -type f -name 'test-*.sh' | sort); do
 	if [[ ${test} =~ .*${EXCLUDES}.* ]] ; then
 		os::log::info "==============================================================="

--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -242,16 +242,18 @@ func newProxyContainer(imageName, clusterName string) (v1.Container, error) {
 			},
 		},
 		Args: []string{
+			// HTTPS default listener for Elasticsearch
 			"--listening-address=:60000",
 			"--tls-cert=/etc/proxy/elasticsearch/logging-es.crt",
 			"--tls-key=/etc/proxy/elasticsearch/logging-es.key",
 			"--tls-client-ca=/etc/proxy/elasticsearch/admin-ca",
+
+			// HTTPs listener for metrics
+			"--metrics-listening-address=:60001",
+			"--metrics-tls-cert=/etc/proxy/secrets/tls.crt",
+			"--metrics-tls-key=/etc/proxy/secrets/tls.key",
+
 			"--upstream-ca=/etc/proxy/elasticsearch/admin-ca",
-			"--auth-whitelisted-name=CN=system.logging.kibana,OU=OpenShift,O=Logging",
-			"--auth-whitelisted-name=CN=system.logging.fluentd,OU=OpenShift,O=Logging",
-			"--auth-whitelisted-name=CN=system.logging.curator,OU=OpenShift,O=Logging",
-			"--auth-whitelisted-name=CN=system.admin,OU=OpenShift,O=Logging",
-			"--auth-whitelisted-name=CN=user.jaeger,OU=OpenShift,O=Logging",
 			"--cache-expiry=60s",
 			`--auth-backend-role=sg_role_admin={"namespace": "default", "verb": "view", "resource": "pods/metrics"}`,
 			`--auth-backend-role=prometheus={"verb": "get", "resource": "/metrics"}`,

--- a/pkg/k8shandler/common_test.go
+++ b/pkg/k8shandler/common_test.go
@@ -406,11 +406,6 @@ func TestProxyContainerTLSClientAuthDefined(t *testing.T) {
 		"--tls-cert=/etc/proxy/elasticsearch/logging-es.crt",
 		"--tls-key=/etc/proxy/elasticsearch/logging-es.key",
 		"--tls-client-ca=/etc/proxy/elasticsearch/admin-ca",
-		"--auth-whitelisted-name=CN=system.logging.kibana,OU=OpenShift,O=Logging",
-		"--auth-whitelisted-name=CN=system.logging.fluentd,OU=OpenShift,O=Logging",
-		"--auth-whitelisted-name=CN=system.logging.curator,OU=OpenShift,O=Logging",
-		"--auth-whitelisted-name=CN=system.admin,OU=OpenShift,O=Logging",
-		"--auth-whitelisted-name=CN=user.jaeger,OU=OpenShift,O=Logging",
 	}
 
 	for _, arg := range want {
@@ -430,6 +425,41 @@ func TestProxyContainerTLSClientAuthDefined(t *testing.T) {
 
 	if !hasMount {
 		t.Errorf("Missing volume mount for tls client auth PKI: %#v", wantVolumeMount)
+	}
+}
+
+func TestProxyContainerMetricsTLSDefined(t *testing.T) {
+	imageName := "openshift/elasticsearch-proxy:1.1"
+	clusterName := "elasticsearch"
+
+	proxyContainer, err := newProxyContainer(imageName, clusterName)
+	if err != nil {
+		t.Errorf("Failed to populate Proxy container: %v", err)
+	}
+
+	want := []string{
+		"--metrics-listening-address=:60001",
+		"--metrics-tls-cert=/etc/proxy/secrets/tls.crt",
+		"--metrics-tls-key=/etc/proxy/secrets/tls.key",
+	}
+
+	for _, arg := range want {
+		if !sliceContainsString(proxyContainer.Args, arg) {
+			t.Errorf("Missing tls client auth argument: %s", arg)
+		}
+	}
+
+	wantVolumeMount := v1.VolumeMount{Name: "elasticsearch-metrics", MountPath: "/etc/proxy/secrets"}
+
+	hasMount := false
+	for _, vm := range proxyContainer.VolumeMounts {
+		if reflect.DeepEqual(vm, wantVolumeMount) {
+			hasMount = true
+		}
+	}
+
+	if !hasMount {
+		t.Errorf("Missing volume mount for tls metrics PKI: %#v", wantVolumeMount)
 	}
 }
 

--- a/pkg/k8shandler/service.go
+++ b/pkg/k8shandler/service.go
@@ -63,7 +63,7 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateServices() error
 		dpl.Namespace,
 		dpl.Name,
 		"restapi",
-		60000,
+		60001,
 		selectorForES("es-node-client", dpl.Name),
 		annotations,
 		false,


### PR DESCRIPTION
This PR extends the proxy container arguments to address the mandatory configuration for exposing metrics from a separate TLS listener using the injected PKI. To address: openshift/elasticsearch-proxy#25