### PR TITLE
Fixing kibana owner refs

### DIFF
--- a/pkg/k8shandler/kibana/rbac.go
+++ b/pkg/k8shandler/kibana/rbac.go
@@ -106,7 +106,7 @@ func (clusterRequest *KibanaRequest) CreateClusterRole(name string, rules []rbac
 		Rules: rules,
 	}
 
-	utils.AddOwnerRefToObject(clusterRole, utils.AsOwner(clusterRequest.cluster))
+	utils.AddOwnerRefToObject(clusterRole, getOwnerRef(clusterRequest.cluster))
 
 	err := clusterRequest.Create(clusterRole)
 	if err != nil && !errors.IsAlreadyExists(err) {

--- a/pkg/k8shandler/kibana/reconciler.go
+++ b/pkg/k8shandler/kibana/reconciler.go
@@ -213,7 +213,7 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaDeployment(proxyConfig 
 
 	kibanaDeployment.Spec.Template.ObjectMeta.Annotations = annotations
 
-	utils.AddOwnerRefToObject(kibanaDeployment, utils.AsOwner(clusterRequest.cluster))
+	utils.AddOwnerRefToObject(kibanaDeployment, getOwnerRef(clusterRequest.cluster))
 
 	err = clusterRequest.Create(kibanaDeployment)
 	if err != nil && !errors.IsAlreadyExists(err) {
@@ -393,7 +393,7 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaService() error {
 			}},
 		})
 
-	utils.AddOwnerRefToObject(kibanaService, utils.AsOwner(clusterRequest.cluster))
+	utils.AddOwnerRefToObject(kibanaService, getOwnerRef(clusterRequest.cluster))
 
 	err := clusterRequest.Create(kibanaService)
 	if err != nil && !errors.IsAlreadyExists(err) {
@@ -617,4 +617,15 @@ func createSharedConfig(namespace, kibanaAppURL, kibanaInfraURL string) *v1.Conf
 			"kibanaInfraURL": kibanaInfraURL,
 		},
 	)
+}
+
+func getOwnerRef(v *kibana.Kibana) metav1.OwnerReference {
+	trueVar := true
+	return metav1.OwnerReference{
+		APIVersion: kibana.SchemeGroupVersion.String(),
+		Kind:       "Kibana",
+		Name:       v.Name,
+		UID:        v.UID,
+		Controller: &trueVar,
+	}
 }

--- a/pkg/k8shandler/kibana/route.go
+++ b/pkg/k8shandler/kibana/route.go
@@ -87,7 +87,7 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaRoute() error {
 		utils.GetWorkingDirFilePath("ca.crt"),
 	)
 
-	utils.AddOwnerRefToObject(kibanaRoute, utils.AsOwner(cluster))
+	utils.AddOwnerRefToObject(kibanaRoute, getOwnerRef(cluster))
 
 	err := clusterRequest.Create(kibanaRoute)
 	if err != nil && !errors.IsAlreadyExists(err) {
@@ -100,7 +100,7 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaRoute() error {
 	}
 
 	sharedConfig := createSharedConfig(cluster.Namespace, kibanaURL, kibanaURL)
-	utils.AddOwnerRefToObject(sharedConfig, utils.AsOwner(cluster))
+	utils.AddOwnerRefToObject(sharedConfig, getOwnerRef(cluster))
 
 	err = clusterRequest.Create(sharedConfig)
 	if err != nil && !errors.IsAlreadyExists(err) {
@@ -120,7 +120,7 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaRoute() error {
 		),
 	)
 
-	utils.AddOwnerRefToObject(sharedRole, utils.AsOwner(clusterRequest.cluster))
+	utils.AddOwnerRefToObject(sharedRole, getOwnerRef(clusterRequest.cluster))
 
 	err = clusterRequest.Create(sharedRole)
 	if err != nil && !errors.IsAlreadyExists(err) {
@@ -139,7 +139,7 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaRoute() error {
 		),
 	)
 
-	utils.AddOwnerRefToObject(sharedRoleBinding, utils.AsOwner(clusterRequest.cluster))
+	utils.AddOwnerRefToObject(sharedRoleBinding, getOwnerRef(clusterRequest.cluster))
 
 	err = clusterRequest.Create(sharedRoleBinding)
 	if err != nil && !errors.IsAlreadyExists(err) {
@@ -172,7 +172,7 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaConsoleExternalLogLink(
 			""),
 	)
 
-	utils.AddOwnerRefToObject(consoleExternalLogLink, utils.AsOwner(cluster))
+	utils.AddOwnerRefToObject(consoleExternalLogLink, getOwnerRef(cluster))
 
 	// In case the object already exists we delete it first
 	if err = clusterRequest.RemoveConsoleExternalLogLink("kibana"); err != nil {

--- a/pkg/k8shandler/kibana/serviceaccount.go
+++ b/pkg/k8shandler/kibana/serviceaccount.go
@@ -40,7 +40,7 @@ func (clusterRequest *KibanaRequest) CreateOrUpdateServiceAccount(name string, a
 		}
 	}
 
-	utils.AddOwnerRefToObject(serviceAccount, utils.AsOwner(clusterRequest.cluster))
+	utils.AddOwnerRefToObject(serviceAccount, getOwnerRef(clusterRequest.cluster))
 
 	logger.DebugObject("Attempting to create serviceacccount %v", serviceAccount)
 	if err := clusterRequest.Create(serviceAccount); err != nil {

--- a/pkg/k8shandler/kibana/trustedcabundle.go
+++ b/pkg/k8shandler/kibana/trustedcabundle.go
@@ -25,7 +25,7 @@ func (clusterRequest *KibanaRequest) createOrUpdateTrustedCABundleConfigMap(conf
 	configMap.ObjectMeta.Labels = make(map[string]string)
 	configMap.ObjectMeta.Labels[constants.InjectTrustedCABundleLabel] = "true"
 
-	utils.AddOwnerRefToObject(configMap, utils.AsOwner(clusterRequest.cluster))
+	utils.AddOwnerRefToObject(configMap, getOwnerRef(clusterRequest.cluster))
 
 	err := clusterRequest.CreateOrUpdateTrustedCaBundleConfigMap(configMap)
 	return err


### PR DESCRIPTION
Looks like these were missed before...

ES currently:
```
  ownerReferences:
  - apiVersion: logging.openshift.io/v1
    controller: true
    kind: Elasticsearch
    name: elasticsearch
    uid: 6596d4f9-b8b8-4fee-b618-62ebca47f41e
```

Kibana currently:
```
  ownerReferences:
  - apiVersion: logging.openshift.io/v1
    controller: true
    kind: ClusterLogging
    name: instance
    uid: 017c1f4d-91dd-4a64-88ee-d65d880f34ad
```

Kibana with this change:
```
  ownerReferences:
  - apiVersion: logging.openshift.io/v1
    controller: true
    kind: Kibana
    name: instance
    uid: c321920e-7127-4574-9378-901fbb79d3aa
```