### PR TITLE
remove unused variable check paths

### DIFF
--- a/olm_deploy/scripts/registry-init.sh
+++ b/olm_deploy/scripts/registry-init.sh
@@ -7,25 +7,9 @@ env | grep IMAGE
 echo -e "\n\n"
 
 IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-quay.io/openshift/origin-elasticsearch-operator:latest}
-if [ -n "${IMAGE_FORMAT:-}" ] ; then
-  IMAGE_ELASTICSEARCH_OPERATOR=$(sed -e "s,\${component},elasticsearch-operator," <(echo $IMAGE_FORMAT))
-fi
-
 IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-quay.io/openshift/origin-logging-elasticsearch6:latest}
-if [ -n "${IMAGE_FORMAT:-}" ] ; then
-  IMAGE_ELASTICSEARCH6=$(sed -e "s,\${component},logging-elasticsearch6," <(echo $IMAGE_FORMAT))
-fi
-
 IMAGE_OAUTH_PROXY=${IMAGE_OAUTH_PROXY:-quay.io/openshift/origin-oauth-proxy:latest}
-if [ -n "${IMAGE_FORMAT:-}" ] ; then
-  IMAGE_OAUTH_PROXY=$(sed -e "s,\${component},oauth-proxy," <(echo $IMAGE_FORMAT))
-fi
-
 IMAGE_LOGGING_KIBANA6=${IMAGE_OAUTH_PROXY:-quay.io/openshift/origin-logging-kibana6:latest}
-if [ -n "${IMAGE_FORMAT:-}" ] ; then
-  IMAGE_LOGGING_KIBANA6=$(sed -e "s,\${component},logging-kibana6," <(echo $IMAGE_FORMAT))
-fi
-
 
 # update the manifest with the image built by ci
 sed -i "s,quay.io/openshift/origin-elasticsearch-operator:latest,${IMAGE_ELASTICSEARCH_OPERATOR}," /manifests/*/*clusterserviceversion.yaml


### PR DESCRIPTION
these checks weren't doing anything since we set the env vars explicitly on the operator-registry catalog deployment, and we don't set image_format.