### PR TITLE
Bug 1835903: Reindex kibana index for kibana6

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -11,7 +11,6 @@ const (
 	TrustedCABundleHashName    = "logging.openshift.io/hash"
 	KibanaTrustedCAName        = "kibana-trusted-ca-bundle"
 	SecretHashPrefix           = "logging.openshift.io/"
-	KibanaInstanceName         = "kibana"
 	ElasticsearchDefaultImage  = "quay.io/openshift/origin-logging-elasticsearch6"
 )
 

--- a/pkg/elasticsearch/cluster.go
+++ b/pkg/elasticsearch/cluster.go
@@ -7,6 +7,25 @@ import (
 	"strings"
 )
 
+func (ec *esClient) GetClusterNodeVersions() ([]string, error) {
+	payload := &EsRequest{
+		Method: http.MethodGet,
+		URI:    "_cluster/stats",
+	}
+
+	ec.fnSendEsRequest(ec.cluster, ec.namespace, payload, ec.k8sClient)
+
+	var nodeVersions []string
+	if versions := walkInterfaceMap("nodes.versions", payload.ResponseBody); versions != nil {
+		for _, value := range versions.([]interface{}) {
+			version := value.(string)
+			nodeVersions = append(nodeVersions, version)
+		}
+	}
+
+	return nodeVersions, nil
+}
+
 func (ec *esClient) GetThresholdEnabled() (bool, error) {
 
 	payload := &EsRequest{

--- a/pkg/elasticsearch/cluster_test.go
+++ b/pkg/elasticsearch/cluster_test.go
@@ -1,0 +1,52 @@
+package elasticsearch_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/elasticsearch-operator/test/helpers"
+)
+
+func TestGetClusterNodeVersion(t *testing.T) {
+	chatter := helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+		"_cluster/stats": {
+			{
+				StatusCode: 200,
+				Body:       `{"nodes": {"versions": ["6.8.1"]}}`,
+			},
+			{
+				StatusCode: 200,
+				Body:       `{"nodes": {"versions": ["6.8.1", "5.6.16"]}}`,
+			},
+		},
+	})
+	esClient := helpers.NewFakeElasticsearchClient("elasticsearch", "test-namespace", fakeClient, chatter)
+
+	tests := []struct {
+		desc string
+		want []string
+	}{
+		{
+			desc: "single version",
+			want: []string{"6.8.1"},
+		},
+		{
+			desc: "multiple version",
+			want: []string{"6.8.1", "5.6.16"},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			got, err := esClient.GetClusterNodeVersions()
+			if err != nil {
+				t.Errorf("got err: %s", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("got %#v, want %#v", got, test.want)
+			}
+		})
+	}
+
+}

--- a/pkg/elasticsearch/indices_test.go
+++ b/pkg/elasticsearch/indices_test.go
@@ -13,32 +13,38 @@ var (
 
 func TestAliasAllNeededPass(t *testing.T) {
 	chatter := testhelpers.NewFakeElasticsearchChatter(
-		map[string]testhelpers.FakeElasticsearchResponse{
+		map[string]testhelpers.FakeElasticsearchResponses{
 			"project.*,.operations.*/_alias": {
-				Error:      nil,
-				StatusCode: 200,
-				Body: `{
-                    "project.test": {
-                        "aliases": {}
-                    },
-                    ".operations.date": {
-                        "aliases": {}
-                    }
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 200,
+					Body: `{
+                      "project.test": {
+                          "aliases": {}
+                      },
+                      ".operations.date": {
+                          "aliases": {}
+                      }
+                    }`,
+				},
 			},
 			"project.test/_alias/app": {
-				Error:      nil,
-				StatusCode: 200,
-				Body: `{
-                    "acknowledged": true
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 200,
+					Body: `{
+                      "acknowledged": true
+                    }`,
+				},
 			},
 			".operations.date/_alias/infra": {
-				Error:      nil,
-				StatusCode: 200,
-				Body: `{
-                    "acknowledged": true
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 200,
+					Body: `{
+                      "acknowledged": true
+                    }`,
+				},
 			},
 		},
 	)
@@ -52,22 +58,26 @@ func TestAliasAllNeededPass(t *testing.T) {
 
 func TestAliasProjectNeededPass(t *testing.T) {
 	chatter := testhelpers.NewFakeElasticsearchChatter(
-		map[string]testhelpers.FakeElasticsearchResponse{
+		map[string]testhelpers.FakeElasticsearchResponses{
 			"project.*,.operations.*/_alias": {
-				Error:      nil,
-				StatusCode: 200,
-				Body: `{
-                    "project.test": {
-                        "aliases": {}
-                    }
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 200,
+					Body: `{
+                        "project.test": {
+                            "aliases": {}
+                        }
+                    }`,
+				},
 			},
 			"project.test/_alias/app": {
-				Error:      nil,
-				StatusCode: 200,
-				Body: `{
-                    "acknowledged": true
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 200,
+					Body: `{
+                        "acknowledged": true
+                    }`,
+				},
 			},
 		},
 	)
@@ -81,22 +91,26 @@ func TestAliasProjectNeededPass(t *testing.T) {
 
 func TestAliasOperationsNeededPass(t *testing.T) {
 	chatter := testhelpers.NewFakeElasticsearchChatter(
-		map[string]testhelpers.FakeElasticsearchResponse{
+		map[string]testhelpers.FakeElasticsearchResponses{
 			"project.*,.operations.*/_alias": {
-				Error:      nil,
-				StatusCode: 200,
-				Body: `{
-                    ".operations.date": {
-                        "aliases": {}
-                    }
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 200,
+					Body: `{
+                        ".operations.date": {
+                            "aliases": {}
+                        }
+                    }`,
+				},
 			},
 			".operations.date/_alias/infra": {
-				Error:      nil,
-				StatusCode: 200,
-				Body: `{
-                    "acknowledged": true
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 200,
+					Body: `{
+                        "acknowledged": true
+                    }`,
+				},
 			},
 		},
 	)
@@ -110,32 +124,38 @@ func TestAliasOperationsNeededPass(t *testing.T) {
 
 func TestAliasAllNeededFail(t *testing.T) {
 	chatter := testhelpers.NewFakeElasticsearchChatter(
-		map[string]testhelpers.FakeElasticsearchResponse{
+		map[string]testhelpers.FakeElasticsearchResponses{
 			"project.*,.operations.*/_alias": {
-				Error:      nil,
-				StatusCode: 200,
-				Body: `{
-                    "project.test": {
-                        "aliases": {}
-                    },
-                    ".operations.date": {
-                        "aliases": {}
-                    }
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 200,
+					Body: `{
+                        "project.test": {
+                            "aliases": {}
+                        },
+                        ".operations.date": {
+                            "aliases": {}
+                        }
+                    }`,
+				},
 			},
 			"project.test/_alias/app": {
-				Error:      nil,
-				StatusCode: 500,
-				Body: `{
-                    "acknowledged": false
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 500,
+					Body: `{
+                        "acknowledged": false
+                    }`,
+				},
 			},
 			".operations.date/_alias/infra": {
-				Error:      nil,
-				StatusCode: 500,
-				Body: `{
-                    "acknowledged": false
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 500,
+					Body: `{
+                        "acknowledged": false
+                    }`,
+				},
 			},
 		},
 	)
@@ -149,22 +169,26 @@ func TestAliasAllNeededFail(t *testing.T) {
 
 func TestAliasProjectNeededFail(t *testing.T) {
 	chatter := testhelpers.NewFakeElasticsearchChatter(
-		map[string]testhelpers.FakeElasticsearchResponse{
+		map[string]testhelpers.FakeElasticsearchResponses{
 			"project.*,.operations.*/_alias": {
-				Error:      nil,
-				StatusCode: 200,
-				Body: `{
-                    "project.test": {
-                        "aliases": {}
-                    }
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 200,
+					Body: `{
+                        "project.test": {
+                            "aliases": {}
+                        }
+                    }`,
+				},
 			},
 			"project.test/_alias/app": {
-				Error:      nil,
-				StatusCode: 500,
-				Body: `{
-                    "acknowledged": false
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 500,
+					Body: `{
+                        "acknowledged": false
+                    }`,
+				},
 			},
 		},
 	)
@@ -178,22 +202,26 @@ func TestAliasProjectNeededFail(t *testing.T) {
 
 func TestAliasOperationsNeededFail(t *testing.T) {
 	chatter := testhelpers.NewFakeElasticsearchChatter(
-		map[string]testhelpers.FakeElasticsearchResponse{
+		map[string]testhelpers.FakeElasticsearchResponses{
 			"project.*,.operations.*/_alias": {
-				Error:      nil,
-				StatusCode: 200,
-				Body: `{
-                    ".operations.date": {
-                        "aliases": {}
-                    }
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 200,
+					Body: `{
+                        ".operations.date": {
+                            "aliases": {}
+                        }
+                    }`,
+				},
 			},
 			".operations.date/_alias/infra": {
-				Error:      nil,
-				StatusCode: 500,
-				Body: `{
-                    "acknowledged": false
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 500,
+					Body: `{
+                        "acknowledged": false
+                    }`,
+				},
 			},
 		},
 	)
@@ -207,36 +235,42 @@ func TestAliasOperationsNeededFail(t *testing.T) {
 
 func TestAliasAllNotNeeded(t *testing.T) {
 	chatter := testhelpers.NewFakeElasticsearchChatter(
-		map[string]testhelpers.FakeElasticsearchResponse{
+		map[string]testhelpers.FakeElasticsearchResponses{
 			"project.*,.operations.*/_alias": {
-				Error:      nil,
-				StatusCode: 200,
-				Body: `{
-                    "project.test": {
-                        "aliases": {
-                            "app": {}
-                        }
-                    },
-                    ".operations.date": {
-                        "aliases": {
-                            "infra": {}
-                        }
-                    }
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 200,
+					Body: `{
+                       "project.test": {
+                           "aliases": {
+                               "app": {}
+                           }
+                       },
+                       ".operations.date": {
+                           "aliases": {
+                               "infra": {}
+                           }
+                       }
+                   }`,
+				},
 			},
 			"project.test/_alias/app": {
-				Error:      nil,
-				StatusCode: 500,
-				Body: `{
-                    "acknowledged": false
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 500,
+					Body: `{
+                        "acknowledged": false
+                    }`,
+				},
 			},
 			".operations.date/_alias/infra": {
-				Error:      nil,
-				StatusCode: 500,
-				Body: `{
-                    "acknowledged": false
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 500,
+					Body: `{
+                        "acknowledged": false
+                    }`,
+				},
 			},
 		},
 	)
@@ -250,24 +284,28 @@ func TestAliasAllNotNeeded(t *testing.T) {
 
 func TestAliasProjectNotNeeded(t *testing.T) {
 	chatter := testhelpers.NewFakeElasticsearchChatter(
-		map[string]testhelpers.FakeElasticsearchResponse{
+		map[string]testhelpers.FakeElasticsearchResponses{
 			"project.*,.operations.*/_alias": {
-				Error:      nil,
-				StatusCode: 200,
-				Body: `{
-                    "project.test": {
-                        "aliases": {
-                            "app": {}
+				{
+					Error:      nil,
+					StatusCode: 200,
+					Body: `{
+                        "project.test": {
+                            "aliases": {
+                                "app": {}
+                            }
                         }
-                    }
-                }`,
+                    }`,
+				},
 			},
 			"project.test/_alias/app": {
-				Error:      nil,
-				StatusCode: 500,
-				Body: `{
-                    "acknowledged": false
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 500,
+					Body: `{
+                        "acknowledged": false
+                    }`,
+				},
 			},
 		},
 	)
@@ -281,24 +319,28 @@ func TestAliasProjectNotNeeded(t *testing.T) {
 
 func TestAliasOperationsNotNeeded(t *testing.T) {
 	chatter := testhelpers.NewFakeElasticsearchChatter(
-		map[string]testhelpers.FakeElasticsearchResponse{
+		map[string]testhelpers.FakeElasticsearchResponses{
 			"project.*,.operations.*/_alias": {
-				Error:      nil,
-				StatusCode: 200,
-				Body: `{
-                    ".operations.date": {
-                        "aliases": {
-                            "infra": {}
+				{
+					Error:      nil,
+					StatusCode: 200,
+					Body: `{
+                        ".operations.date": {
+                            "aliases": {
+                                "infra": {}
+                            }
                         }
-                    }
-                }`,
+                    }`,
+				},
 			},
 			".operations.date/_alias/infra": {
-				Error:      nil,
-				StatusCode: 500,
-				Body: `{
-                    "acknowledged": false
-                }`,
+				{
+					Error:      nil,
+					StatusCode: 500,
+					Body: `{
+                        "acknowledged": false
+                    }`,
+				},
 			},
 		},
 	)

--- a/pkg/elasticsearch/templates_test.go
+++ b/pkg/elasticsearch/templates_test.go
@@ -19,11 +19,13 @@ var (
 
 func TestCreateIndexTemplateWhenError(t *testing.T) {
 	chatter := testhelpers.NewFakeElasticsearchChatter(
-		map[string]testhelpers.FakeElasticsearchResponse{
+		map[string]testhelpers.FakeElasticsearchResponses{
 			"_template/foo": {
-				Error:      fmt.Errorf("test error %s", t.Name()),
-				StatusCode: http.StatusInternalServerError,
-				Body:       "{}",
+				{
+					Error:      fmt.Errorf("test error %s", t.Name()),
+					StatusCode: http.StatusInternalServerError,
+					Body:       "{}",
+				},
 			},
 		})
 	esClient := testhelpers.NewFakeElasticsearchClient(cluster, namespace, k8sClient, chatter)
@@ -35,11 +37,13 @@ func TestCreateIndexTemplateWhenError(t *testing.T) {
 
 func TestCreateIndexTemplateWhenResponseNot200(t *testing.T) {
 	chatter := testhelpers.NewFakeElasticsearchChatter(
-		map[string]testhelpers.FakeElasticsearchResponse{
+		map[string]testhelpers.FakeElasticsearchResponses{
 			"_template/foo": {
-				Error:      nil,
-				StatusCode: 500,
-				Body:       "{}",
+				{
+					Error:      nil,
+					StatusCode: 500,
+					Body:       "{}",
+				},
 			},
 		})
 	esClient := testhelpers.NewFakeElasticsearchClient(cluster, namespace, k8sClient, chatter)
@@ -51,11 +55,13 @@ func TestCreateIndexTemplateWhenResponseNot200(t *testing.T) {
 
 func TestCreateIndexTemplateWhenResponse200(t *testing.T) {
 	chatter := testhelpers.NewFakeElasticsearchChatter(
-		map[string]testhelpers.FakeElasticsearchResponse{
+		map[string]testhelpers.FakeElasticsearchResponses{
 			"_template/foo": {
-				Error:      nil,
-				StatusCode: 200,
-				Body:       "{}",
+				{
+					Error:      nil,
+					StatusCode: 200,
+					Body:       "{}",
+				},
 			},
 		})
 	esClient := testhelpers.NewFakeElasticsearchClient(cluster, namespace, k8sClient, chatter)
@@ -67,11 +73,13 @@ func TestCreateIndexTemplateWhenResponse200(t *testing.T) {
 
 func TestCreateIndexTemplateWhenResponse201(t *testing.T) {
 	chatter := testhelpers.NewFakeElasticsearchChatter(
-		map[string]testhelpers.FakeElasticsearchResponse{
+		map[string]testhelpers.FakeElasticsearchResponses{
 			"_template/foo": {
-				Error:      nil,
-				StatusCode: 201,
-				Body:       "{}",
+				{
+					Error:      nil,
+					StatusCode: 201,
+					Body:       "{}",
+				},
 			},
 		})
 	esClient := testhelpers.NewFakeElasticsearchClient(cluster, namespace, k8sClient, chatter)

--- a/pkg/k8shandler/cr.go
+++ b/pkg/k8shandler/cr.go
@@ -1,0 +1,24 @@
+package k8shandler
+
+import (
+	"context"
+	"fmt"
+
+	loggingv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetElasticsearchCR(c client.Client, ns string) (*loggingv1.Elasticsearch, error) {
+	esl := &loggingv1.ElasticsearchList{}
+	opts := &client.ListOptions{Namespace: ns}
+
+	if err := c.List(context.TODO(), opts, esl); err != nil {
+		return nil, fmt.Errorf("failed to find elasticsearch instance in %q: %s", ns, err)
+	}
+
+	if len(esl.Items) == 0 {
+		return nil, fmt.Errorf("failed to find elasticsearch instance in %q: empty result set", ns)
+	}
+
+	return &esl.Items[0], nil
+}

--- a/pkg/k8shandler/kibana/kibanarequest.go
+++ b/pkg/k8shandler/kibana/kibanarequest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	kibana "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+	"github.com/openshift/elasticsearch-operator/pkg/elasticsearch"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -12,8 +13,9 @@ import (
 )
 
 type KibanaRequest struct {
-	client  client.Client
-	cluster *kibana.Kibana
+	client   client.Client
+	cluster  *kibana.Kibana
+	esClient elasticsearch.Client
 }
 
 // TODO: determine if this is even necessary

--- a/pkg/k8shandler/migrations/kibana5to6.go
+++ b/pkg/k8shandler/migrations/kibana5to6.go
@@ -1,0 +1,452 @@
+package migrations
+
+import (
+	"encoding/json"
+	"fmt"
+
+	estypes "github.com/openshift/elasticsearch-operator/pkg/types/elasticsearch"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	kibanaIndex         = ".kibana"
+	kibana6Index        = ".kibana-6"
+	kibana5to6EsVersion = "6"
+)
+
+func (mr *migrationRequest) reIndexKibana5to6() error {
+	ok, err := mr.matchRequiredMajorVersion(kibana5to6EsVersion)
+	if err != nil {
+		return err
+	}
+
+	if !ok {
+		return fmt.Errorf("skipping migration not all nodes match min required versions %q", kibana5to6EsVersion)
+	}
+
+	if mr.migrationCompleted() {
+		logrus.Infof("migration completed: re-indexing %q to %q", kibanaIndex, kibana6Index)
+		return nil
+	}
+
+	if err := mr.setKibanaIndexReadOnly(); err != nil {
+		return err
+	}
+
+	if err := mr.createNewKibana6Index(); err != nil {
+		return err
+	}
+
+	if err := mr.reIndexIntoKibana6(); err != nil {
+		return err
+	}
+
+	if err := mr.aliasKibana(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (mr *migrationRequest) migrationCompleted() bool {
+	indices, err := mr.esClient.ListIndicesForAlias(kibanaIndex)
+	if err != nil {
+		logrus.Errorf("failed to list indices for alias %q: %s", kibanaIndex, err)
+		return false
+	}
+
+	return len(indices) != 0
+}
+
+func (mr *migrationRequest) setKibanaIndexReadOnly() error {
+	curSett, err := mr.esClient.GetIndexSettings(kibanaIndex)
+	if err != nil {
+		return fmt.Errorf("failed to get index settings for %q: %s", kibanaIndex, err)
+	}
+
+	if curSett != nil {
+		if curSett.Index != nil {
+			if curSett.Index.Blocks.Write {
+				logrus.Infof("skipping setting index %q to read-only because already completed", kibanaIndex)
+				return nil
+			}
+		}
+	}
+
+	settings := &estypes.IndexSettings{
+		Index: &estypes.IndexingSettings{
+			Blocks: &estypes.IndexBlocksSettings{
+				Write: true,
+			},
+		},
+	}
+
+	if err := mr.esClient.UpdateIndexSettings(kibanaIndex, settings); err != nil {
+		return fmt.Errorf("failed to set index %q to read only: %s", kibanaIndex, err)
+	}
+	return nil
+}
+
+func (mr *migrationRequest) createNewKibana6Index() error {
+	curIndex, err := mr.esClient.GetIndex(kibana6Index)
+	if err != nil {
+		return fmt.Errorf("failed to get index for %q: %s", kibana6Index, err)
+	}
+
+	if curIndex != nil {
+		if curIndex.Name == kibana6Index {
+			logrus.Infof("skipping creating index %q anew because already existing", kibana6Index)
+			return nil
+		}
+	}
+
+	mappings := make(map[string]interface{})
+	err = json.Unmarshal([]byte(kibana6IndexMappings), &mappings)
+	if err != nil {
+		return fmt.Errorf("failed to read kibana 6 mappings: %s", err)
+	}
+
+	index := &estypes.Index{
+		Name: kibana6Index,
+		Settings: estypes.IndexSettings{
+			NumberOfShards: 1,
+			Index: &estypes.IndexingSettings{
+				Format: 6,
+				Mapper: &estypes.IndexMapperSettings{
+					Dynamic: false,
+				},
+			},
+		},
+		Mappings: mappings,
+	}
+
+	if err := mr.esClient.CreateIndex(kibana6Index, index); err != nil {
+		return fmt.Errorf("failed to create new index %q: %s", kibana6Index, err)
+	}
+	return nil
+}
+
+func (mr *migrationRequest) reIndexIntoKibana6() error {
+	indices, err := mr.esClient.GetAllIndices(kibana6Index)
+	if err != nil {
+		return fmt.Errorf("failed fetching doc count for %q before re-indexing: %s", kibana6Index, err)
+	}
+
+	var index *estypes.CatIndicesResponse
+	for _, idx := range indices {
+		if idx.Index == kibana6Index {
+			index = &idx
+			break
+		}
+	}
+
+	if index == nil {
+		return fmt.Errorf("failed fetching doc count for index %q: index not found", kibana6Index)
+	}
+
+	if index.DocsCount != "0" {
+		logrus.Infof("skipping re-indexing %q to %q because already completed", kibanaIndex, kibana6Index)
+		return nil
+	}
+
+	err = mr.esClient.ReIndex(kibanaIndex, kibana6Index, kibanReIndexScript, "painless")
+	if err != nil {
+		return fmt.Errorf("failed to reindex kibana6: %s", err)
+	}
+	return nil
+}
+
+func (mr *migrationRequest) aliasKibana() error {
+	if mr.migrationCompleted() {
+		logrus.Infof("skipping aliasing %q to %q because alias existing", kibanaIndex, kibana6Index)
+		return nil
+	}
+
+	actions := estypes.AliasActions{
+		Actions: []estypes.AliasAction{
+			{
+				Add: &estypes.AddAliasAction{
+					Index: kibana6Index,
+					Alias: kibanaIndex,
+				},
+			},
+			{
+				RemoveIndex: &estypes.RemoveAliasAction{
+					Index: kibanaIndex,
+				},
+			},
+		},
+	}
+
+	if err := mr.esClient.UpdateAlias(actions); err != nil {
+		return fmt.Errorf("failed to change alias %s to %s: %s", kibanaIndex, kibana6Index, err)
+	}
+	return nil
+}
+
+const (
+	kibanReIndexScript = `
+ctx._source = [ ctx._type : ctx._source ]; ctx._source.type = ctx._type; ctx._id = ctx._type + ":" + ctx._id; ctx._type = "doc";
+`
+
+	kibana6IndexMappings = `
+{
+  "doc": {
+    "properties": {
+      "type": {
+        "type": "keyword"
+      },
+      "updated_at": {
+        "type": "date"
+      },
+      "config": {
+        "properties": {
+          "buildNum": {
+            "type": "keyword"
+          }
+        }
+      },
+      "index-pattern": {
+        "properties": {
+          "fieldFormatMap": {
+            "type": "text"
+          },
+          "fields": {
+            "type": "text"
+          },
+          "intervalName": {
+            "type": "keyword"
+          },
+          "notExpandable": {
+            "type": "boolean"
+          },
+          "sourceFilters": {
+            "type": "text"
+          },
+          "timeFieldName": {
+            "type": "keyword"
+          },
+          "title": {
+            "type": "text"
+          }
+        }
+      },
+      "visualization": {
+        "properties": {
+          "description": {
+            "type": "text"
+          },
+          "kibanaSavedObjectMeta": {
+            "properties": {
+              "searchSourceJSON": {
+                "type": "text"
+              }
+            }
+          },
+          "savedSearchId": {
+            "type": "keyword"
+          },
+          "title": {
+            "type": "text"
+          },
+          "uiStateJSON": {
+            "type": "text"
+          },
+          "version": {
+            "type": "integer"
+          },
+          "visState": {
+            "type": "text"
+          }
+        }
+      },
+      "search": {
+        "properties": {
+          "columns": {
+            "type": "keyword"
+          },
+          "description": {
+            "type": "text"
+          },
+          "hits": {
+            "type": "integer"
+          },
+          "kibanaSavedObjectMeta": {
+            "properties": {
+              "searchSourceJSON": {
+                "type": "text"
+              }
+            }
+          },
+          "sort": {
+            "type": "keyword"
+          },
+          "title": {
+            "type": "text"
+          },
+          "version": {
+            "type": "integer"
+          }
+        }
+      },
+      "dashboard": {
+        "properties": {
+          "description": {
+            "type": "text"
+          },
+          "hits": {
+            "type": "integer"
+          },
+          "kibanaSavedObjectMeta": {
+            "properties": {
+              "searchSourceJSON": {
+                "type": "text"
+              }
+            }
+          },
+          "optionsJSON": {
+            "type": "text"
+          },
+          "panelsJSON": {
+            "type": "text"
+          },
+          "refreshInterval": {
+            "properties": {
+              "display": {
+                "type": "keyword"
+              },
+              "pause": {
+                "type": "boolean"
+              },
+              "section": {
+                "type": "integer"
+              },
+              "value": {
+                "type": "integer"
+              }
+            }
+          },
+          "timeFrom": {
+            "type": "keyword"
+          },
+          "timeRestore": {
+            "type": "boolean"
+          },
+          "timeTo": {
+            "type": "keyword"
+          },
+          "title": {
+            "type": "text"
+          },
+          "uiStateJSON": {
+            "type": "text"
+          },
+          "version": {
+            "type": "integer"
+          }
+        }
+      },
+      "url": {
+        "properties": {
+          "accessCount": {
+            "type": "long"
+          },
+          "accessDate": {
+            "type": "date"
+          },
+          "createDate": {
+            "type": "date"
+          },
+          "url": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 2048
+              }
+            }
+          }
+        }
+      },
+      "server": {
+        "properties": {
+          "uuid": {
+            "type": "keyword"
+          }
+        }
+      },
+      "timelion-sheet": {
+        "properties": {
+          "description": {
+            "type": "text"
+          },
+          "hits": {
+            "type": "integer"
+          },
+          "kibanaSavedObjectMeta": {
+            "properties": {
+              "searchSourceJSON": {
+                "type": "text"
+              }
+            }
+          },
+          "timelion_chart_height": {
+            "type": "integer"
+          },
+          "timelion_columns": {
+            "type": "integer"
+          },
+          "timelion_interval": {
+            "type": "keyword"
+          },
+          "timelion_other_interval": {
+            "type": "keyword"
+          },
+          "timelion_rows": {
+            "type": "integer"
+          },
+          "timelion_sheet": {
+            "type": "text"
+          },
+          "title": {
+            "type": "text"
+          },
+          "version": {
+            "type": "integer"
+          }
+        }
+      },
+      "graph-workspace": {
+        "properties": {
+          "description": {
+            "type": "text"
+          },
+          "kibanaSavedObjectMeta": {
+            "properties": {
+              "searchSourceJSON": {
+                "type": "text"
+              }
+            }
+          },
+          "numLinks": {
+            "type": "integer"
+          },
+          "numVertices": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "text"
+          },
+          "version": {
+            "type": "integer"
+          },
+          "wsState": {
+            "type": "text"
+          }
+        }
+      }
+    }
+  }
+}
+`
+)

--- a/pkg/k8shandler/migrations/kibana5to6_test.go
+++ b/pkg/k8shandler/migrations/kibana5to6_test.go
@@ -1,0 +1,650 @@
+package migrations
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/elasticsearch-operator/pkg/elasticsearch"
+	"github.com/openshift/elasticsearch-operator/test/helpers"
+
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Migrating", func() {
+	defer GinkgoRecover()
+
+	var (
+		chatter   *helpers.FakeElasticsearchChatter
+		client    elasticsearch.Client
+		k8sClient kclient.Client = fake.NewFakeClient()
+	)
+
+	const (
+		esCluster   = "elasticsearch"
+		esNamespace = "openshift-logging"
+	)
+
+	Describe("index `.kibana` into `.kibana-6`", func() {
+
+		Context("updating the settings of the old `.kibana` index", func() {
+			It("should sets it index to read only", func() {
+				chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+					".kibana/_settings": {
+						{
+							StatusCode: 200,
+							Body:       `{"index": {"blocks": {"write": false}}}`,
+						},
+						{
+							StatusCode: 200,
+							Body:       "{}",
+						},
+					},
+				})
+				client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+				kr := migrationRequest{
+					client:   k8sClient,
+					esClient: client,
+				}
+
+				Expect(kr.setKibanaIndexReadOnly()).Should(Succeed())
+
+				// Get Index settings first
+				req, found := chatter.GetRequest(".kibana/_settings")
+				Expect(found).To(BeTrue())
+				Expect(req.Method).To(Equal(http.MethodGet))
+
+				// Update Index settings
+				req, found = chatter.GetRequest(".kibana/_settings")
+				Expect(found).To(BeTrue())
+				Expect(req.Method).To(Equal(http.MethodPut))
+				Expect(req.Body).Should(MatchJSON(expectedKibanaROPayload))
+			})
+
+			It("should skip updating the settings if already read-only", func() {
+				chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+					".kibana/_settings": {
+						{
+							StatusCode: 200,
+							Body:       `{"index": {"blocks": {"write": true}}}`,
+						},
+					},
+				})
+				client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+				kr := migrationRequest{
+					client:   k8sClient,
+					esClient: client,
+				}
+
+				Expect(kr.setKibanaIndexReadOnly()).Should(Succeed())
+
+				// Get Index settings first
+				req, found := chatter.GetRequest(".kibana/_settings")
+				Expect(found).To(BeTrue())
+				Expect(req.Method).To(Equal(http.MethodGet))
+				Expect(req.Body).To(BeEmpty())
+			})
+		})
+
+		Context("creating the new index `.kibana-6`", func() {
+			It("should succeed if not existing", func() {
+				chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+					".kibana-6": {
+						{
+							StatusCode: 404,
+							Body:       `{}`,
+						},
+						{
+							StatusCode: 200,
+							Body:       "{}",
+						},
+					},
+				})
+				client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+				kr := migrationRequest{
+					client:   k8sClient,
+					esClient: client,
+				}
+
+				Expect(kr.createNewKibana6Index()).Should(Succeed())
+
+				// Check if index exists
+				req, found := chatter.GetRequest(".kibana-6")
+				Expect(found).To(BeTrue())
+				Expect(req.Method).To(Equal(http.MethodGet))
+
+				req, found = chatter.GetRequest(".kibana-6")
+				Expect(found).To(BeTrue())
+				Expect(req.Method).To(Equal(http.MethodPut))
+				Expect(req.Body).Should(MatchJSON(expectedKibana6Payload))
+			})
+
+			It("should skip if index existing", func() {
+				chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+					".kibana-6": {
+						{
+							StatusCode: 200,
+							Body:       `{"Settings": {}}`,
+						},
+					},
+				})
+				client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+				kr := migrationRequest{
+					client:   k8sClient,
+					esClient: client,
+				}
+
+				Expect(kr.createNewKibana6Index()).Should(Succeed())
+
+				// Check if index exists
+				req, found := chatter.GetRequest(".kibana-6")
+				Expect(found).To(BeTrue())
+				Expect(req.Method).To(Equal(http.MethodGet))
+			})
+		})
+
+		Context("re-indexing `.kibana` to `.kibana-6`", func() {
+			It("should succeed if migration not completed", func() {
+				chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+					"_cat/indices/.kibana-6?format=json": {
+						{
+							StatusCode: 200,
+							Body:       `[{"health":"green","status":"open","index":".kibana-6","uuid":"KNegGDiRSs6dxWzdxWqkaQ","pri":"1","rep":"1","docs.count":"0","docs.deleted":"0","store.size":"6.4kb","pri.store.size":"3.2kb"}]`,
+						},
+					},
+					"_reindex": {
+						{
+							StatusCode: 200,
+							Body:       "{}",
+						},
+					},
+				})
+				client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+				kr := migrationRequest{
+					client:   k8sClient,
+					esClient: client,
+				}
+
+				Expect(kr.reIndexIntoKibana6()).Should(Succeed())
+
+				req, found := chatter.GetRequest("_cat/indices/.kibana-6?format=json")
+				Expect(found).To(BeTrue())
+				Expect(req.Method).To(Equal(http.MethodGet))
+
+				req, found = chatter.GetRequest("_reindex")
+				Expect(found).To(BeTrue())
+				Expect(req.Method).To(Equal(http.MethodPost))
+			})
+
+			It("should skip if migration completed", func() {
+				chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+					"_cat/indices/.kibana-6?format=json": {
+						{
+							StatusCode: 200,
+							Body:       `[{"health":"green","status":"open","index":".kibana-6","uuid":"KNegGDiRSs6dxWzdxWqkaQ","pri":"1","rep":"1","docs.count":"1","docs.deleted":"0","store.size":"6.4kb","pri.store.size":"3.2kb"}]`,
+						},
+					},
+					"_reindex": {
+						{
+							StatusCode: 200,
+							Body:       "{}",
+						},
+					},
+				})
+				client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+				kr := migrationRequest{
+					client:   k8sClient,
+					esClient: client,
+				}
+
+				Expect(kr.reIndexIntoKibana6()).Should(Succeed())
+
+				req, found := chatter.GetRequest("_cat/indices/.kibana-6?format=json")
+				Expect(found).To(BeTrue())
+				Expect(req.Method).To(Equal(http.MethodGet))
+
+				_, found = chatter.GetRequest("_reindex")
+				Expect(found).To(BeFalse())
+			})
+		})
+
+		Context("aliasing `.kibana` to `.kibana-6`", func() {
+			It("should succeed if not set", func() {
+				chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+					"_alias/.kibana": {
+						{
+							StatusCode: 404,
+							Body:       "{}",
+						},
+					},
+					"_aliases": {
+						{
+							StatusCode: 200,
+							Body:       "{}",
+						},
+					},
+				})
+				client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+				kr := migrationRequest{
+					client:   k8sClient,
+					esClient: client,
+				}
+
+				Expect(kr.aliasKibana()).Should(Succeed())
+
+				req, found := chatter.GetRequest("_alias/.kibana")
+				Expect(found).To(BeTrue())
+				Expect(req.Method).To(Equal(http.MethodGet))
+
+				req, found = chatter.GetRequest("_aliases")
+				Expect(found).To(BeTrue())
+				Expect(req.Method).To(Equal(http.MethodPost))
+				Expect(req.Body).Should(MatchJSON(expectedAliasesPayload))
+			})
+		})
+
+		It("should migrate the `.kibana` index to `.kibana-6`", func() {
+			chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+				"_cluster/stats": {
+					{
+						StatusCode: 200,
+						Body:       `{"nodes": {"versions": ["6.8.1"]}}`,
+					},
+				},
+				"_cat/indices/.kibana-6?format=json": {
+					{
+						StatusCode: 200,
+						Body:       `[{"health":"green","status":"open","index":".kibana-6","uuid":"KNegGDiRSs6dxWzdxWqkaQ","pri":"1","rep":"1","docs.count":"0","docs.deleted":"0","store.size":"6.4kb","pri.store.size":"3.2kb"}]`,
+					},
+				},
+				"_alias/.kibana": {
+					// Initial check if migration complete
+					{
+						StatusCode: 404,
+						Body:       "{}",
+					},
+					// Check migration complete before switching alias
+					{
+						StatusCode: 404,
+						Body:       "{}",
+					},
+				},
+				".kibana/_settings": {
+					{
+						StatusCode: 200,
+						Body:       `{"index": {"blocks": {"write": false}}}`,
+					},
+					{
+						StatusCode: 200,
+						Body:       "{}",
+					},
+				},
+				".kibana-6": {
+					{
+						StatusCode: 404,
+						Body:       `{}`,
+					},
+					{
+						StatusCode: 200,
+						Body:       "{}",
+					},
+				},
+				"_reindex": {
+					{
+						StatusCode: 200,
+						Body:       "{}",
+					},
+				},
+				"_aliases": {
+					{
+						StatusCode: 200,
+						Body:       "{}",
+					},
+				},
+			})
+			client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+			kr := migrationRequest{
+				client:   k8sClient,
+				esClient: client,
+			}
+
+			Expect(kr.reIndexKibana5to6()).Should(Succeed())
+
+			expectedReq := map[string][]int{
+				"_cluster/stats":                     {1},
+				"_alias/.kibana":                     {2, 9}, // Check migration completed
+				"_cat/indices/.kibana-6?format=json": {7},    // Check index docs count before re-index
+				".kibana/_settings":                  {3, 4}, // Check & update read-only
+				".kibana-6":                          {5, 6}, // Check & create new index
+				"_reindex":                           {8},    // ReIndex
+				"_aliases":                           {10},   // Set alias
+			}
+
+			for key, seqNos := range expectedReq {
+				seqNo := seqNos[0]
+				expectedReq[key] = seqNos[1:]
+
+				req, found := chatter.GetRequest(key)
+				Expect(found).To(BeTrue())
+				Expect(req.SeqNo).To(Equal(seqNo), fmt.Sprintf("URI: %s", req.URI))
+			}
+
+		})
+	})
+})
+
+const (
+	expectedKibanaROPayload = `
+{
+  "index": {
+    "blocks": {
+      "write": true
+    }
+  }
+}
+`
+	expectedKibana6Payload = `
+{
+  "settings" : {
+    "number_of_shards" : 1,
+    "index": {
+      "format": 6,
+      "mapper": {
+        "dynamic": false
+      }
+    }
+  },
+  "mappings" : {
+    "doc": {
+      "properties": {
+        "type": {
+          "type": "keyword"
+        },
+        "updated_at": {
+          "type": "date"
+        },
+        "config": {
+          "properties": {
+            "buildNum": {
+              "type": "keyword"
+            }
+          }
+        },
+        "index-pattern": {
+          "properties": {
+            "fieldFormatMap": {
+              "type": "text"
+            },
+            "fields": {
+              "type": "text"
+            },
+            "intervalName": {
+              "type": "keyword"
+            },
+            "notExpandable": {
+              "type": "boolean"
+            },
+            "sourceFilters": {
+              "type": "text"
+            },
+            "timeFieldName": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            }
+          }
+        },
+        "visualization": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "savedSearchId": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "uiStateJSON": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            },
+            "visState": {
+              "type": "text"
+            }
+          }
+        },
+        "search": {
+          "properties": {
+            "columns": {
+              "type": "keyword"
+            },
+            "description": {
+              "type": "text"
+            },
+            "hits": {
+              "type": "integer"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "sort": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            }
+          }
+        },
+        "dashboard": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "hits": {
+              "type": "integer"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "optionsJSON": {
+              "type": "text"
+            },
+            "panelsJSON": {
+              "type": "text"
+            },
+            "refreshInterval": {
+              "properties": {
+                "display": {
+                  "type": "keyword"
+                },
+                "pause": {
+                  "type": "boolean"
+                },
+                "section": {
+                  "type": "integer"
+                },
+                "value": {
+                  "type": "integer"
+                }
+              }
+            },
+            "timeFrom": {
+              "type": "keyword"
+            },
+            "timeRestore": {
+              "type": "boolean"
+            },
+            "timeTo": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "uiStateJSON": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            }
+          }
+        },
+        "url": {
+          "properties": {
+            "accessCount": {
+              "type": "long"
+            },
+            "accessDate": {
+              "type": "date"
+            },
+            "createDate": {
+              "type": "date"
+            },
+            "url": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 2048
+                }
+              }
+            }
+          }
+        },
+        "server": {
+          "properties": {
+            "uuid": {
+              "type": "keyword"
+            }
+          }
+        },
+        "timelion-sheet": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "hits": {
+              "type": "integer"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "timelion_chart_height": {
+              "type": "integer"
+            },
+            "timelion_columns": {
+              "type": "integer"
+            },
+            "timelion_interval": {
+              "type": "keyword"
+            },
+            "timelion_other_interval": {
+              "type": "keyword"
+            },
+            "timelion_rows": {
+              "type": "integer"
+            },
+            "timelion_sheet": {
+              "type": "text"
+            },
+            "title": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            }
+          }
+        },
+        "graph-workspace": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "numLinks": {
+              "type": "integer"
+            },
+            "numVertices": {
+              "type": "integer"
+            },
+            "title": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            },
+            "wsState": {
+              "type": "text"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`
+	expectedReIndexPayload = `
+{
+  "source": {
+    "index": ".kibana"
+  },
+  "dest": {
+    "index": ".kibana-6"
+  },
+  "script": {
+    "inline": "ctx._source = [ ctx._type : ctx._source ]; ctx._source.type = ctx._type; ctx._id = ctx._type + \":\" + ctx._id; ctx._type = \"doc\"; ",
+    "lang": "painless"
+  }
+}
+`
+	expectedAliasesPayload = `
+{
+  "actions" : [
+    { "add":  { "index": ".kibana-6", "alias": ".kibana" } },
+    { "remove_index": { "index": ".kibana" } }
+  ]
+}
+`
+)

--- a/pkg/k8shandler/migrations/migrations.go
+++ b/pkg/k8shandler/migrations/migrations.go
@@ -1,0 +1,86 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/openshift/elasticsearch-operator/pkg/elasticsearch"
+	estypes "github.com/openshift/elasticsearch-operator/pkg/types/elasticsearch"
+	"github.com/openshift/elasticsearch-operator/pkg/utils"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type MigrationRequest interface {
+	RunKibanaMigrations() error
+	RunElasticsearchMigrations() error
+}
+
+func NewMigrationRequest(client client.Client, esClient elasticsearch.Client) MigrationRequest {
+	return &migrationRequest{
+		client:   client,
+		esClient: esClient,
+	}
+}
+
+type migrationRequest struct {
+	client   client.Client
+	esClient elasticsearch.Client
+}
+
+func (mr *migrationRequest) RunKibanaMigrations() error {
+	logrus.Debugf("running Kibana migrations")
+	if index, _ := mr.esClient.GetIndex(kibanaIndex); index == nil {
+		logrus.Infof("skipping kibana migrations: no index %q available", kibanaIndex)
+		return nil
+	}
+
+	indices, err := mr.esClient.GetAllIndices(kibanaIndex)
+	if err != nil {
+		return fmt.Errorf("failed to get `.kibana` index health before running migrations: %s", err)
+	}
+
+	health, err := getIndexHealth(indices, kibanaIndex)
+	if err != nil {
+		return fmt.Errorf("failed to get `.kibana` index health before running migrations: %s", err)
+	}
+
+	if health != "green" && health != "yellow" {
+		return fmt.Errorf("waiting for `.kibana` index recovery before running migrations: %s / (green,yellow)", health)
+	}
+
+	logrus.Debugf("attempting re-indexing `.kibana` into `.kibana-6`")
+	if err := mr.reIndexKibana5to6(); err != nil {
+		return fmt.Errorf("failed re-indexing `.kibana` into `.kibana-6`: %s", err)
+	}
+	return nil
+}
+
+func (mr *migrationRequest) RunElasticsearchMigrations() error {
+	logrus.Debugf("running elasticsearch migrations")
+	return nil
+}
+
+func (mr *migrationRequest) matchRequiredMajorVersion(version string) (bool, error) {
+	versions, err := mr.esClient.GetClusterNodeVersions()
+	if err != nil {
+		return false, err
+	}
+
+	if versions == nil {
+		return false, nil
+	}
+
+	if len(versions) > 1 {
+		return false, nil
+	}
+
+	return (utils.GetMajorVersion(versions[0]) == version), nil
+}
+
+func getIndexHealth(indices estypes.CatIndicesResponses, name string) (string, error) {
+	if len(indices) == 0 {
+		return "unknown", fmt.Errorf("failed to get index health for %q ", name)
+	}
+
+	return indices[0].Health, nil
+}

--- a/pkg/k8shandler/migrations/migrations_suite_test.go
+++ b/pkg/k8shandler/migrations/migrations_suite_test.go
@@ -1,0 +1,13 @@
+package migrations
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMigrations(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Migrations Suite")
+}

--- a/pkg/k8shandler/migrations/migrations_test.go
+++ b/pkg/k8shandler/migrations/migrations_test.go
@@ -1,0 +1,99 @@
+package migrations
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/elasticsearch-operator/pkg/elasticsearch"
+	"github.com/openshift/elasticsearch-operator/test/helpers"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Running", func() {
+	defer GinkgoRecover()
+
+	var (
+		chatter   *helpers.FakeElasticsearchChatter
+		client    elasticsearch.Client
+		k8sClient kclient.Client = fake.NewFakeClient()
+	)
+
+	const (
+		esCluster   = "elasticsearch"
+		esNamespace = "openshift-logging"
+	)
+
+	Describe("Kibana migrations", func() {
+		It("should skip if `.kibana` index health is not green", func() {
+			chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+				".kibana": {
+					{
+						StatusCode: 200,
+						Body:       `{}`,
+					},
+				},
+				"_cat/indices/.kibana?format=json": {
+					{
+						StatusCode: 200,
+						Body:       `[{"health":"red","status":"open","index":".kibana","uuid":"KNegGDiRSs6dxWzdxWqkaQ","pri":"1","rep":"1","docs.count":"1","docs.deleted":"0","store.size":"6.4kb","pri.store.size":"3.2kb"}]`,
+					},
+				},
+			})
+			client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+			kr := migrationRequest{
+				client:   k8sClient,
+				esClient: client,
+			}
+
+			Expect(kr.RunKibanaMigrations()).ShouldNot(Succeed())
+		})
+
+		It("should skip if `.kibana` index not existing", func() {
+			chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+				".kibana": {
+					{
+						StatusCode: 404,
+						Body:       `{}`,
+					},
+				},
+			})
+			client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+			kr := migrationRequest{
+				client:   k8sClient,
+				esClient: client,
+			}
+
+			Expect(kr.RunKibanaMigrations()).Should(Succeed())
+
+		})
+
+		It("should skip if `.kibana` index health is not available", func() {
+			chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+				".kibana": {
+					{
+						StatusCode: 200,
+						Body:       `{}`,
+					},
+				},
+				"_cat/indices/.kibana?format=json": {
+					{
+						StatusCode: 404,
+						Body:       `{}`,
+					},
+				},
+			})
+			client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+			kr := migrationRequest{
+				client:   k8sClient,
+				esClient: client,
+			}
+
+			Expect(kr.RunKibanaMigrations()).ShouldNot(Succeed())
+
+		})
+	})
+})

--- a/pkg/types/elasticsearch/types.go
+++ b/pkg/types/elasticsearch/types.go
@@ -38,9 +38,10 @@ func (index *Index) AddAlias(name string, isWriteIndex bool) *Index {
 
 type Index struct {
 	//Name  intentionally not serialized
-	Name     string                `json:"-"`
-	Settings IndexSettings         `json:"settings,omitempty"`
-	Aliases  map[string]IndexAlias `json:"aliases,omitempty"`
+	Name     string                 `json:"-"`
+	Settings IndexSettings          `json:"settings,omitempty"`
+	Aliases  map[string]IndexAlias  `json:"aliases,omitempty"`
+	Mappings map[string]interface{} `json:"mappings,omitempty"`
 }
 
 type IndexTemplate struct {
@@ -57,6 +58,74 @@ type IndexAlias struct {
 }
 
 type IndexSettings struct {
-	NumberOfShards   int32 `json:"number_of_shards"`
-	NumberOfReplicas int32 `json:"number_of_replicas"`
+	NumberOfShards   int32             `json:"number_of_shards,omitempty"`
+	NumberOfReplicas int32             `json:"number_of_replicas,omitempty"`
+	Index            *IndexingSettings `json:"index,omitempty"`
+}
+
+type IndexingSettings struct {
+	Format  int32                 `json:"format,omitempty"`
+	Blocks  *IndexBlocksSettings  `json:"blocks,omitempty"`
+	Mapper  *IndexMapperSettings  `json:"mapper,omitempty"`
+	Mapping *IndexMappingSettings `json:"mapping,omitempty"`
+}
+
+type IndexBlocksSettings struct {
+	Write bool `json:"write"`
+}
+
+type IndexMapperSettings struct {
+	Dynamic bool `json:"dynamic"`
+}
+
+type IndexMappingSettings struct {
+	SingleType bool `json:"single_type"`
+}
+
+type ReIndex struct {
+	Source IndexRef      `json:"source"`
+	Dest   IndexRef      `json:"dest"`
+	Script ReIndexScript `json:"script"`
+}
+
+type ReIndexScript struct {
+	Inline string `json:"inline"`
+	Lang   string `json:"lang"`
+}
+
+type IndexRef struct {
+	Index string `json:"index"`
+}
+
+type AliasActions struct {
+	Actions []AliasAction `json:"actions"`
+}
+
+type AliasAction struct {
+	Add         *AddAliasAction    `json:"add,omitempty"`
+	RemoveIndex *RemoveAliasAction `json:"remove_index,omitempty"`
+}
+
+type AddAliasAction struct {
+	Index string `json:"index"`
+	Alias string `json:"alias"`
+}
+
+type RemoveAliasAction struct {
+	Index string `json:"index"`
+}
+
+type CatIndicesResponses []CatIndicesResponse
+
+type CatIndicesResponse struct {
+	Health           string `json:"health,omitempty"`
+	Status           string `json:"status,omitempty"`
+	Index            string `json:"index,omitempty"`
+	UUID             string `json:"uuis,omitempty"`
+	Primaries        string `json:"pri,omitempty"`
+	Replicas         string `json:"rep,omitempty"`
+	DocsCount        string `json:"docs.count,omitempty"`
+	DocsDeleted      string `json:"docs.deleted,omitempty"`
+	StoreSize        string `json:"store.size,omitempty"`
+	PrimaryStoreSize string `json:"pri.store.size,omitempty"`
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -484,6 +485,7 @@ func SetProxyEnvVars(proxyConfig *configv1.Proxy) []v1.EnvVar {
 	}
 	return envVars
 }
+
 func Contains(list []string, s string) bool {
 	for _, item := range list {
 		if s == item {
@@ -492,4 +494,9 @@ func Contains(list []string, s string) bool {
 	}
 
 	return false
+}
+
+func GetMajorVersion(v string) string {
+	ver := strings.Split(v, ".")
+	return ver[0]
 }

--- a/test/e2e-olm/utils.go
+++ b/test/e2e-olm/utils.go
@@ -8,7 +8,6 @@ import (
 
 	consolev1 "github.com/openshift/api/console/v1"
 	elasticsearch "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
-	"github.com/openshift/elasticsearch-operator/pkg/constants"
 	"github.com/openshift/elasticsearch-operator/test/utils"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	v1 "k8s.io/api/core/v1"
@@ -22,7 +21,7 @@ const (
 	retryInterval        = time.Second * 1
 	timeout              = time.Second * 300
 	cleanupRetryInterval = time.Second * 1
-	cleanupTimeout       = time.Second * 5
+	cleanupTimeout       = time.Second * 30
 	elasticsearchCRName  = "elasticsearch"
 	kibanaCRName         = "kibana"
 )
@@ -134,7 +133,7 @@ func createElasticsearchSecret(t *testing.T, f *framework.Framework, ctx *framew
 		},
 	)
 
-	t.Logf("Creating %v", elasticsearchSecret)
+	t.Logf("Creating secret %s/%s", elasticsearchSecret.Namespace, elasticsearchSecret.Name)
 	err = f.Client.Create(goctx.TODO(), elasticsearchSecret, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		return err
@@ -182,7 +181,7 @@ func createKibanaCR(namespace string) *elasticsearch.Kibana {
 
 	return &elasticsearch.Kibana{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.KibanaInstanceName,
+			Name:      "kibana",
 			Namespace: namespace,
 		},
 		Spec: elasticsearch.KibanaSpec{

--- a/test/helpers/elasticsearch.go
+++ b/test/helpers/elasticsearch.go
@@ -4,24 +4,43 @@ import (
 	"encoding/json"
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
-
 	"github.com/openshift/elasticsearch-operator/pkg/elasticsearch"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func NewFakeElasticsearchChatter(responses map[string]FakeElasticsearchResponse) *FakeElasticsearchChatter {
+func NewFakeElasticsearchChatter(responses map[string]FakeElasticsearchResponses) *FakeElasticsearchChatter {
+	// Copy responses into chatter to unshare between multiple instances
+	fres := make(map[string]FakeElasticsearchResponses)
+	for key, res := range responses {
+		fres[key] = res
+	}
+
 	return &FakeElasticsearchChatter{
-		Requests:  map[string]string{},
-		Responses: responses,
+		Requests:     map[string]FakeElasticsearchRequests{},
+		RequestOrder: map[string]int{},
+		Responses:    fres,
+		seqNo:        1,
 	}
 }
 
 type FakeElasticsearchChatter struct {
-	Requests  map[string]string
-	Responses map[string]FakeElasticsearchResponse
+	seqNo        int
+	Requests     map[string]FakeElasticsearchRequests
+	RequestOrder map[string]int
+	Responses    map[string]FakeElasticsearchResponses
 }
+
+type FakeElasticsearchRequests []FakeElasticsearchRequest
+
+type FakeElasticsearchRequest struct {
+	URI    string
+	Method string
+	Body   string
+	SeqNo  int
+}
+
+type FakeElasticsearchResponses []FakeElasticsearchResponse
 
 type FakeElasticsearchResponse struct {
 	Error      error
@@ -29,22 +48,52 @@ type FakeElasticsearchResponse struct {
 	Body       string
 }
 
-func (chat *FakeElasticsearchChatter) GetRequest(key string) (string, bool) {
-	request, found := chat.Requests[key]
-	return request, found
+func (chat *FakeElasticsearchChatter) GetRequest(key string) (*FakeElasticsearchRequest, bool) {
+	requests, found := chat.Requests[key]
+	if !found {
+		return nil, found
+	}
+
+	request := requests[0]
+	chat.Requests[key] = requests[1:]
+	return &request, found
 }
 
-func (chat *FakeElasticsearchChatter) GetResponse(key string) (FakeElasticsearchResponse, bool) {
-	response, found := chat.Responses[key]
-	return response, found
+func (chat *FakeElasticsearchChatter) GetResponse(key string) (*FakeElasticsearchResponse, bool) {
+	responses, found := chat.Responses[key]
+	if !found {
+		return nil, found
+	}
+
+	response := responses[0]
+	chat.Responses[key] = responses[1:]
+	return &response, found
+}
+
+func (chat *FakeElasticsearchChatter) recordRequest(payload *elasticsearch.EsRequest) {
+	key := payload.URI
+	req := FakeElasticsearchRequest{
+		URI:    key,
+		Body:   payload.RequestBody,
+		Method: payload.Method,
+		SeqNo:  chat.nextSeqNo(),
+	}
+	chat.Requests[key] = append(chat.Requests[key], req)
+}
+
+func (chat *FakeElasticsearchChatter) nextSeqNo() int {
+	next := chat.seqNo
+	chat.seqNo = chat.seqNo + 1
+	return next
 }
 
 func (response *FakeElasticsearchResponse) BodyAsResponseBody() map[string]interface{} {
-	body := &map[string]interface{}{}
-	if err := json.Unmarshal([]byte(response.Body), body); err != nil {
-		Fail(fmt.Sprintf("Unable to convert to response body %q: %v", response.Body, err))
+	body := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(response.Body), &body); err != nil {
+		body = make(map[string]interface{})
+		body["results"] = response.Body
 	}
-	return *body
+	return body
 }
 
 func NewFakeElasticsearchClient(cluster, namespace string, k8sClient client.Client, chatter *FakeElasticsearchChatter) elasticsearch.Client {
@@ -56,10 +105,11 @@ func NewFakeElasticsearchClient(cluster, namespace string, k8sClient client.Clie
 
 func NewFakeSendRequestFn(chatter *FakeElasticsearchChatter) elasticsearch.FnEsSendRequest {
 	return func(cluster, namespace string, payload *elasticsearch.EsRequest, client client.Client) {
-		chatter.Requests[payload.URI] = payload.RequestBody
+		chatter.recordRequest(payload)
 		if val, found := chatter.GetResponse(payload.URI); found {
 			payload.Error = val.Error
 			payload.StatusCode = val.StatusCode
+			payload.RawResponseBody = val.Body
 			payload.ResponseBody = val.BodyAsResponseBody()
 		} else {
 			payload.Error = fmt.Errorf("No fake response found for uri %q: %v", payload.URI, payload)


### PR DESCRIPTION
This PR addresses the need to reindex the index during updating to kibana 6. Based on the official guide for elasticsearch installation w/o xpack:
https://www.elastic.co/guide/en/kibana/6.0/migrating-6.0-index.html

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1835903

Depends on: #356 ~openshift/origin-aggregated-logging#1900~