### PR TITLE
Adjusting IM cj specs for namespace noise

### DIFF
--- a/pkg/indexmanagement/reconcile.go
+++ b/pkg/indexmanagement/reconcile.go
@@ -37,7 +37,7 @@ const (
 var (
 	defaultCPURequest      = resource.MustParse("100m")
 	defaultMemoryRequest   = resource.MustParse("32Mi")
-	jobHistoryLimitFailed  = utils.GetInt32(2)
+	jobHistoryLimitFailed  = utils.GetInt32(1)
 	jobHistoryLimitSuccess = utils.GetInt32(1)
 
 	millisPerSecond = uint64(1000)
@@ -324,6 +324,7 @@ func newCronJob(clusterName, image, namespace, name, schedule string, nodeSelect
 			Labels:    imLabels,
 		},
 		Spec: batch.CronJobSpec{
+			ConcurrencyPolicy:          batch.ForbidConcurrent,
 			SuccessfulJobsHistoryLimit: jobHistoryLimitSuccess,
 			FailedJobsHistoryLimit:     jobHistoryLimitFailed,
 			Schedule:                   schedule,


### PR DESCRIPTION
Minor tuning based on k8s docs:

Looking to adjust the amount of pods that are left behind, currently we see something like:
```
ocp-index-mgm-delete-app-1585950300-9rz25       0/1     Error     0          30m
ocp-index-mgm-delete-app-1585951200-7c9cx       0/1     Error     0          14m
ocp-index-mgm-delete-audit-1585950300-d9mct     0/1     Error     0          30m
ocp-index-mgm-delete-audit-1585951200-vsbq7     0/1     Error     0          14m
ocp-index-mgm-delete-infra-1585950300-gbkdw     0/1     Error     0          30m
ocp-index-mgm-delete-infra-1585951200-sz4lf     0/1     Error     0          14m
ocp-index-mgm-rollover-app-1585950300-dbzwm     0/1     Error     0          30m
ocp-index-mgm-rollover-app-1585951200-fpxlr     0/1     Error     0          14m
ocp-index-mgm-rollover-audit-1585950300-fmmxw   0/1     Error     0          30m
ocp-index-mgm-rollover-audit-1585951200-4npb8   0/1     Error     0          14m
ocp-index-mgm-rollover-infra-1585950300-j5d78   0/1     Error     0          30m
ocp-index-mgm-rollover-infra-1585951200-5x5lt   0/1     Error     0          14m
```
We can likely get away with one failure and one success so we know how the most recent run did.
Also turning off concurrency because we shouldn't have the same IM job run more than once at a time.

[1] https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy
[2] https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits