### PR TITLE
Bug 1835083: Update ports if they differ from the desired

### DIFF
--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -716,6 +716,11 @@ func (node *deploymentNode) isChanged() bool {
 			logger.Debugf("Container Args are different between current and desired for %s", nodeContainer.Name)
 			changed = true
 		}
+		if !reflect.DeepEqual(desiredContainer.Ports, nodeContainer.Ports) {
+			nodeContainer.Ports = desiredContainer.Ports
+			logger.Debugf("Container Ports are different between current and desired for %s", nodeContainer.Name)
+			changed = true
+		}
 		var updatedContainer v1.Container
 		var resourceUpdated bool
 		if updatedContainer, resourceUpdated = updateResources(node, nodeContainer, desiredContainer); resourceUpdated {

--- a/pkg/k8shandler/deployment_test.go
+++ b/pkg/k8shandler/deployment_test.go
@@ -208,6 +208,18 @@ var _ = Describe("deployment", func() {
 			Expect(desired.isChanged()).To(BeTrue())
 			Expect(desired.self.Spec.Template.Spec.Containers[0].Args).To(Equal(elasticsearch.Args))
 		})
+		It("should recognize container ports when they change", func() {
+			elasticsearch.Ports = []v1.ContainerPort{
+				{
+					Name:          "someotherport",
+					ContainerPort: 60000,
+					Protocol:      v1.ProtocolTCP,
+				},
+			}
+			desired = newDesired(elasticsearch)
+			Expect(desired.isChanged()).To(BeTrue())
+			Expect(desired.self.Spec.Template.Spec.Containers[0].Ports).To(Equal(elasticsearch.Ports))
+		})
 
 	})
 })

--- a/pkg/k8shandler/elasticsearch_suite_test.go
+++ b/pkg/k8shandler/elasticsearch_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func Testelasticsearch(t *testing.T) {
+func TestElasticsearchSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "elasticsearch Suite")
+	RunSpecs(t, "Elasticsearch Suite")
 }

--- a/pkg/k8shandler/kibana/k8shandler_suite_test.go
+++ b/pkg/k8shandler/kibana/k8shandler_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestK8sHandler(t *testing.T) {
+func TestKibanaSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "K8sHandler Suite")
+	RunSpecs(t, "Kibana Suite")
 }

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -677,6 +677,11 @@ func (node *statefulSetNode) isChanged() bool {
 			logger.Debugf("Container EnvVars are different between current and desired for %s", nodeContainer.Name)
 			changed = true
 		}
+		if !reflect.DeepEqual(desiredContainer.Ports, nodeContainer.Ports) {
+			nodeContainer.Ports = desiredContainer.Ports
+			logger.Debugf("Container Ports are different between current and desired for %s", nodeContainer.Name)
+			changed = true
+		}
 
 		node.self.Spec.Template.Spec.Containers[index] = nodeContainer
 	}


### PR DESCRIPTION
This PR updates ports to desired to address the upgrade scenario where we modified exposed ports and clients are no longer able to communicate to the ES cluster

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1835083