### PR TITLE
Omit helper tool downloads for ART build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ regenerate:
 	@rm -f $(GEN_TIMESTAMP)
 	@$(MAKE) generate
 
-build: fmt lint generate
+build: fmt
 	@go build -o $(GOBIN)/elasticsearch-operator $(MAIN_PKG)
 
 clean:


### PR DESCRIPTION
This PR removes any helper downloads on build to satisfy ART build process requirements and to prevent errors as seen here: openshift/cluster-logging-operator#436