### PR TITLE
Add annotation to configure loglevel

### DIFF
--- a/hack/cr.yaml
+++ b/hack/cr.yaml
@@ -3,6 +3,8 @@ apiVersion: "logging.openshift.io/v1"
 kind: "Elasticsearch"
 metadata:
   name: "elasticsearch"
+  annotations:
+      elasticsearch.openshift.io/loglevel: trace
 spec:
   managementState: "Managed"
   nodeSpec:

--- a/pkg/k8shandler/common_test.go
+++ b/pkg/k8shandler/common_test.go
@@ -366,7 +366,7 @@ func TestProxyContainerResourcesDefined(t *testing.T) {
 	expectedCPU := resource.MustParse("100m")
 	expectedMemory := resource.MustParse("64Mi")
 
-	proxyContainer, err := newProxyContainer(imageName, clusterName)
+	proxyContainer, err := newProxyContainer(imageName, clusterName, LogConfig{})
 	if err != nil {
 		t.Errorf("Failed to populate Proxy container: %v", err)
 	}
@@ -400,7 +400,7 @@ func TestProxyContainerTLSClientAuthDefined(t *testing.T) {
 	imageName := "openshift/elasticsearch-proxy:1.1"
 	clusterName := "elasticsearch"
 
-	proxyContainer, err := newProxyContainer(imageName, clusterName)
+	proxyContainer, err := newProxyContainer(imageName, clusterName, LogConfig{})
 	if err != nil {
 		t.Errorf("Failed to populate Proxy container: %v", err)
 	}
@@ -435,7 +435,7 @@ func TestProxyContainerMetricsTLSDefined(t *testing.T) {
 	imageName := "openshift/elasticsearch-proxy:1.1"
 	clusterName := "elasticsearch"
 
-	proxyContainer, err := newProxyContainer(imageName, clusterName)
+	proxyContainer, err := newProxyContainer(imageName, clusterName, LogConfig{})
 	if err != nil {
 		t.Errorf("Failed to populate Proxy container: %v", err)
 	}
@@ -476,7 +476,7 @@ func TestPodSpecHasTaintTolerations(t *testing.T) {
 		},
 	}
 
-	podTemplateSpec := newPodTemplateSpec("test-node-name", "test-cluster-name", "test-namespace-name", api.ElasticsearchNode{}, api.ElasticsearchNodeSpec{}, map[string]string{}, map[api.ElasticsearchNodeRole]bool{}, nil)
+	podTemplateSpec := newPodTemplateSpec("test-node-name", "test-cluster-name", "test-namespace-name", api.ElasticsearchNode{}, api.ElasticsearchNodeSpec{}, map[string]string{}, map[api.ElasticsearchNodeRole]bool{}, nil, LogConfig{})
 
 	if !reflect.DeepEqual(podTemplateSpec.Spec.Tolerations, expectedTolerations) {
 		t.Errorf("Exp. the tolerations to be %v but was %v", expectedTolerations, podTemplateSpec.Spec.Tolerations)
@@ -570,7 +570,8 @@ func preparePodTemplateSpecProvidingNodeSelectors(selectors map[string]string) v
 		api.ElasticsearchNodeSpec{},
 		map[string]string{},
 		map[api.ElasticsearchNodeRole]bool{},
-		nil)
+		nil,
+		LogConfig{})
 }
 
 func buildResource(cpuLimit, cpuRequest, memLimit, memRequest resource.Quantity) v1.ResourceRequirements {

--- a/pkg/k8shandler/defaults.go
+++ b/pkg/k8shandler/defaults.go
@@ -24,8 +24,6 @@ const (
 	heapDumpLocation        = "/elasticsearch/persistent/heapdump.hprof"
 
 	k8sTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-
-	logAppenderAnnotation = "elasticsearch.openshift.io/develLogAppender"
 )
 
 func kibanaIndexMode(mode string) (string, error) {
@@ -40,13 +38,6 @@ func kibanaIndexMode(mode string) (string, error) {
 
 func esUnicastHost(clusterName, namespace string) string {
 	return fmt.Sprintf("%v-cluster.%v.svc", clusterName, namespace)
-}
-
-func rootLogger(cluster *api.Elasticsearch) string {
-	if value, ok := cluster.GetAnnotations()[logAppenderAnnotation]; ok {
-		return value
-	}
-	return "console"
 }
 
 func calculateReplicaCount(dpl *api.Elasticsearch) int {

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -53,7 +53,7 @@ func (deploymentNode *deploymentNode) populateReference(nodeName string, node ap
 	}
 
 	progressDeadlineSeconds := int32(1800)
-
+	logConfig := getLogConfig(cluster.GetAnnotations())
 	deployment.Spec = apps.DeploymentSpec{
 		Replicas: &replicas,
 		Selector: &metav1.LabelSelector{
@@ -64,7 +64,7 @@ func (deploymentNode *deploymentNode) populateReference(nodeName string, node ap
 		},
 		ProgressDeadlineSeconds: &progressDeadlineSeconds,
 		Paused:                  false,
-		Template:                newPodTemplateSpec(nodeName, cluster.Name, cluster.Namespace, node, cluster.Spec.Spec, labels, roleMap, client),
+		Template:                newPodTemplateSpec(nodeName, cluster.Name, cluster.Namespace, node, cluster.Spec.Spec, labels, roleMap, client, logConfig),
 	}
 
 	addOwnerRefToObject(&deployment, getOwnerRef(cluster))

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -49,13 +49,13 @@ func (statefulSetNode *statefulSetNode) populateReference(nodeName string, node 
 	}
 
 	partition := int32(0)
-
+	logConfig := getLogConfig(cluster.GetAnnotations())
 	statefulSet.Spec = apps.StatefulSetSpec{
 		Replicas: &replicas,
 		Selector: &metav1.LabelSelector{
 			MatchLabels: newLabelSelector(cluster.Name, nodeName, roleMap),
 		},
-		Template: newPodTemplateSpec(nodeName, cluster.Name, cluster.Namespace, node, cluster.Spec.Spec, labels, roleMap, client),
+		Template: newPodTemplateSpec(nodeName, cluster.Name, cluster.Namespace, node, cluster.Spec.Spec, labels, roleMap, client, logConfig),
 		UpdateStrategy: apps.StatefulSetUpdateStrategy{
 			Type: apps.RollingUpdateStatefulSetStrategyType,
 			RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{

--- a/pkg/k8shandler/util.go
+++ b/pkg/k8shandler/util.go
@@ -13,6 +13,41 @@ import (
 	api "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
 )
 
+const (
+	loglevelAnnotation          = "elasticsearch.openshift.io/loglevel"
+	serverLogAppenderAnnotation = "elasticsearch.openshift.io/develLogAppender"
+	serverLoglevelAnnotation    = "elasticsearch.openshift.io/esloglevel"
+)
+
+type LogConfig struct {
+	//LogLevel of the proxy and server security
+	LogLevel string
+	//ServerLogLevel of the remainder of Elasticsearch
+	ServerLoglevel string
+	//ServerAppender where to log messages
+	ServerAppender string
+}
+
+func getLogConfig(annotations map[string]string) LogConfig {
+	config := LogConfig{"info", "info", "console"}
+	if value, found := annotations[loglevelAnnotation]; found {
+		if strings.TrimSpace(value) != "" {
+			config.LogLevel = value
+		}
+	}
+	if value, found := annotations[serverLoglevelAnnotation]; found {
+		if strings.TrimSpace(value) != "" {
+			config.ServerLoglevel = value
+		}
+	}
+	if value, found := annotations[serverLogAppenderAnnotation]; found {
+		if strings.TrimSpace(value) != "" {
+			config.ServerAppender = value
+		}
+	}
+	return config
+}
+
 func selectorForES(nodeRole string, clusterName string) map[string]string {
 
 	return map[string]string{

--- a/pkg/k8shandler/util_test.go
+++ b/pkg/k8shandler/util_test.go
@@ -3,9 +3,35 @@ package k8shandler
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	api "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
 	v1 "k8s.io/api/core/v1"
 )
+
+var _ = Describe("util.go", func() {
+	defer GinkgoRecover()
+	Describe("#getLogConfig", func() {
+		It("should return 'info' when annotation is missing", func() {
+			Expect(getLogConfig(map[string]string{}).LogLevel).To(Equal("info"))
+			Expect(getLogConfig(map[string]string{}).ServerLoglevel).To(Equal("info"))
+			Expect(getLogConfig(map[string]string{}).ServerAppender).To(Equal("console"))
+		})
+		It("should return 'info' when annotation value is empty", func() {
+			annotations := map[string]string{"elasticsearch.openshift.io/loglevel": "", "elasticsearch.openshift.io/develLogAppender": "", "elasticsearch.openshift.io/esloglevel": ""}
+			Expect(getLogConfig(annotations).LogLevel).To(Equal("info"))
+			Expect(getLogConfig(annotations).ServerLoglevel).To(Equal("info"))
+			Expect(getLogConfig(annotations).ServerAppender).To(Equal("console"))
+		})
+		It("should return the value when annotation value is not empty", func() {
+			annotations := map[string]string{"elasticsearch.openshift.io/loglevel": "foo", "elasticsearch.openshift.io/develLogAppender": "bar", "elasticsearch.openshift.io/esloglevel": "xyz"}
+			Expect(getLogConfig(annotations).LogLevel).To(Equal("foo"))
+			Expect(getLogConfig(annotations).ServerLoglevel).To(Equal("xyz"))
+			Expect(getLogConfig(annotations).ServerAppender).To(Equal("bar"))
+		})
+	})
+})
 
 func TestSelectorsBothUndefined(t *testing.T) {
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"encoding/json"
 	"os"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
@@ -61,10 +62,13 @@ func DebugObject(sprintfMessage string, object interface{}) {
 }
 func init() {
 	level := os.Getenv("LOG_LEVEL")
+	if strings.TrimSpace(level) == "" {
+		return
+	}
 	parsed, err := logrus.ParseLevel(level)
 	if err != nil {
-		parsed = logrus.InfoLevel
-		logrus.Warnf("Unable to parse loglevel %q", level)
+		logrus.Warnf("Unable to parse LOG_LEVEL %q", level)
+		return
 	}
 	logrus.SetLevel(parsed)
 }

--- a/test/e2e-olm/elasticsearch_test.go
+++ b/test/e2e-olm/elasticsearch_test.go
@@ -162,6 +162,7 @@ func elasticsearchFullClusterTest(t *testing.T, f *framework.Framework, ctx *fra
 			Namespace: namespace,
 			Annotations: map[string]string{
 				"elasticsearch.openshift.io/develLogAppender": "console",
+				"elasticsearch.openshift.io/loglevel":         "trace",
 			},
 		},
 		Spec: elasticsearch.ElasticsearchSpec{


### PR DESCRIPTION
This PR adds the ability to configure the loglevel via an annotation so that we can get better log info while running tests.  It separates setting the loglevel of the security plugin from the rest of the server