### PR TITLE
Bug 1809498: Remove selecting Elasticsearch image from CR

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -143,8 +143,8 @@ func main() {
 		log.Info(err.Error())
 	}
 
+	log.Info("This operator no longer honors the image specified by the custom resources so that it is able to properly coordinate the configuration with the image.")
 	log.Info("Starting the Cmd.")
-
 	// Start the Cmd
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
 		log.Error(err, "Manager exited non-zero")

--- a/manifests/4.5/kibanas.crd.yaml
+++ b/manifests/4.5/kibanas.crd.yaml
@@ -21,9 +21,6 @@ spec:
           type: object
           description: Specification of the desired behavior of the Kibana
           properties:
-            image:
-              type: string
-              description: Kibana image
             resources:
               type: object
               description: The resource requirements for Kibana
@@ -49,9 +46,6 @@ spec:
               type: object
               description: Specification of the Kibana Proxy component
               properties:
-                image:
-                  type: string
-                  description: Proxy image
                 resources:
                   type: object
                   description: The resource requirements for Kibana

--- a/pkg/apis/logging/v1/elasticsearch_types.go
+++ b/pkg/apis/logging/v1/elasticsearch_types.go
@@ -230,6 +230,7 @@ const (
 	ProxyContainerTerminated ClusterConditionType = "ProxyContainerTerminated"
 	Unschedulable            ClusterConditionType = "Unschedulable"
 	NodeStorage              ClusterConditionType = "NodeStorage"
+	CustomImage              ClusterConditionType = "CustomImageIgnored"
 )
 
 type ClusterEvent string

--- a/pkg/apis/logging/v1/kibana_types.go
+++ b/pkg/apis/logging/v1/kibana_types.go
@@ -8,7 +8,6 @@ import (
 // KibanaSpec defines the desired state of Kibana
 // +k8s:openapi-gen=true
 type KibanaSpec struct {
-	Image           string                   `json:"image"`
 	ManagementState ManagementState          `json:"managementState"`
 	Resources       *v1.ResourceRequirements `json:"resources"`
 	NodeSelector    map[string]string        `json:"nodeSelector,omitempty"`
@@ -18,7 +17,6 @@ type KibanaSpec struct {
 }
 
 type ProxySpec struct {
-	Image     string                   `json:"image"`
 	Resources *v1.ResourceRequirements `json:"resources"`
 }
 

--- a/pkg/controller/elasticsearch/controller.go
+++ b/pkg/controller/elasticsearch/controller.go
@@ -6,7 +6,9 @@ import (
 
 	loggingv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
 
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -83,6 +85,29 @@ func (r *ReconcileElasticsearch) Reconcile(request reconcile.Request) (reconcile
 
 	if cluster.Spec.ManagementState == loggingv1.ManagementStateUnmanaged {
 		return reconcile.Result{}, nil
+	}
+
+	if cluster.Spec.Spec.Image != "" {
+		if cluster.Status.Conditions == nil {
+			cluster.Status.Conditions = []loggingv1.ClusterCondition{}
+		}
+		exists := false
+		for _, condition := range cluster.Status.Conditions {
+			if condition.Type == loggingv1.CustomImage {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			cluster.Status.Conditions = append(cluster.Status.Conditions, loggingv1.ClusterCondition{
+				Type:               loggingv1.CustomImage,
+				Status:             v1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "CustomImageUnsupported",
+				Message:            "Specifiying a custom image from the customer resource is not supported",
+			})
+		}
+
 	}
 
 	if err = k8shandler.Reconcile(cluster, r.client); err != nil {

--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -25,12 +25,8 @@ func addOwnerRefToObject(o metav1.Object, r metav1.OwnerReference) {
 	}
 }
 
-func getImage(commonImage string) string {
-	image := commonImage
-	if image == "" {
-		image = utils.LookupEnvWithDefault("ELASTICSEARCH_IMAGE", constants.ElasticsearchDefaultImage)
-	}
-	return image
+func getImage() string {
+	return utils.LookupEnvWithDefault("ELASTICSEARCH_IMAGE", constants.ElasticsearchDefaultImage)
 }
 
 func getNodeRoleMap(node api.ElasticsearchNode) map[api.ElasticsearchNodeRole]bool {
@@ -374,7 +370,7 @@ func newPodTemplateSpec(nodeName, clusterName, namespace string, node api.Elasti
 			Affinity: newAffinity(roleMap),
 			Containers: []v1.Container{
 				newElasticsearchContainer(
-					getImage(commonSpec.Image),
+					getImage(),
 					newEnvVars(nodeName, clusterName, resourceRequirements.Limits.Memory().String(), roleMap),
 					resourceRequirements,
 				),

--- a/pkg/k8shandler/kibana/kibana_test.go
+++ b/pkg/k8shandler/kibana/kibana_test.go
@@ -37,7 +37,6 @@ var _ = Describe("Kibana", func() {
 				Namespace: "test-namespace",
 			},
 			Spec: kibana.KibanaSpec{
-				Image:           "hub/openshift/kibana:latest",
 				ManagementState: kibana.ManagementStateManaged,
 				Replicas:        2,
 			},

--- a/pkg/k8shandler/kibana/reconciler.go
+++ b/pkg/k8shandler/kibana/reconciler.go
@@ -443,20 +443,12 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaService() error {
 	return nil
 }
 
-func getImage(commonImage string) string {
-	image := commonImage
-	if image == "" {
-		image = utils.LookupEnvWithDefault("KIBANA_IMAGE", kibanaDefaultImage)
-	}
-	return image
+func getImage() string {
+	return utils.LookupEnvWithDefault("KIBANA_IMAGE", kibanaDefaultImage)
 }
 
-func getProxyImage(commonImage string) string {
-	image := commonImage
-	if image == "" {
-		image = utils.LookupEnvWithDefault("PROXY_IMAGE", kibanaProxyDefaultImage)
-	}
-	return image
+func getProxyImage() string {
+	return utils.LookupEnvWithDefault("PROXY_IMAGE", kibanaProxyDefaultImage)
 }
 
 func newKibanaPodSpec(cluster *KibanaRequest, elasticsearchName string, proxyConfig *configv1.Proxy,
@@ -476,7 +468,7 @@ func newKibanaPodSpec(cluster *KibanaRequest, elasticsearchName string, proxyCon
 		}
 	}
 
-	kibanaImage := getImage(visSpec.Image)
+	kibanaImage := getImage()
 	kibanaContainer := NewContainer(
 		"kibana",
 		kibanaImage,
@@ -528,7 +520,7 @@ func newKibanaPodSpec(cluster *KibanaRequest, elasticsearchName string, proxyCon
 		}
 	}
 
-	proxyImage := getProxyImage(visSpec.ProxySpec.Image)
+	proxyImage := getProxyImage()
 	kibanaProxyContainer := NewContainer(
 		"kibana-proxy",
 		proxyImage,


### PR DESCRIPTION
This PR removes choosing the ES image from the CR:
* The image should not be independent of the operator that is proving config
* ES CR provider could point to an ES5 image but operator only knows about ES6

https://bugzilla.redhat.com/show_bug.cgi?id=1809498