### PR TITLE
Bug 1827690: Adding ImagePullBackOff condition to unschedulableNodes

### DIFF
--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -199,7 +199,8 @@ func getNodeUpgradeInProgress(cluster *api.Elasticsearch) NodeTypeInterface {
 
 func progressUnshedulableNodes(cluster *api.Elasticsearch) {
 	for _, node := range cluster.Status.Nodes {
-		if isPodUnschedulableConditionTrue(node.Conditions) {
+		if isPodUnschedulableConditionTrue(node.Conditions) ||
+			isPodImagePullBackOff(node.Conditions) {
 			for _, nodeTypeInterface := range nodes[nodeMapKey(cluster.Name, cluster.Namespace)] {
 				if node.DeploymentName == nodeTypeInterface.name() ||
 					node.StatefulSetName == nodeTypeInterface.name() {

--- a/pkg/k8shandler/status.go
+++ b/pkg/k8shandler/status.go
@@ -533,6 +533,11 @@ func isPodUnschedulableConditionTrue(conditions []api.ClusterCondition) bool {
 	return condition != nil && condition.Status == v1.ConditionTrue
 }
 
+func isPodImagePullBackOff(conditions []api.ClusterCondition) bool {
+	condition := getESNodeConditionWithReason(conditions, api.ESContainerWaiting, "ImagePullBackOff")
+	return condition != nil && condition.Status == v1.ConditionTrue
+}
+
 func getESNodeCondition(conditions []api.ClusterCondition, conditionType api.ClusterConditionType) (int, *api.ClusterCondition) {
 	if conditions == nil {
 		return -1, nil
@@ -543,6 +548,20 @@ func getESNodeCondition(conditions []api.ClusterCondition, conditionType api.Clu
 		}
 	}
 	return -1, nil
+}
+
+func getESNodeConditionWithReason(conditions []api.ClusterCondition, conditionType api.ClusterConditionType, conditionReason string) *api.ClusterCondition {
+	if conditions == nil {
+		return nil
+	}
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			if conditions[i].Reason == conditionReason {
+				return &conditions[i]
+			}
+		}
+	}
+	return nil
 }
 
 func updateESNodeCondition(status *api.ElasticsearchStatus, condition *api.ClusterCondition) bool {


### PR DESCRIPTION
Addresses: https://bugzilla.redhat.com/show_bug.cgi?id=1827690

When an ES node is unable to be ready due to `ImagePullBackOff` we weren't allowing it to be fixed outside of a normal cluster restart (which requires the cluster to be in a certain condition which it would never reach).

This functionality is similar to the condition that the pod is unschedulable