### PR TITLE
fix make deploy on 4.4

### DIFF
--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -8,21 +8,5 @@ IMAGE_TAG=$1
 IMAGE_BUILDER=${2:-imagebuilder}
 IMAGE_BUILDER_OPTS=${3:-}
 
-workdir=${WORKDIR:-$( mktemp --tmpdir -d elasticsearch-operator-build-XXXXXXXXXX )}
-if [ -z "${WORKDIR:-}" ] ; then
-    trap "rm -rf $workdir" EXIT
-fi
-
-if image_is_ubi Dockerfile ; then
-    pull_ubi_if_needed
-fi
-
-if image_needs_private_repo Dockerfile ; then
-    repodir=$( get_private_repo_dir $workdir )
-    mountarg="-mount $repodir:/etc/yum.repos.d/"
-else
-    mountarg=""
-fi
-
 echo building image $IMAGE_TAG - this may take a few minutes until you see any output . . .
-$IMAGE_BUILDER $IMAGE_BUILDER_OPTS $mountarg -t $IMAGE_TAG .
+podman build $IMAGE_BUILDER_OPTS -t $IMAGE_TAG .

--- a/hack/common
+++ b/hack/common
@@ -184,11 +184,11 @@ function login_to_registry() {
             username=kubeadmin
         fi
     fi
-    docker login -u "$username" -p "$token" "$1" > /dev/null
+    podman login --tls-verify=false -u "$username" -p "$token" "$1" > /dev/null
 }
 
 function push_image() {
-    skopeo copy --dest-tls-verify=false docker-daemon:"$1" docker://"$2"
+    podman push --tls-verify=false "$1" "$2"
 }
 
 if [ $REMOTE_REGISTRY = false ] ; then

--- a/hack/deploy-image.sh
+++ b/hack/deploy-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -euo pipefail
 
 if [ "${REMOTE_REGISTRY:-true}" = false ] ; then
     exit 0
@@ -31,13 +31,12 @@ if [ "${USE_IMAGE_STREAM:-false}" = true ] ; then
     exit 0
 fi
 
-IMAGE_TAGGER=${IMAGE_TAGGER:-docker tag}
 LOCAL_PORT=${LOCAL_PORT:-5000}
 
 image_tag=$( echo "$IMAGE_TAG" | sed -e 's,quay.io/,,' )
 tag=${tag:-"127.0.0.1:${LOCAL_PORT}/$image_tag"}
 
-${IMAGE_TAGGER} ${IMAGE_TAG} ${tag}
+podman tag ${IMAGE_TAG} ${tag}
 
 echo "Setting up port-forwarding to remote registry..."
 oc --loglevel=9 -n openshift-image-registry port-forward service/image-registry ${LOCAL_PORT}:5000 > pf.log 2>&1 &


### PR DESCRIPTION
This PR fixes the 4.4 `make deploy` target for our dev experience to depend on podman in light of our switch to rely on buildah