### PR TITLE
Bug 1827063: Grant perm to set owner ref to metrics Service resource

### DIFF
--- a/manifests/4.5/elasticsearch-operator.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/elasticsearch-operator.v4.5.0.clusterserviceversion.yaml
@@ -220,6 +220,14 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          resourceNames:
+          - "elasticsearch-operator"
+          verbs:
+          - "update"
       deployments:
       - name: elasticsearch-operator
         spec:


### PR DESCRIPTION
This PR adds missing permissions to allow the operator to set the owner reference to the metrics service resource.

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1827063