### PR TITLE
Re-organize comments to give better CRD `description` fields.

### DIFF
--- a/pkg/apis/logging/v1/elasticsearch_types.go
+++ b/pkg/apis/logging/v1/elasticsearch_types.go
@@ -115,8 +115,10 @@ type ElasticsearchNodeSpec struct {
 }
 
 type ElasticsearchStorageSpec struct {
-	StorageClassName *string            `json:"storageClassName,omitempty"`
-	Size             *resource.Quantity `json:"size,omitempty"`
+	// The class of storage to provision. More info: https://kubernetes.io/docs/concepts/storage/storage-classes/
+	StorageClassName *string `json:"storageClassName,omitempty"`
+	// The capacity of storage to provision.
+	Size *resource.Quantity `json:"size,omitempty"`
 }
 
 // ElasticsearchNodeStatus represents the status of individual Elasticsearch node
@@ -137,31 +139,31 @@ type ElasticsearchNodeUpgradeStatus struct {
 	UpgradePhase             ElasticsearchUpgradePhase `json:"upgradePhase,omitempty"`
 }
 
-// ClusterCondition contains details for the current condition of this elasticsearch cluster.
-// Status: the status of the condition.
-// LastTransitionTime: Last time the condition transitioned from one status to another.
-// Reason: Unique, one-word, CamelCase reason for the condition's last transition.
-// Message: Human-readable message indicating details about last transition.
 type ClusterCondition struct {
-	Type               ClusterConditionType `json:"type"`
-	Status             v1.ConditionStatus   `json:"status"`
-	LastTransitionTime metav1.Time          `json:"lastTransitionTime"`
-	Reason             string               `json:"reason,omitempty" protobuf:"bytes,5,opt,name=reason"`
-	Message            string               `json:"message,omitempty" protobuf:"bytes,6,opt,name=message"`
+	Type   ClusterConditionType `json:"type"`
+	Status v1.ConditionStatus   `json:"status"`
+	// Last time the condition transitioned from one status to another.
+	LastTransitionTime metav1.Time `json:"lastTransitionTime"`
+	// Unique, one-word, CamelCase reason for the condition's last transition.
+	Reason string `json:"reason,omitempty" protobuf:"bytes,5,opt,name=reason"`
+	// Human-readable message indicating details about last transition.
+	Message string `json:"message,omitempty" protobuf:"bytes,6,opt,name=message"`
 }
 
-// RedundancyPolicyType controls number of elasticsearch replica shards
-// FullRedundancy - each index is fully replicated on every Data node in the cluster
-// MultipleRedundancy - each index is spread over half of the Data nodes
-// SingleRedundancy - one replica shard
-// ZeroRedundancy - no replica shards
+// +kubebuilder:validation:Enum=FullRedundancy;MultipleRedundancy;SingleRedundancy;ZeroRedundancy
+
+// The policy towards data redundancy to specify the number of redundant primary shards
 type RedundancyPolicyType string
 
 const (
-	FullRedundancy     RedundancyPolicyType = "FullRedundancy"
+	// FullRedundancy - each index is fully replicated on every Data node in the cluster
+	FullRedundancy RedundancyPolicyType = "FullRedundancy"
+	// MultipleRedundancy - each index is spread over half of the Data nodes
 	MultipleRedundancy RedundancyPolicyType = "MultipleRedundancy"
-	SingleRedundancy   RedundancyPolicyType = "SingleRedundancy"
-	ZeroRedundancy     RedundancyPolicyType = "ZeroRedundancy"
+	// SingleRedundancy - one replica shard
+	SingleRedundancy RedundancyPolicyType = "SingleRedundancy"
+	// ZeroRedundancy - no replica shards
+	ZeroRedundancy RedundancyPolicyType = "ZeroRedundancy"
 )
 
 type ElasticsearchNodeRole string


### PR DESCRIPTION
The CLO operator will soon generate CRDs from Go code, which uses Go comments
to fill in the CRD validation `description` fields. Add text and re-organized
comments to give better descriptions.

Signed-off-by: Alan Conway <aconway@redhat.com>