### PR TITLE
Fix missing GOROOT for CRD/API generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CURPATH=$(PWD)
 
+export GOROOT=$(shell go env GOROOT)
 export GOFLAGS=-mod=vendor
 export GO111MODULE=on
 export GOBIN=$(CURDIR)/bin


### PR DESCRIPTION
Generating k8s API code referencing the golang std library needs a reference to GOROOT (See https://github.com/operator-framework/operator-sdk/issues/1545).