### PR TITLE
Bug 1842445: Drop curl verbosity in index management scripts

### DIFF
--- a/pkg/indexmanagement/scripts.go
+++ b/pkg/indexmanagement/scripts.go
@@ -3,9 +3,8 @@ package indexmanagement
 const rolloverScript = `
 set -euo pipefail
 decoded=$(echo $PAYLOAD | base64 -d)
-code=$(curl "$ES_SERVICE/${POLICY_MAPPING}-write/_rollover?pretty" \
+code=$(curl -s "$ES_SERVICE/${POLICY_MAPPING}-write/_rollover?pretty" \
   -w "%{response_code}" \
-  -sv \
   --cacert /etc/indexmanagement/keys/admin-ca \
   --cert /etc/indexmanagement/keys/admin-cert \
   --key /etc/indexmanagement/keys/admin-key \
@@ -70,7 +69,7 @@ else
     echo deleting indices: "${indices}"
 fi
 
-code=$(curl -sv $ES_SERVICE/${indices}?pretty \
+code=$(curl -s $ES_SERVICE/${indices}?pretty \
   -w "%{response_code}" \
   --cacert /etc/indexmanagement/keys/admin-ca \
   --cert /etc/indexmanagement/keys/admin-cert \


### PR DESCRIPTION
To address: https://bugzilla.redhat.com/show_bug.cgi?id=1842445

Needs backport: release-4.5