### PR TITLE
Bug 1837867: configure default and admin roles for proxy

### DIFF
--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -243,6 +243,8 @@ func newProxyContainer(imageName, clusterName, namespace string, logConfig LogCo
 			`--auth-backend-role=jaeger={"verb": "get", "resource": "/jaeger", "resourceAPIGroup": "elasticsearch.jaegertracing.io"}`,
 			`--auth-backend-role=elasticsearch-operator={"namespace": "*", "verb": "*", "resource": "*", "resourceAPIGroup": "logging.openshift.io"}`,
 			fmt.Sprintf("--auth-backend-role=index-management={\"namespace\":\"%s\", \"verb\": \"*\", \"resource\": \"indices\", \"resourceAPIGroup\": \"elasticsearch.openshift.io\"}", namespace),
+			"--auth-admin-role=admin_reader",
+			"--auth-default-role=project_user",
 		},
 		Resources: v1.ResourceRequirements{
 			Limits: v1.ResourceList{

--- a/pkg/k8shandler/common_test.go
+++ b/pkg/k8shandler/common_test.go
@@ -431,7 +431,7 @@ func TestProxyContainerTLSClientAuthDefined(t *testing.T) {
 	}
 }
 
-func TestProxyContainerMetricsTLSDefined(t *testing.T) {
+func TestProxyContainerSpec(t *testing.T) {
 	imageName := "openshift/elasticsearch-proxy:1.1"
 	clusterName := "elasticsearch"
 
@@ -444,6 +444,8 @@ func TestProxyContainerMetricsTLSDefined(t *testing.T) {
 		"--metrics-listening-address=:60001",
 		"--metrics-tls-cert=/etc/proxy/secrets/tls.crt",
 		"--metrics-tls-key=/etc/proxy/secrets/tls.key",
+		"--auth-admin-role=admin_reader",
+		"--auth-default-role=project_user",
 	}
 
 	for _, arg := range wantArgs {


### PR DESCRIPTION
This PR:
* configures the elasticsearch proxy to define admin and default roles

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1837867

blocked by:
* https://github.com/openshift/elasticsearch-proxy/pull/39
* https://github.com/openshift/origin-aggregated-logging/pull/1902