### PR TITLE
Kibana isn't tied to openshift-logging namespace anymore

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,7 +1,6 @@
 package constants
 
 const (
-	OpenshiftNS                = "openshift-logging"
 	ProxyName                  = "cluster"
 	TrustedCABundleKey         = "ca-bundle.crt"
 	TrustedCABundleMountDir    = "/etc/pki/ca-trust/extracted/pem/"
@@ -10,6 +9,7 @@ const (
 	TrustedCABundleHashName    = "logging.openshift.io/hash"
 	KibanaTrustedCAName        = "kibana-trusted-ca-bundle"
 	SecretHashPrefix           = "logging.openshift.io/"
+	KibanaInstanceName         = "instance"
 )
 
 var ReconcileForGlobalProxyList = []string{KibanaTrustedCAName}

--- a/pkg/controller/kibanasecret/controller.go
+++ b/pkg/controller/kibanasecret/controller.go
@@ -3,7 +3,6 @@ package kibanasecret
 import (
 	"time"
 
-	"github.com/openshift/elasticsearch-operator/pkg/constants"
 	"github.com/openshift/elasticsearch-operator/pkg/k8shandler/kibana"
 	"github.com/openshift/elasticsearch-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -80,5 +79,5 @@ func (r *ReconcileKibanaSecret) Reconcile(request reconcile.Request) (reconcile.
 
 // handleSecret returns true if meta namespace is "openshift-logging" and name is "kibana" or "kibana-proxy".
 func handleSecret(meta metav1.Object) bool {
-	return meta.GetNamespace() == constants.OpenshiftNS && utils.ContainsString([]string{"kibana", "kibana-proxy"}, meta.GetName())
+	return utils.ContainsString([]string{"kibana", "kibana-proxy"}, meta.GetName())
 }

--- a/pkg/controller/trustedcabundle/controller.go
+++ b/pkg/controller/trustedcabundle/controller.go
@@ -5,7 +5,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/elasticsearch-operator/pkg/constants"
-	kibana_handler "github.com/openshift/elasticsearch-operator/pkg/k8shandler/kibana"
+	kibanahandler "github.com/openshift/elasticsearch-operator/pkg/k8shandler/kibana"
 	"github.com/openshift/elasticsearch-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,7 +77,7 @@ type ReconcileTrustedCABundle struct {
 // When the user configured and/or system certs are updated, the pods are triggered to restart.
 func (r *ReconcileTrustedCABundle) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	if request.Name == constants.KibanaTrustedCAName {
-		if err := kibana_handler.ReconcileKibanaInstance(request, r.client); err != nil {
+		if err := kibanahandler.ReconcileKibanaInstance(request, r.client); err != nil {
 			// Failed to reconcile - requeuing.
 			return reconcileResult, err
 		}
@@ -88,5 +88,5 @@ func (r *ReconcileTrustedCABundle) Reconcile(request reconcile.Request) (reconci
 
 // handleConfigMap returns true if meta namespace is "openshift-logging".
 func handleConfigMap(meta metav1.Object) bool {
-	return meta.GetNamespace() == constants.OpenshiftNS && utils.ContainsString(constants.ReconcileForGlobalProxyList, meta.GetName())
+	return utils.ContainsString(constants.ReconcileForGlobalProxyList, meta.GetName())
 }

--- a/pkg/k8shandler/kibana/reconciler_test.go
+++ b/pkg/k8shandler/kibana/reconciler_test.go
@@ -19,13 +19,19 @@ import (
 )
 
 func TestNewKibanaPodSpecSetsProxyToUseServiceAccountAsOAuthClient(t *testing.T) {
-	cluster := &KibanaRequest{}
+	cluster := &KibanaRequest{
+		cluster: &kibana.Kibana{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+			},
+		},
+	}
 	spec := newKibanaPodSpec(cluster, "kibana", nil, nil)
 	for _, arg := range spec.Containers[1].Args {
 		keyValue := strings.Split(arg, "=")
 		if len(keyValue) >= 2 && keyValue[0] == "-client-id" {
-			if keyValue[1] != "system:serviceaccount:openshift-logging:kibana" {
-				t.Error("Exp. the proxy container arg 'client-id=system:serviceaccount:openshift-logging:kibana'")
+			if keyValue[1] != "system:serviceaccount:test-namespace:kibana" {
+				t.Error("Exp. the proxy container arg 'client-id=system:serviceaccount:test-namespace:kibana'")
 			}
 		}
 		if len(keyValue) >= 2 && keyValue[0] == "-scope" {
@@ -38,7 +44,13 @@ func TestNewKibanaPodSpecSetsProxyToUseServiceAccountAsOAuthClient(t *testing.T)
 
 func TestNewKibanaPodSpecWhenFieldsAreUndefined(t *testing.T) {
 
-	cluster := &KibanaRequest{}
+	cluster := &KibanaRequest{
+		cluster: &kibana.Kibana{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+			},
+		},
+	}
 	podSpec := newKibanaPodSpec(cluster, "test-app-name", nil, nil)
 
 	if len(podSpec.Containers) != 2 {
@@ -77,6 +89,9 @@ func TestNewKibanaPodSpecWhenResourcesAreDefined(t *testing.T) {
 	clusterRequest := &KibanaRequest{
 		client: nil,
 		cluster: &kibana.Kibana{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+			},
 			Spec: kibana.KibanaSpec{
 				Resources: newResourceRequirements("100Gi", "", "120Gi", "500m"),
 				ProxySpec: kibana.ProxySpec{
@@ -132,6 +147,9 @@ func TestNewKibanaPodSpecWhenNodeSelectorIsDefined(t *testing.T) {
 	clusterRequest := &KibanaRequest{
 		client: nil,
 		cluster: &kibana.Kibana{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+			},
 			Spec: kibana.KibanaSpec{
 				NodeSelector: expSelector,
 			},
@@ -152,6 +170,9 @@ func TestNewKibanaPodNoTolerations(t *testing.T) {
 	clusterRequest := &KibanaRequest{
 		client: nil,
 		cluster: &kibana.Kibana{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+			},
 			Spec: kibana.KibanaSpec{},
 		},
 	}
@@ -177,6 +198,9 @@ func TestNewKibanaPodWithTolerations(t *testing.T) {
 	clusterRequest := &KibanaRequest{
 		client: nil,
 		cluster: &kibana.Kibana{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+			},
 			Spec: kibana.KibanaSpec{
 				Tolerations: expTolerations,
 			},
@@ -196,6 +220,9 @@ func TestNewKibanaPodSpecWhenProxyConfigExists(t *testing.T) {
 	clusterRequest := &KibanaRequest{
 		client: nil,
 		cluster: &kibana.Kibana{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+			},
 			Spec: kibana.KibanaSpec{},
 		},
 	}


### PR DESCRIPTION
Changeset:
* TrustedCABundle controller isn't tied to `openshift-logging` namespace
* Kibana's ES path is now generated from the Kibana CR namespace
* Minor code fixes