### PR TITLE
Bug 1834311: Fix trusted ca bundle and hash reconciliation

### DIFF
--- a/pkg/controller/proxyconfig/controller.go
+++ b/pkg/controller/proxyconfig/controller.go
@@ -63,7 +63,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 var _ reconcile.Reconciler = &ReconcileProxyConfig{}
 
-// ReconcileProxyConfig reconciles a ClusterLogging object
+//ReconcileProxyConfig reconciles the kibana resource
+//create or update events of the cluster proxy.
 type ReconcileProxyConfig struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver

--- a/pkg/controller/trustedcabundle/controller.go
+++ b/pkg/controller/trustedcabundle/controller.go
@@ -5,7 +5,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/elasticsearch-operator/pkg/constants"
-	kibanahandler "github.com/openshift/elasticsearch-operator/pkg/k8shandler/kibana"
+	"github.com/openshift/elasticsearch-operator/pkg/k8shandler/kibana"
 	"github.com/openshift/elasticsearch-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,7 +64,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 var _ reconcile.Reconciler = &ReconcileTrustedCABundle{}
 
-// ReconcileProxyConfig reconciles a ClusterLogging object
+//ReconcileTrustedCABundle reconciles the kibana resource on
+//creates or update events of the trusted CA bundle config map.
 type ReconcileTrustedCABundle struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
@@ -72,15 +73,12 @@ type ReconcileTrustedCABundle struct {
 	scheme *runtime.Scheme
 }
 
-// Reconcile reads that state of the trusted CA bundle configmap objects for the
-// collector and the visualization resources.
+// Reconcile reads that state of the trusted CA bundle configmap objects for Kibana resource.
 // When the user configured and/or system certs are updated, the pods are triggered to restart.
 func (r *ReconcileTrustedCABundle) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	if request.Name == constants.KibanaTrustedCAName {
-		if err := kibanahandler.ReconcileKibanaInstance(request, r.client); err != nil {
-			// Failed to reconcile - requeuing.
-			return reconcileResult, err
-		}
+	if err := kibana.ReconcileKibanaInstance(request, r.client); err != nil {
+		// Failed to reconcile - requeuing.
+		return reconcileResult, err
 	}
 
 	return reconcile.Result{}, nil


### PR DESCRIPTION
This PR addresses several issues on reconciliation of the trusted CA-Bundle config map as well the hash annotation on the Kibana deployment.

To address:
- https://bugzilla.redhat.com/show_bug.cgi?id=1834311
- https://bugzilla.redhat.com/show_bug.cgi?id=1833273

Needs backport to: release-4.4