### PR TITLE
Bug 1812920: Adding nodeSelector to operator deployment

### DIFF
--- a/manifests/4.4/elasticsearch-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/elasticsearch-operator.v4.4.0.clusterserviceversion.yaml
@@ -172,6 +172,8 @@ spec:
               labels:
                 name: elasticsearch-operator
             spec:
+              nodeSelector:
+                kubernetes.io/os: linux
               serviceAccountName: elasticsearch-operator
               containers:
                 - name: elasticsearch-operator


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/elasticsearch-operator/pull/254
Adds a `"kubernetes.io/os": "linux"` node selector for the ClusterLoggingOperator deployment

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1812920