### PR TITLE
Bug 1809498: Adding logic to add alias for old indices to match new data structure

### DIFF
--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -17,6 +17,8 @@ import (
 var wrongConfig bool
 var nodes map[string][]NodeTypeInterface
 
+var aliasNeededMap map[string]bool
+
 func FlushNodes(clusterName, namespace string) {
 	nodes[nodeMapKey(clusterName, namespace)] = []NodeTypeInterface{}
 }
@@ -147,6 +149,19 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateElasticsearchClu
 					elasticsearchRequest.client,
 					int32(calculateReplicaCount(elasticsearchRequest.cluster))); err != nil {
 					logrus.Error(err)
+				}
+				if aliasNeededMap == nil {
+					aliasNeededMap = make(map[string]bool)
+				}
+				if val, ok := aliasNeededMap[nodeMapKey(elasticsearchRequest.cluster.Name, elasticsearchRequest.cluster.Namespace)]; !ok || val {
+					// add alias to old indices if they exist and don't have one
+					// this should be removed after one release...
+					successful := elasticsearchRequest.AddAliasForOldIndices()
+
+					if successful {
+						aliasNeededMap[nodeMapKey(elasticsearchRequest.cluster.Name, elasticsearchRequest.cluster.Namespace)] = false
+					}
+
 				}
 			}
 		}


### PR DESCRIPTION
This PR fixes changes from LOG-606 lost during merge or rebase 
Adding back in from bad merge.  Originally part of LOG-606

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1809498