### PR TITLE
Bug 1840909: Updating cert restarts to also adhere to primaries instead of none

### DIFF
--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -471,8 +471,8 @@ func (elasticsearchRequest *ElasticsearchRequest) performFullClusterRestart() er
 			containsClusterCondition(api.UpdatingSettings, v1.ConditionTrue, clusterStatus) {
 
 			// disable shard allocation
-			if ok, err := esClient.SetShardAllocation(api.ShardAllocationNone); !ok {
-				logrus.Warnf("Unable to disable shard allocation: %v", err)
+			if ok, err := esClient.SetShardAllocation(api.ShardAllocationPrimaries); !ok {
+				logrus.Warnf("Unable to set shard allocation to primaries: %v", err)
 			}
 
 			// flush nodes
@@ -501,7 +501,7 @@ func (elasticsearchRequest *ElasticsearchRequest) performFullClusterRestart() er
 
 			// check that all nodes have been restarted by seeing if they still have the need to cert restart
 			if len(getScheduledCertRedeployNodes(elasticsearchRequest.cluster)) > 0 {
-				return fmt.Errorf("Not all nodes were able to be restarted yet...")
+				return fmt.Errorf("Not all nodes were able to be restarted yet")
 			}
 
 			updateUpdatingSettingsCondition(clusterStatus, v1.ConditionTrue)
@@ -520,7 +520,7 @@ func (elasticsearchRequest *ElasticsearchRequest) performFullClusterRestart() er
 			len(podStatus[api.ElasticsearchRoleMaster][api.PodStateTypeNotReady]) > 0 {
 
 			logrus.Warnf("Waiting for all cluster nodes to rejoin after full cluster restart...")
-			return fmt.Errorf("Waiting for all cluster nodes to rejoin after full cluster restart...")
+			return fmt.Errorf("Waiting for all cluster nodes to rejoin after full cluster restart")
 		}
 
 		// reenable shard allocation

--- a/pkg/k8shandler/status.go
+++ b/pkg/k8shandler/status.go
@@ -42,6 +42,8 @@ func (elasticsearchRequest *ElasticsearchRequest) UpdateClusterStatus() error {
 	switch {
 	case allocation == "none":
 		clusterStatus.ShardAllocationEnabled = api.ShardAllocationNone
+	case allocation == "primaries":
+		clusterStatus.ShardAllocationEnabled = api.ShardAllocationPrimaries
 	case err != nil:
 		clusterStatus.ShardAllocationEnabled = api.ShardAllocationUnknown
 	default:


### PR DESCRIPTION
Addresses: https://bugzilla.redhat.com/show_bug.cgi?id=1840909