### PR TITLE
Bug 1835083: Add mTLS credentials to rollover IM script

### DIFF
--- a/pkg/indexmanagement/scripts.go
+++ b/pkg/indexmanagement/scripts.go
@@ -7,6 +7,8 @@ code=$(curl "$ES_SERVICE/${POLICY_MAPPING}-write/_rollover?pretty" \
   -w "%{response_code}" \
   -sv \
   --cacert /etc/indexmanagement/keys/admin-ca \
+  --cert /etc/indexmanagement/keys/admin-cert \
+  --key /etc/indexmanagement/keys/admin-key \
   -HContent-Type:application/json \
   -XPOST \
   -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \


### PR DESCRIPTION
To address: https://bugzilla.redhat.com/show_bug.cgi?id=1835083

Needs backport: release-4.5