### PR TITLE
[release-4.5] Revert "Bug 1843564: Add missing mTLS credentials for indexmanagement…

### DIFF
--- a/pkg/indexmanagement/scripts.go
+++ b/pkg/indexmanagement/scripts.go
@@ -23,8 +23,6 @@ set -euo pipefail
 
 writeIndices=$(curl -s $ES_SERVICE/${POLICY_MAPPING}-*/_alias/${POLICY_MAPPING}-write \
   --cacert /etc/indexmanagement/keys/admin-ca \
-  --cert /etc/indexmanagement/keys/admin-cert \
-  --key /etc/indexmanagement/keys/admin-key \
   -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
   -HContent-Type:application/json)
 
@@ -42,8 +40,6 @@ writeIndex=$(echo "${writeIndices}" | python -c "$CMD")
 
 indices=$(curl -s $ES_SERVICE/${POLICY_MAPPING}/_settings/index.creation_date \
   --cacert /etc/indexmanagement/keys/admin-ca \
-  --cert /etc/indexmanagement/keys/admin-cert \
-  --key /etc/indexmanagement/keys/admin-key \
   -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
   -HContent-Type:application/json)
 
@@ -71,8 +67,6 @@ fi
 code=$(curl -sv $ES_SERVICE/${indices}?pretty \
   -w "%{response_code}" \
   --cacert /etc/indexmanagement/keys/admin-ca \
-  --cert /etc/indexmanagement/keys/admin-cert \
-  --key /etc/indexmanagement/keys/admin-key \
   -HContent-Type:application/json \
   -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
   -o /tmp/response.txt \


### PR DESCRIPTION
Manual backport of #374 due to [reason](https://github.com/openshift/elasticsearch-operator/pull/374#issuecomment-639286038).

This reverts commit c02c8b69600cbe042df54bd884503cbdb60730dd.