### PR TITLE
Add virtual role for indexmanagement cronjobs

### DIFF
--- a/pkg/indexmanagement/scripts.go
+++ b/pkg/indexmanagement/scripts.go
@@ -7,10 +7,9 @@ code=$(curl "$ES_SERVICE/$POLICY_MAPPING-write/_rollover?pretty" \
   -w "%{response_code}" \
   -sv \
   --cacert /etc/indexmanagement/keys/admin-ca \
-  --cert /etc/indexmanagement/keys/admin-cert \
-  --key /etc/indexmanagement/keys/admin-key \
   -HContent-Type:application/json \
   -XPOST \
+  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
   -o /tmp/response.txt \
   -d $decoded)
 if [ "$code" == "200" ] ; then
@@ -24,8 +23,7 @@ set -euox pipefail
 
 indices=$(curl -s $ES_SERVICE/$ALIAS/_settings/index.creation_date \
   --cacert /etc/indexmanagement/keys/admin-ca \
-	--cert /etc/indexmanagement/keys/admin-cert \
-	--key /etc/indexmanagement/keys/admin-key \
+  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
   -HContent-Type:application/json)
 
 CMD=$(cat <<END
@@ -65,9 +63,8 @@ fi
 code=$(curl -sv $ES_SERVICE/${indices}?pretty \
   -w "%{response_code}" \
   --cacert /etc/indexmanagement/keys/admin-ca \
-  --cert /etc/indexmanagement/keys/admin-cert \
-  --key /etc/indexmanagement/keys/admin-key \
   -HContent-Type:application/json \
+  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
   -o /tmp/response.txt \
   -XDELETE )
 

--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -209,7 +209,7 @@ func newElasticsearchContainer(imageName string, envVars []v1.EnvVar, resourceRe
 	}
 }
 
-func newProxyContainer(imageName, clusterName string, logConfig LogConfig) (v1.Container, error) {
+func newProxyContainer(imageName, clusterName, namespace string, logConfig LogConfig) (v1.Container, error) {
 	cpuLimit, err := resource.ParseQuantity("100m")
 	if err != nil {
 		return v1.Container{}, err
@@ -265,6 +265,7 @@ func newProxyContainer(imageName, clusterName string, logConfig LogConfig) (v1.C
 			`--auth-backend-role=prometheus={"verb": "get", "resource": "/metrics"}`,
 			`--auth-backend-role=jaeger={"verb": "get", "resource": "/jaeger", "resourceAPIGroup": "elasticsearch.jaegertracing.io"}`,
 			`--auth-backend-role=elasticsearch-operator={"namespace": "*", "verb": "*", "resource": "*", "resourceAPIGroup": "logging.openshift.io"}`,
+			fmt.Sprintf("--auth-backend-role=index-management={\"namespace\":\"%s\", \"verb\": \"*\", \"resource\": \"indices\", \"resourceAPIGroup\": \"elasticsearch.openshift.io\"}", namespace),
 			`--cl-infra-role-name=sg_role_admin`,
 		},
 		Resources: v1.ResourceRequirements{
@@ -379,7 +380,7 @@ func newPodTemplateSpec(nodeName, clusterName, namespace string, node api.Elasti
 
 	resourceRequirements := newResourceRequirements(node.Resources, commonSpec.Resources)
 	proxyImage := utils.LookupEnvWithDefault("ELASTICSEARCH_PROXY", "quay.io/openshift/origin-elasticsearch-proxy:latest")
-	proxyContainer, _ := newProxyContainer(proxyImage, clusterName, logConfig)
+	proxyContainer, _ := newProxyContainer(proxyImage, clusterName, namespace, logConfig)
 
 	selectors := mergeSelectors(node.NodeSelector, commonSpec.NodeSelector)
 	// We want to make sure the pod ends up allocated on linux node. Thus we make sure the

--- a/pkg/k8shandler/common_test.go
+++ b/pkg/k8shandler/common_test.go
@@ -366,7 +366,7 @@ func TestProxyContainerResourcesDefined(t *testing.T) {
 	expectedCPU := resource.MustParse("100m")
 	expectedMemory := resource.MustParse("64Mi")
 
-	proxyContainer, err := newProxyContainer(imageName, clusterName, LogConfig{})
+	proxyContainer, err := newProxyContainer(imageName, clusterName, "openshift-logging", LogConfig{})
 	if err != nil {
 		t.Errorf("Failed to populate Proxy container: %v", err)
 	}
@@ -400,7 +400,7 @@ func TestProxyContainerTLSClientAuthDefined(t *testing.T) {
 	imageName := "openshift/elasticsearch-proxy:1.1"
 	clusterName := "elasticsearch"
 
-	proxyContainer, err := newProxyContainer(imageName, clusterName, LogConfig{})
+	proxyContainer, err := newProxyContainer(imageName, clusterName, "openshift-logging", LogConfig{})
 	if err != nil {
 		t.Errorf("Failed to populate Proxy container: %v", err)
 	}
@@ -435,7 +435,7 @@ func TestProxyContainerMetricsTLSDefined(t *testing.T) {
 	imageName := "openshift/elasticsearch-proxy:1.1"
 	clusterName := "elasticsearch"
 
-	proxyContainer, err := newProxyContainer(imageName, clusterName, LogConfig{})
+	proxyContainer, err := newProxyContainer(imageName, clusterName, "openshift-logging", LogConfig{})
 	if err != nil {
 		t.Errorf("Failed to populate Proxy container: %v", err)
 	}

--- a/pkg/k8shandler/rbac.go
+++ b/pkg/k8shandler/rbac.go
@@ -3,6 +3,7 @@ package k8shandler
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
@@ -10,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+	"github.com/openshift/elasticsearch-operator/pkg/types/k8s"
 	rbac "k8s.io/api/rbac/v1"
 	errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -122,7 +124,10 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateRBAC() error {
 
 	addOwnerRefToObject(proxyRoleBinding, owner)
 
-	return createOrUpdateClusterRoleBinding(proxyRoleBinding, elasticsearchRequest.client)
+	if err := createOrUpdateClusterRoleBinding(proxyRoleBinding, elasticsearchRequest.client); err != nil {
+		return err
+	}
+	return reconcileIndexManagmentRbac(dpl, owner, elasticsearchRequest.client)
 }
 
 func createOrUpdateClusterRole(role *rbac.ClusterRole, client client.Client) error {
@@ -140,6 +145,88 @@ func createOrUpdateClusterRole(role *rbac.ClusterRole, client client.Client) err
 			if updateErr := client.Update(context.TODO(), existingRole); updateErr != nil {
 				logrus.Debugf("failed to update ClusterRole %v status: %v", existingRole.Name, updateErr)
 				return updateErr
+			}
+			return nil
+		})
+	}
+	return nil
+}
+
+func reconcileIndexManagmentRbac(cluster *v1.Elasticsearch, owner metav1.OwnerReference, client client.Client) error {
+	role := k8s.NewRole(
+		"elasticsearch-index-management",
+		cluster.Namespace,
+		newPolicyRules(
+			newPolicyRule(
+				[]string{"elasticsearch.openshift.io"},
+				[]string{"indices"},
+				[]string{},
+				[]string{"*"},
+				[]string{},
+			),
+		),
+	)
+	addOwnerRefToObject(role, owner)
+	if err := reconcileRole(role, client); err != nil {
+		return err
+	}
+
+	subject := newSubject(
+		"ServiceAccount",
+		cluster.Name,
+		cluster.Namespace,
+	)
+	subject.APIGroup = ""
+	rolebinding := k8s.NewRoleBinding(
+		role.Name,
+		role.Namespace,
+		role.Name,
+		newSubjects(subject),
+	)
+	addOwnerRefToObject(rolebinding, owner)
+	return reconcileRoleBinding(rolebinding, client)
+}
+
+func reconcileRole(role *rbac.Role, client client.Client) error {
+	if err := client.Create(context.TODO(), role); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create Role %s/%s: %v", role.Namespace, role.Name, err)
+		}
+		current := &rbac.Role{}
+		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if getErr := client.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: role.Namespace}, current); getErr != nil {
+				logrus.Debugf("could not get Role %s/%s: %v", role.Namespace, role.Name, getErr)
+				return getErr
+			}
+			if !reflect.DeepEqual(current.Rules, role.Rules) {
+				logrus.Debugf("Updating Role %s/%s ...", role.Namespace, role.Name)
+				if updateErr := client.Update(context.TODO(), current); updateErr != nil {
+					logrus.Debugf("failed to update Role %s/%s: %v", role.Namespace, role.Name, updateErr)
+					return updateErr
+				}
+			}
+			return nil
+		})
+	}
+	return nil
+}
+func reconcileRoleBinding(rolebinding *rbac.RoleBinding, client client.Client) error {
+	if err := client.Create(context.TODO(), rolebinding); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create RoleBinding %s/%s: %v", rolebinding.Namespace, rolebinding.Name, err)
+		}
+		current := &rbac.RoleBinding{}
+		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if getErr := client.Get(context.TODO(), types.NamespacedName{Name: rolebinding.Name, Namespace: rolebinding.Namespace}, current); getErr != nil {
+				logrus.Debugf("could not get RoleBindng %s/%s: %v", rolebinding.Namespace, rolebinding.Name, getErr)
+				return getErr
+			}
+			if !reflect.DeepEqual(current.Subjects, rolebinding.Subjects) {
+				logrus.Debugf("Updating RoleBinding %s/%s ...", rolebinding.Namespace, rolebinding.Name)
+				if updateErr := client.Update(context.TODO(), current); updateErr != nil {
+					logrus.Debugf("failed to update RoleBinding %s/%s: %v", rolebinding.Namespace, rolebinding.Name, updateErr)
+					return updateErr
+				}
 			}
 			return nil
 		})

--- a/pkg/types/k8s/configmap.go
+++ b/pkg/types/k8s/configmap.go
@@ -1,4 +1,4 @@
-package factory
+package k8s
 
 import (
 	v1 "k8s.io/api/core/v1"

--- a/pkg/types/k8s/rbac.go
+++ b/pkg/types/k8s/rbac.go
@@ -1,0 +1,41 @@
+package k8s
+
+import (
+	rbac "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//NewRole stubs a role
+func NewRole(roleName, namespace string, rules []rbac.PolicyRule) *rbac.Role {
+	return &rbac.Role{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Role",
+			APIVersion: rbac.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: namespace,
+		},
+		Rules: rules,
+	}
+}
+
+//NewRoleBinding stubs a role binding
+func NewRoleBinding(bindingName, namespace, roleName string, subjects []rbac.Subject) *rbac.RoleBinding {
+	return &rbac.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RoleBinding",
+			APIVersion: rbac.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bindingName,
+			Namespace: namespace,
+		},
+		RoleRef: rbac.RoleRef{
+			Kind:     "Role",
+			Name:     roleName,
+			APIGroup: rbac.GroupName,
+		},
+		Subjects: subjects,
+	}
+}


### PR DESCRIPTION
This PR fixes IndexManagement crons to:

* utilize SA token
* Create role to a virtual resource for indexmanagent
* Configure proxy to evaluate role

cc @ewolinetz 

depends on https://github.com/openshift/origin-aggregated-logging/pull/1863