### PR TITLE
Bug 1832125: Expose es-metrics svc target port in proxy container

### DIFF
--- a/hack/deploy-example-secrets.sh
+++ b/hack/deploy-example-secrets.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
-set -euo pipefail
 
-if [ -n "${DEBUG:-}" ]; then
-    set -x
-fi
+set -euo pipefail
 
 namespace=$1
 
@@ -12,7 +9,8 @@ oc -n $namespace create secret generic elasticsearch  \
 	--from-file=admin-key=/tmp/example-secrets/system.admin.key \
 	--from-file=admin-cert=/tmp/example-secrets/system.admin.crt \
 	--from-file=admin-ca=/tmp/example-secrets/ca.crt \
+	--from-file=/tmp/example-secrets/elasticsearch.key \
 	--from-file=/tmp/example-secrets/elasticsearch.crt \
 	--from-file=/tmp/example-secrets/logging-es.key \
-	--from-file=/tmp/example-secrets/logging-es.crt \
-	--from-file=/tmp/example-secrets/elasticsearch.key
+	--from-file=/tmp/example-secrets/logging-es.crt
+

--- a/hack/test-e2e-olm.sh
+++ b/hack/test-e2e-olm.sh
@@ -9,7 +9,7 @@ current_dir=$(dirname "${BASH_SOURCE[0]}" )
 source "${current_dir}/lib/init.sh"
 source "${current_dir}/lib/util/logs.sh"
 
-EXCLUDES="verify-es-metrics"
+EXCLUDES=" "
 for test in $( find "${current_dir}/testing-olm" -type f -name 'test-*.sh' | sort); do
 	if [[ ${test} =~ .*${EXCLUDES}.* ]] ; then
 		os::log::info "==============================================================="

--- a/hack/testing-olm/test-200-verify-es-metrics-access.sh
+++ b/hack/testing-olm/test-200-verify-es-metrics-access.sh
@@ -3,63 +3,73 @@
 # allowed to retrieve metrices from elasticsearch
 set -euo pipefail
 
-if [ -n "${DEBUG:-}" ]; then
-    set -x
-fi
-
 repo_dir="$(dirname $0)/../.."
 source "${repo_dir}/hack/testing-olm/utils"
-
-ARTIFACT_DIR=${ARTIFACT_DIR:-"$(pwd)/_output"}/$(basename ${BASH_SOURCE[0]})
-if [ ! -d $ARTIFACT_DIR ] ; then
-  mkdir -p $ARTIFACT_DIR
+ARTIFACT_DIR=${ARTIFACT_DIR:-"$(pwd)/_output"}
+test_artifact_dir=$ARTIFACT_DIR/$(basename ${BASH_SOURCE[0]})
+if [ ! -d $test_artifact_dir ] ; then
+  mkdir -p $test_artifact_dir
 fi
 
-TEST_NAMESPACE="${TEST_NAMESPACE:-e2e-test-${RANDOM}}"
 suffix=$RANDOM
+TEST_NAMESPACE="${TEST_NAMESPACE:-e2e-test-${suffix}}"
 UNAUTHORIZED_SA="unauthorized-sa-${suffix}"
 AUTHORIZED_SA="authorized-sa-${suffix}"
 CLUSTERROLE="prometheus-k8s-${suffix}"
 
-function cleanup() {
-    local result_code="$?"
-    set +e
-
-    if [ "${DO_CLEANUP:-true}" == "true" ] ; then  
-
-      oc -n ${TEST_NAMESPACE} exec $(oc ${TEST_NAMESPACE} get pods -l component=elasticsearch -o jsonpath={.items[0].metadata.name}) -c elasticsearch -- cat /tmp/metrics.txt ||: >$ARTIFACT_DIR/metrics.log
-      oc -n ${TEST_NAMESPACE} get configmap/elasticsearch  -o jsonpath={.data}> $ARTIFACT_DIR/configmap-elasticsearch.log 2>&1
-      get_all_logging_pod_logs ${TEST_NAMESPACE} $ARTIFACT_DIR
-
-      for name in "ns/openshift-operators-redhat" "ns/${TEST_NAMESPACE}" ; do
-          oc delete ${name}  > $ARTIFACT_DIR/cleanup.log 2>&1
-          try_until_failure "oc get ${name}" "$((1 * $minute))"
-      done
-      oc delete clusterrole ${CLUSTERROLE} >> $ARTIFACT_DIR/cleanup.log 2>&1 ||:
-      oc delete clusterrolebinding ${CLUSTERROLE} >> $ARTIFACT_DIR/cleanup.log 2>&1 ||:
-      oc delete clusterrolebinding view-${CLUSTERROLE} >> $ARTIFACT_DIR/cleanup.log 2>&1 ||:
-    fi
-    set -e
-    exit ${result_code}
+start_seconds=$(date +%s)
+cleanup(){
+  local return_code="$?"
+  set +e
+  log::info "Running cleanup"
+  end_seconds=$(date +%s)
+  runtime="$(($end_seconds - $start_seconds))s"
+  
+  if [ "${DO_CLEANUP:-true}" == "true" ] ; then
+    gather_logging_resources ${TEST_NAMESPACE} $test_artifact_dir
+    for item in "ns/${TEST_NAMESPACE}" "ns/openshift-operators-redhat"; do
+      oc delete $item --wait=true --ignore-not-found --force --grace-period=0
+    done
+    oc delete clusterrole ${CLUSTERROLE} >> $test_artifact_dir/cleanup.log 2>&1 ||:
+    oc delete clusterrolebinding ${CLUSTERROLE} >> $test_artifact_dir/cleanup.log 2>&1 ||:
+    oc delete clusterrolebinding view-${CLUSTERROLE} >> $test_artifact_dir/cleanup.log 2>&1 ||:
+  fi
+  
+  set -e
+  exit ${return_code}
 }
-trap cleanup EXIT
+trap cleanup exit
 
 if [ "${DO_SETUP:-true}" == "true" ] ; then
+  for item in "${TEST_NAMESPACE}" "openshift-operators-redhat" ; do
+    if oc get project ${item} > /dev/null 2>&1 ; then
+      echo using existing project ${item}
+    else
+      oc create namespace ${item}
+    fi
+  done
+
+  export ELASTICSEARCH_OPERATOR_NAMESPACE=${TEST_NAMESPACE}
   deploy_elasticsearch_operator
 
-  #deploy elasticsearch cluster
-  expect_success "oc -n ${TEST_NAMESPACE} create ns ${TEST_NAMESPACE}"
   expect_success "${repo_dir}/hack/deploy-example-secrets.sh  ${TEST_NAMESPACE}"
   expect_success "oc -n ${TEST_NAMESPACE} create -f ${repo_dir}/hack/cr.yaml"
-  
-  #wait for pod
-  wait_for_deployment_to_be_ready ${TEST_NAMESPACE} $(oc -n ${TEST_NAMESPACE} get deployment -l component=elasticsearch -o jsonpath={.items[0].metadata.name}) $((2 * $minute))
+
+  log::info "Waiting for elasticsearch-operator to deploy the cluster..."
+  try_until_success "oc -n ${TEST_NAMESPACE} get deployment -l component=elasticsearch -o jsonpath={.items[0].metadata.name})" $((2 * $minute))
+  expect_success "oc wait -n ${TEST_NAMESPACE} --timeout=240s --for=condition=available deployment -l component=elasticsearch"
+
 fi
 
-log::info Creating serviceaccounts to verify metrics
+log::info "------------------------------------------"
+log::info "Creating serviceaccounts to verify metrics"
+log::info "------------------------------------------"
 oc -n ${TEST_NAMESPACE} create serviceaccount ${UNAUTHORIZED_SA}
 oc -n ${TEST_NAMESPACE} create serviceaccount ${AUTHORIZED_SA}
 
+log::info "-------------------------------------------------------------"
+log::info "Creating RBAC for authorised serviceaccount to verify metrics"
+log::info "-------------------------------------------------------------"
 result=$(oc get clusterrole ${CLUSTERROLE} --ignore-not-found ||:)
 if [ "$result" == "" ] ; then
   echo "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\", \"kind\":\"ClusterRole\",\"metadata\":{\"name\":\"${CLUSTERROLE}\"},\"rules\":[{\"nonResourceURLs\":[\"/metrics\"],\"verbs\":[\"get\"]}]}" | oc create -f -
@@ -74,6 +84,10 @@ if [ "$result" == "" ] ; then
   log::info Binding ${AUTHORIZED_SA} to be cable of getting namespaces
   oc create clusterrolebinding --clusterrole=basic-user view-${CLUSTERROLE} --serviceaccount=${TEST_NAMESPACE}:${AUTHORIZED_SA}
 fi
+
+log::info "---------------------------------------------------------------"
+log::info "Creating RBAC for unauthorised serviceaccount to verify metrics"
+log::info "---------------------------------------------------------------"
 result=$(oc get clusterrolebinding view-${CLUSTERROLE}-unauth --ignore-not-found ||:)
 if [ "$result" == "" ] ; then
   log::info Binding ${UNAUTHORIZED_SA} to be cable of getting namespaces
@@ -82,21 +96,30 @@ fi
 
 es_pod=$(oc -n ${TEST_NAMESPACE} get pod -l component=elasticsearch -o jsonpath={.items[0].metadata.name})
 
+log::info "---------------------------------------------------------------"
+log::info "Waiting until elasticsearch cluster initialization is completed"
+log::info "---------------------------------------------------------------"
+try_until_success "oc -n ${TEST_NAMESPACE} exec ${es_pod} -c elasticsearch -- test -f /opt/app-root/src/init_complete" $((2 * $minute))
+
 push_test_script_to_es(){
   es_pod=$1
   token=$2
   service_ip=elasticsearch-metrics.${TEST_NAMESPACE}.svc
-  echo "curl -ks -o /tmp/metrics.txt https://${service_ip}:60000/_prometheus/metrics -H Authorization:'Bearer ${token}' -w '%{response_code}\n'" > /tmp/test
+  echo "curl -ks -o /tmp/metrics.txt https://${service_ip}:60001/_prometheus/metrics -H Authorization:'Bearer ${token}' -w '%{response_code}\n'" > /tmp/test
   expect_success "oc -n ${TEST_NAMESPACE} cp /tmp/test ${es_pod}:/tmp/test -c elasticsearch"
   expect_success "oc -n ${TEST_NAMESPACE} exec ${es_pod} -c elasticsearch -- chmod 777 /tmp/test"
 }
 
-log::info Checking ${UNAUTHORIZED_SA} ability to read metrics through metrics service
-token=$(oc -n ${TEST_NAMESPACE} serviceaccounts get-token $UNAUTHORIZED_SA)
-push_test_script_to_es $es_pod $token
-expect_success_and_text "oc -n ${TEST_NAMESPACE} exec ${es_pod} -c elasticsearch -- bash -c /tmp/test" '403'
-
-log::info Checking ${AUTHORIZED_SA} ability to read metrics
+log::info "---------------------------------------------------------------------------"
+log::info "Checking ${AUTHORIZED_SA} ability to read metrics through metrics service"
+log::info "---------------------------------------------------------------------------"
 token=$(oc -n ${TEST_NAMESPACE} serviceaccounts get-token $AUTHORIZED_SA)
 push_test_script_to_es $es_pod $token
 expect_success_and_text "oc -n ${TEST_NAMESPACE} exec ${es_pod} -c elasticsearch -- bash -c /tmp/test" '200'
+
+log::info "---------------------------------------------------------------------------"
+log::info "Checking ${UNAUTHORIZED_SA} ability to read metrics through metrics service"
+log::info "---------------------------------------------------------------------------"
+token=$(oc -n ${TEST_NAMESPACE} serviceaccounts get-token $UNAUTHORIZED_SA)
+push_test_script_to_es $es_pod $token
+expect_success_and_text "oc -n ${TEST_NAMESPACE} exec ${es_pod} -c elasticsearch -- bash -c /tmp/test" '403'

--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -197,6 +197,11 @@ func newProxyContainer(imageName, clusterName, namespace string, logConfig LogCo
 				ContainerPort: 60000,
 				Protocol:      v1.ProtocolTCP,
 			},
+			{
+				Name:          "metrics",
+				ContainerPort: 60001,
+				Protocol:      v1.ProtocolTCP,
+			},
 		},
 		Env: []v1.EnvVar{
 			{

--- a/pkg/k8shandler/service.go
+++ b/pkg/k8shandler/service.go
@@ -62,7 +62,7 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateServices() error
 		fmt.Sprintf("%s-%s", dpl.Name, "metrics"),
 		dpl.Namespace,
 		dpl.Name,
-		"restapi",
+		"metrics",
 		60001,
 		selectorForES("es-node-client", dpl.Name),
 		annotations,


### PR DESCRIPTION
This PR adds the missing elasticsearch-proxy container port for the elasticsearch-metrics service. In addition it re-enables the `verify-es-metrics` E2E test.

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1832125