### PR TITLE
Bug 1833145: Set network policy when doing upgrades to prevent connections

### DIFF
--- a/manifests/4.5/elasticsearch-operator.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/elasticsearch-operator.v4.5.0.clusterserviceversion.yaml
@@ -232,6 +232,13 @@ spec:
           - "elasticsearch-operator"
           verbs:
           - "update"
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
       deployments:
       - name: elasticsearch-operator
         spec:

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -350,6 +350,11 @@ func (node *deploymentNode) rollingRestart(upgradeStatus *api.ElasticsearchNodeS
 
 		if replicas > 0 {
 
+			if err := EnforceNetworkPolicy(node.self.Namespace, node.client, node.self.ObjectMeta.OwnerReferences); err != nil {
+				logrus.Warnf("Unable to create network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
+				return
+			}
+
 			// disable shard allocation
 			if ok, err := node.esClient.SetShardAllocation(api.ShardAllocationPrimaries); !ok {
 				logrus.Warnf("Unable to disable shard allocation: %v", err)
@@ -408,6 +413,11 @@ func (node *deploymentNode) rollingRestart(upgradeStatus *api.ElasticsearchNodeS
 	}
 
 	if upgradeStatus.UpgradeStatus.UpgradePhase == api.RecoveringData {
+
+		if err := RelaxNetworkPolicy(node.self.Namespace, node.client); err != nil {
+			logrus.Warnf("Unable to delete network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
+			return
+		}
 
 		if status, _ := node.esClient.GetClusterHealthStatus(); !utils.Contains(desiredClusterStates, status) {
 			logrus.Infof("Waiting for cluster to recover: %s / %v", status, desiredClusterStates)
@@ -497,6 +507,11 @@ func (node *deploymentNode) update(upgradeStatus *api.ElasticsearchNodeStatus) e
 	if upgradeStatus.UpgradeStatus.UpgradePhase == "" ||
 		upgradeStatus.UpgradeStatus.UpgradePhase == api.ControllerUpdated {
 
+		if err := EnforceNetworkPolicy(node.self.Namespace, node.client, node.self.ObjectMeta.OwnerReferences); err != nil {
+			logrus.Warnf("Unable to create network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
+			return err
+		}
+
 		// disable shard allocation
 		if ok, err := node.esClient.SetShardAllocation(api.ShardAllocationPrimaries); !ok {
 			logrus.Warnf("Unable to disable shard allocation: %v", err)
@@ -552,6 +567,11 @@ func (node *deploymentNode) update(upgradeStatus *api.ElasticsearchNodeStatus) e
 	}
 
 	if upgradeStatus.UpgradeStatus.UpgradePhase == api.RecoveringData {
+
+		if err := RelaxNetworkPolicy(node.self.Namespace, node.client); err != nil {
+			logrus.Warnf("Unable to delete network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
+			return err
+		}
 
 		if status, err := node.esClient.GetClusterHealthStatus(); !utils.Contains(desiredClusterStates, status) {
 			logrus.Infof("Waiting for cluster to recover: %s / %v", status, desiredClusterStates)

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -278,7 +278,10 @@ func (node *statefulSetNode) rollingRestart(upgradeStatus *api.ElasticsearchNode
 	if upgradeStatus.UpgradeStatus.UpgradePhase == "" ||
 		upgradeStatus.UpgradeStatus.UpgradePhase == api.ControllerUpdated {
 
-		// nothing to do here -- just maintaing a framework structure
+		if err := EnforceNetworkPolicy(node.self.Namespace, node.client, node.self.ObjectMeta.OwnerReferences); err != nil {
+			logrus.Warnf("Unable to create network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
+			return
+		}
 
 		upgradeStatus.UpgradeStatus.UpgradePhase = api.NodeRestarting
 	}
@@ -338,6 +341,11 @@ func (node *statefulSetNode) rollingRestart(upgradeStatus *api.ElasticsearchNode
 	}
 
 	if upgradeStatus.UpgradeStatus.UpgradePhase == api.RecoveringData {
+
+		if err := RelaxNetworkPolicy(node.self.Namespace, node.client); err != nil {
+			logrus.Warnf("Unable to delete network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
+			return
+		}
 
 		upgradeStatus.UpgradeStatus.UpgradePhase = api.ControllerUpdated
 		upgradeStatus.UpgradeStatus.UnderUpgrade = ""
@@ -486,6 +494,11 @@ func (node *statefulSetNode) update(upgradeStatus *api.ElasticsearchNodeStatus) 
 	if upgradeStatus.UpgradeStatus.UpgradePhase == "" ||
 		upgradeStatus.UpgradeStatus.UpgradePhase == api.ControllerUpdated {
 
+		if err := EnforceNetworkPolicy(node.self.Namespace, node.client, node.self.ObjectMeta.OwnerReferences); err != nil {
+			logrus.Warnf("Unable to create network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
+			return err
+		}
+
 		if err := node.executeUpdate(); err != nil {
 			return err
 		}
@@ -536,6 +549,11 @@ func (node *statefulSetNode) update(upgradeStatus *api.ElasticsearchNodeStatus) 
 	}
 
 	if upgradeStatus.UpgradeStatus.UpgradePhase == api.RecoveringData {
+
+		if err := RelaxNetworkPolicy(node.self.Namespace, node.client); err != nil {
+			logrus.Warnf("Unable to delete network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
+			return err
+		}
 
 		upgradeStatus.UpgradeStatus.UpgradePhase = api.ControllerUpdated
 		upgradeStatus.UpgradeStatus.UnderUpgrade = ""


### PR DESCRIPTION
This will allow the Elasticsearch Operator to prevent ingress traffic to the ES cluster on port 9200 from anywhere other than the Elasticsearch Operator pod itself.

This should assist in the upgrade process as we will be able to halt logs flowing in.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1833145