### PR TITLE
[release-4.5] Bug 1843715: Perform a full cluster restart when upgrading ES maj versions

### DIFF
--- a/pkg/elasticsearch/client.go
+++ b/pkg/elasticsearch/client.go
@@ -42,6 +42,10 @@ type Client interface {
 	SetMinMasterNodes(numberMasters int32) (bool, error)
 	DoSynchronizedFlush() (bool, error)
 
+	// Cluster State API
+	GetLowestClusterVersion() (string, error)
+	IsNodeInCluster(nodeName string) (bool, error)
+
 	// Health API
 	GetClusterHealth() (api.ClusterHealth, error)
 	GetClusterHealthStatus() (string, error)

--- a/pkg/elasticsearch/cluster_test.go
+++ b/pkg/elasticsearch/cluster_test.go
@@ -50,3 +50,89 @@ func TestGetClusterNodeVersion(t *testing.T) {
 	}
 
 }
+
+func TestGetLowestClusterVersion(t *testing.T) {
+	chatter := helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+		"_cluster/stats/nodes/_all": {
+			{
+				StatusCode: 200,
+				Body:       `{"nodes": {"versions": ["6.8.1"]}}`,
+			},
+			{
+				StatusCode: 200,
+				Body:       `{"nodes": {"versions": ["6.8.1", "5.6.16"]}}`,
+			},
+		},
+	})
+	esClient := helpers.NewFakeElasticsearchClient("elasticsearch", "test-namespace", fakeClient, chatter)
+
+	tests := []struct {
+		desc string
+		want string
+	}{
+		{
+			desc: "single version",
+			want: "6.8.1",
+		},
+		{
+			desc: "split versions",
+			want: "5.6.16",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			got, err := esClient.GetLowestClusterVersion()
+			if err != nil {
+				t.Errorf("got err: %s", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("got %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsNodeInCluster(t *testing.T) {
+	chatter := helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+		"_cluster/state/nodes": {
+			{
+				StatusCode: 200,
+				Body:       `{"nodes": {"nodeuuid1": {"name": "node1"}}}`,
+			},
+			{
+				StatusCode: 200,
+				Body:       `{"nodes": {"nodeuuid1": {"name": "node1"}, "nodeuuid2": {"name": "node2"}}}`,
+			},
+		},
+	})
+	esClient := helpers.NewFakeElasticsearchClient("elasticsearch", "test-namespace", fakeClient, chatter)
+
+	tests := []struct {
+		desc string
+		want bool
+	}{
+		{
+			desc: "node not in cluster",
+			want: false,
+		},
+		{
+			desc: "node in cluster",
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			got, err := esClient.IsNodeInCluster("node2")
+			if err != nil {
+				t.Errorf("got err: %s", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("got %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -6,13 +6,17 @@ import (
 	"reflect"
 
 	"github.com/openshift/elasticsearch-operator/pkg/utils"
+	"github.com/openshift/elasticsearch-operator/pkg/utils/comparators"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 
 	api "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
 )
+
+const expectedMinVersion = "6.0"
 
 var wrongConfig bool
 var nodes map[string][]NodeTypeInterface
@@ -47,7 +51,7 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateElasticsearchClu
 	elasticsearchRequest.getNodes()
 
 	progressUnshedulableNodes(elasticsearchRequest.cluster)
-	err = elasticsearchRequest.performFullClusterRestart()
+	err = elasticsearchRequest.performCertClusterRestart()
 	if err != nil {
 		return elasticsearchRequest.UpdateClusterStatus()
 	}
@@ -78,20 +82,39 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateElasticsearchClu
 	} else {
 
 		if len(scheduledUpgradeNodes) > 0 {
-			for _, node := range scheduledUpgradeNodes {
-				logrus.Debugf("Perform a update for %v", node.name())
-				clusterStatus := elasticsearchRequest.cluster.Status.DeepCopy()
-				_, nodeStatus := getNodeStatus(node.name(), clusterStatus)
 
-				err := node.update(nodeStatus)
+			// get the current ES version
+			version, err := esClient.GetLowestClusterVersion()
+			if err != nil {
+				// this can be because we couldn't get a valid response from ES
+				logrus.Warnf("when trying to get LowestClusterVersion: %v", err)
+			} else {
 
-				addNodeState(node, nodeStatus)
-				if err := elasticsearchRequest.setNodeStatus(node, nodeStatus, clusterStatus); err != nil {
-					logrus.Error(err)
-				}
+				logrus.Debugf("Found current cluster version to be %q", version)
+				comparison := comparators.CompareVersions(version, expectedMinVersion)
 
-				if err != nil {
-					logrus.Warnf("Error occurred while updating node %v: %v", node.name(), err)
+				// if it is < what we expect (6.0) then do full cluster restart:
+				if comparison > 0 {
+					// perform a full cluster restart
+					if err := elasticsearchRequest.fullClusterRestart(scheduledUpgradeNodes); err != nil {
+						logrus.Warnf("when trying to perform full cluster restart: %v", err)
+					}
+
+				} else {
+
+					for _, node := range scheduledUpgradeNodes {
+						logrus.Debugf("Perform a update for %v", node.name())
+						clusterStatus := elasticsearchRequest.cluster.Status.DeepCopy()
+						_, nodeStatus := getNodeStatus(node.name(), clusterStatus)
+						err := node.update(nodeStatus)
+						addNodeState(node, nodeStatus)
+						if err := elasticsearchRequest.setNodeStatus(node, nodeStatus, clusterStatus); err != nil {
+							logrus.Error(err)
+						}
+						if err != nil {
+							logrus.Warnf("Error occurred while updating node %v: %v", node.name(), err)
+						}
+					}
 				}
 			}
 
@@ -141,6 +164,11 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateElasticsearchClu
 					}
 
 					elasticsearchRequest.updateMinMasters()
+				}
+
+				// ensure we always have shard allocation to All if we aren't doing an upgrade...
+				if ok, err := esClient.SetShardAllocation(api.ShardAllocationAll); !ok {
+					logrus.Warnf("Unable to enable shard allocation: %v", err)
 				}
 
 				// we only want to update our replicas if we aren't in the middle up an upgrade
@@ -440,10 +468,10 @@ func (elasticsearchRequest *ElasticsearchRequest) updateNodeStatus(status api.El
 	return nil
 }
 
-// Full cluster restart is required when certs need to be refreshed
+// performCertClusterRestart is required when certs need to be refreshed
 // this is a very high priority action since the cluster may be fractured/unusable
 // in the case where certs aren't all rolled out correctly or are expired
-func (elasticsearchRequest *ElasticsearchRequest) performFullClusterRestart() error {
+func (elasticsearchRequest *ElasticsearchRequest) performCertClusterRestart() error {
 	esClient := elasticsearchRequest.esClient
 
 	// make sure we have nodes that are scheduled for full cluster restart first
@@ -535,12 +563,133 @@ func (elasticsearchRequest *ElasticsearchRequest) performFullClusterRestart() er
 	// 5 -- recovery
 	// wait for cluster to go green again
 	if containsClusterCondition(api.Restarting, v1.ConditionTrue, clusterStatus) {
-		if status, _ := esClient.GetClusterHealthStatus(); status != "green" {
-			logrus.Infof("Waiting for cluster to complete recovery: %v / green", status)
-			return fmt.Errorf("Cluster has not completed recovery after restart: %v / green", status)
+		status, err := esClient.GetClusterHealthStatus()
+		if err != nil {
+			return fmt.Errorf("Receieved error while trying to get cluster health for %q: %v", elasticsearchRequest.cluster.Name, err)
+		}
+
+		if !utils.Contains(desiredClusterStates, status) {
+			return fmt.Errorf("Waiting for cluster to recover: %s / %v", status, desiredClusterStates)
 		}
 
 		logrus.Infof("Completed full cluster restart for cert redeploy on %v", elasticsearchRequest.cluster.Name)
+		updateRestartingCondition(clusterStatus, v1.ConditionFalse)
+	}
+
+	return nil
+}
+
+func (elasticsearchRequest *ElasticsearchRequest) fullClusterRestart(scheduledUpgradeNodes []NodeTypeInterface) error {
+	esClient := elasticsearchRequest.esClient
+	clusterStatus := &elasticsearchRequest.cluster.Status
+
+	// 1 -- precheck
+	// no restarting conditions set
+	if len(scheduledUpgradeNodes) > 0 {
+
+		if containsClusterCondition(api.Restarting, v1.ConditionFalse, clusterStatus) &&
+			containsClusterCondition(api.UpdatingSettings, v1.ConditionFalse, clusterStatus) {
+
+			if status, _ := esClient.GetClusterHealthStatus(); !utils.Contains(desiredClusterStates, status) {
+				return fmt.Errorf("Waiting for cluster %q to be recovered before restarting: %s / %v", elasticsearchRequest.cluster.Name, status, desiredClusterStates)
+			}
+
+			logrus.Infof("Beginning full cluster restart on %v", elasticsearchRequest.cluster.Name)
+
+			// set conditions here for next check
+			updateUpdatingSettingsCondition(clusterStatus, v1.ConditionTrue)
+		}
+
+		// 2 -- prep for restart
+		// condition updatingsettings true
+		if containsClusterCondition(api.Restarting, v1.ConditionFalse, clusterStatus) &&
+			containsClusterCondition(api.UpdatingSettings, v1.ConditionTrue, clusterStatus) {
+
+			if err := EnforceNetworkPolicy(elasticsearchRequest.cluster.Namespace, elasticsearchRequest.client, []metav1.OwnerReference{getOwnerRef(elasticsearchRequest.cluster)}); err != nil {
+				return fmt.Errorf("Unable to create network policy for cluster %s in namespace %s: %v", elasticsearchRequest.cluster.Name, elasticsearchRequest.cluster.Namespace, err)
+			}
+
+			// disable shard allocation
+			if ok, err := esClient.SetShardAllocation(api.ShardAllocationPrimaries); !ok {
+				return fmt.Errorf("Unable to set shard allocation to primaries: %v", err)
+			}
+
+			// flush nodes
+			if ok, err := esClient.DoSynchronizedFlush(); !ok {
+				logrus.Warnf("Unable to perform synchronized flush: %v", err)
+			}
+
+			updateRestartingCondition(clusterStatus, v1.ConditionTrue)
+			updateUpdatingSettingsCondition(clusterStatus, v1.ConditionFalse)
+		}
+
+		// 3 -- restart
+		// condition restarting true
+		if containsClusterCondition(api.Restarting, v1.ConditionTrue, clusterStatus) &&
+			containsClusterCondition(api.UpdatingSettings, v1.ConditionFalse, clusterStatus) {
+
+			// call fullClusterRestart on each node that is scheduled for a full cluster restart
+			for _, node := range scheduledUpgradeNodes {
+				_, nodeStatus := getNodeStatus(node.name(), clusterStatus)
+
+				node.progressNodeChanges(nodeStatus)
+
+				addNodeState(node, nodeStatus)
+				if err := elasticsearchRequest.setNodeStatus(node, nodeStatus, clusterStatus); err != nil {
+					logrus.Warnf("unable to set node status. %s", err.Error())
+				}
+			}
+
+			// check that all nodes have been restarted by seeing if they still have the need to cert restart
+			if len(getScheduledUpgradeNodes(elasticsearchRequest.cluster)) > 0 {
+				return fmt.Errorf("Not all nodes were able to be restarted yet")
+			}
+
+			updateUpdatingSettingsCondition(clusterStatus, v1.ConditionTrue)
+		}
+	}
+
+	// 4 -- post restart
+	// condition restarting true and updatingsettings true
+	if containsClusterCondition(api.Restarting, v1.ConditionTrue, clusterStatus) &&
+		containsClusterCondition(api.UpdatingSettings, v1.ConditionTrue, clusterStatus) {
+
+		// verify all nodes rejoined
+		// check that we have no failed/notReady nodes
+		logrus.Infof("Waiting for all nodes to rejoin cluster %q in namespace %q", elasticsearchRequest.cluster.Name, elasticsearchRequest.cluster.Namespace)
+
+		for _, node := range scheduledUpgradeNodes {
+			if err, _ := node.waitForNodeRejoinCluster(); err != nil {
+				return fmt.Errorf("Timed out waiting for %v to rejoin cluster %v", node.name(), elasticsearchRequest.cluster.Name)
+			}
+		}
+
+		// reenable shard allocation
+		if ok, err := esClient.SetShardAllocation(api.ShardAllocationAll); !ok {
+			return fmt.Errorf("Unable to enable shard allocation: %v", err)
+		}
+
+		updateUpdatingSettingsCondition(clusterStatus, v1.ConditionFalse)
+	}
+
+	// 5 -- recovery
+	// wait for cluster to go yellow/green again
+	if containsClusterCondition(api.Restarting, v1.ConditionTrue, clusterStatus) {
+
+		if err := RelaxNetworkPolicy(elasticsearchRequest.cluster.Namespace, elasticsearchRequest.client); err != nil {
+			return fmt.Errorf("Unable to delete network policy for cluster %s in namespace %s: %v", elasticsearchRequest.cluster.Name, elasticsearchRequest.cluster.Namespace, err)
+		}
+
+		status, err := esClient.GetClusterHealthStatus()
+		if err != nil {
+			return fmt.Errorf("Receieved error while trying to get cluster health for %q: %v", elasticsearchRequest.cluster.Name, err)
+		}
+
+		if !utils.Contains(desiredClusterStates, status) {
+			return fmt.Errorf("Waiting for cluster to recover: %s / %v", status, desiredClusterStates)
+		}
+
+		logrus.Infof("Completed full cluster restart on %v", elasticsearchRequest.cluster.Name)
 		updateRestartingCondition(clusterStatus, v1.ConditionFalse)
 	}
 

--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -653,6 +653,7 @@ func newNetworkPolicy(namespace string) networking.NetworkPolicy {
 
 	protocol := v1.ProtocolTCP
 	port := intstr.FromInt(9200)
+	internalPort := intstr.FromInt(9300)
 
 	return networking.NetworkPolicy{
 		TypeMeta: metav1.TypeMeta{
@@ -678,12 +679,49 @@ func newNetworkPolicy(namespace string) networking.NetworkPolicy {
 									"name": "elasticsearch-operator",
 								},
 							},
+							// This needs to be present but empty so it will select all namespaces
+							// since we do not have a label for our operator namespace
+							NamespaceSelector: &metav1.LabelSelector{},
 						},
 					},
 					Ports: []networking.NetworkPolicyPort{
 						{
 							Protocol: &protocol,
 							Port:     &port,
+						},
+					},
+				},
+				{
+					From: []networking.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"component": "elasticsearch",
+								},
+							},
+						},
+					},
+					Ports: []networking.NetworkPolicyPort{
+						{
+							Protocol: &protocol,
+							Port:     &port,
+						},
+					},
+				},
+				{
+					From: []networking.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"component": "elasticsearch",
+								},
+							},
+						},
+					},
+					Ports: []networking.NetworkPolicyPort{
+						{
+							Protocol: &protocol,
+							Port:     &internalPort,
 						},
 					},
 				},

--- a/pkg/k8shandler/cr.go
+++ b/pkg/k8shandler/cr.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	loggingv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -13,7 +14,11 @@ func GetElasticsearchCR(c client.Client, ns string) (*loggingv1.Elasticsearch, e
 	opts := &client.ListOptions{Namespace: ns}
 
 	if err := c.List(context.TODO(), opts, esl); err != nil {
-		return nil, fmt.Errorf("failed to find elasticsearch instance in %q: %s", ns, err)
+		if errors.IsNotFound(err) {
+			return nil, err
+		}
+
+		return nil, fmt.Errorf("unable to get elasticsearch instance in %q: %w", ns, err)
 	}
 
 	if len(esl.Items) == 0 {

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -340,11 +340,6 @@ func (node *deploymentNode) rollingRestart(upgradeStatus *api.ElasticsearchNodeS
 
 		if replicas > 0 {
 
-			if err := EnforceNetworkPolicy(node.self.Namespace, node.client, node.self.ObjectMeta.OwnerReferences); err != nil {
-				logrus.Warnf("Unable to create network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
-				return
-			}
-
 			// disable shard allocation
 			if ok, err := node.esClient.SetShardAllocation(api.ShardAllocationPrimaries); !ok {
 				logrus.Warnf("Unable to disable shard allocation: %v", err)
@@ -403,11 +398,6 @@ func (node *deploymentNode) rollingRestart(upgradeStatus *api.ElasticsearchNodeS
 	}
 
 	if upgradeStatus.UpgradeStatus.UpgradePhase == api.RecoveringData {
-
-		if err := RelaxNetworkPolicy(node.self.Namespace, node.client); err != nil {
-			logrus.Warnf("Unable to delete network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
-			return
-		}
 
 		if status, _ := node.esClient.GetClusterHealthStatus(); !utils.Contains(desiredClusterStates, status) {
 			logrus.Infof("Waiting for cluster to recover: %s / %v", status, desiredClusterStates)
@@ -497,11 +487,6 @@ func (node *deploymentNode) update(upgradeStatus *api.ElasticsearchNodeStatus) e
 	if upgradeStatus.UpgradeStatus.UpgradePhase == "" ||
 		upgradeStatus.UpgradeStatus.UpgradePhase == api.ControllerUpdated {
 
-		if err := EnforceNetworkPolicy(node.self.Namespace, node.client, node.self.ObjectMeta.OwnerReferences); err != nil {
-			logrus.Warnf("Unable to create network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
-			return err
-		}
-
 		// disable shard allocation
 		if ok, err := node.esClient.SetShardAllocation(api.ShardAllocationPrimaries); !ok {
 			logrus.Warnf("Unable to disable shard allocation: %v", err)
@@ -557,11 +542,6 @@ func (node *deploymentNode) update(upgradeStatus *api.ElasticsearchNodeStatus) e
 	}
 
 	if upgradeStatus.UpgradeStatus.UpgradePhase == api.RecoveringData {
-
-		if err := RelaxNetworkPolicy(node.self.Namespace, node.client); err != nil {
-			logrus.Warnf("Unable to delete network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
-			return err
-		}
 
 		if status, err := node.esClient.GetClusterHealthStatus(); !utils.Contains(desiredClusterStates, status) {
 			logrus.Infof("Waiting for cluster to recover: %s / %v", status, desiredClusterStates)

--- a/pkg/k8shandler/kibana/reconciler.go
+++ b/pkg/k8shandler/kibana/reconciler.go
@@ -48,6 +48,10 @@ func Reconcile(request reconcile.Request, k8sClient client.Client, esClient elas
 
 	err := k8sClient.Get(context.TODO(), key, kibanaInstance)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+
 		return err
 	}
 

--- a/pkg/k8shandler/nodetypefactory.go
+++ b/pkg/k8shandler/nodetypefactory.go
@@ -22,6 +22,8 @@ type NodeTypeInterface interface {
 	updateReference(node NodeTypeInterface)
 	delete() error
 	isMissing() bool
+	progressNodeChanges(upgradeStatus *api.ElasticsearchNodeStatus) error // this function is used to tell the node to push out its changes
+	waitForNodeRejoinCluster() (error, bool)                              // this function is used to determine if a node has rejoined the cluster
 }
 
 // NodeTypeFactory is a factory to construct either statefulset or deployment

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -278,11 +278,6 @@ func (node *statefulSetNode) rollingRestart(upgradeStatus *api.ElasticsearchNode
 	if upgradeStatus.UpgradeStatus.UpgradePhase == "" ||
 		upgradeStatus.UpgradeStatus.UpgradePhase == api.ControllerUpdated {
 
-		if err := EnforceNetworkPolicy(node.self.Namespace, node.client, node.self.ObjectMeta.OwnerReferences); err != nil {
-			logrus.Warnf("Unable to create network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
-			return
-		}
-
 		upgradeStatus.UpgradeStatus.UpgradePhase = api.NodeRestarting
 	}
 
@@ -341,11 +336,6 @@ func (node *statefulSetNode) rollingRestart(upgradeStatus *api.ElasticsearchNode
 	}
 
 	if upgradeStatus.UpgradeStatus.UpgradePhase == api.RecoveringData {
-
-		if err := RelaxNetworkPolicy(node.self.Namespace, node.client); err != nil {
-			logrus.Warnf("Unable to delete network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
-			return
-		}
 
 		upgradeStatus.UpgradeStatus.UpgradePhase = api.ControllerUpdated
 		upgradeStatus.UpgradeStatus.UnderUpgrade = ""
@@ -494,11 +484,6 @@ func (node *statefulSetNode) update(upgradeStatus *api.ElasticsearchNodeStatus) 
 	if upgradeStatus.UpgradeStatus.UpgradePhase == "" ||
 		upgradeStatus.UpgradeStatus.UpgradePhase == api.ControllerUpdated {
 
-		if err := EnforceNetworkPolicy(node.self.Namespace, node.client, node.self.ObjectMeta.OwnerReferences); err != nil {
-			logrus.Warnf("Unable to create network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
-			return err
-		}
-
 		if err := node.executeUpdate(); err != nil {
 			return err
 		}
@@ -549,11 +534,6 @@ func (node *statefulSetNode) update(upgradeStatus *api.ElasticsearchNodeStatus) 
 	}
 
 	if upgradeStatus.UpgradeStatus.UpgradePhase == api.RecoveringData {
-
-		if err := RelaxNetworkPolicy(node.self.Namespace, node.client); err != nil {
-			logrus.Warnf("Unable to delete network policy for cluster %s in namespace %s: %v", node.clusterName, node.self.Namespace, err)
-			return err
-		}
 
 		upgradeStatus.UpgradeStatus.UpgradePhase = api.ControllerUpdated
 		upgradeStatus.UpgradeStatus.UnderUpgrade = ""

--- a/pkg/k8shandler/status.go
+++ b/pkg/k8shandler/status.go
@@ -44,10 +44,10 @@ func (elasticsearchRequest *ElasticsearchRequest) UpdateClusterStatus() error {
 		clusterStatus.ShardAllocationEnabled = api.ShardAllocationNone
 	case allocation == "primaries":
 		clusterStatus.ShardAllocationEnabled = api.ShardAllocationPrimaries
-	case err != nil:
-		clusterStatus.ShardAllocationEnabled = api.ShardAllocationUnknown
-	default:
+	case allocation == "all":
 		clusterStatus.ShardAllocationEnabled = api.ShardAllocationAll
+	default:
+		clusterStatus.ShardAllocationEnabled = api.ShardAllocationUnknown
 	}
 
 	clusterStatus.Pods = rolePodStateMap(cluster.Namespace, cluster.Name, elasticsearchRequest.client)

--- a/pkg/types/elasticsearch/types.go
+++ b/pkg/types/elasticsearch/types.go
@@ -129,3 +129,29 @@ type CatIndicesResponse struct {
 	StoreSize        string `json:"store.size,omitempty"`
 	PrimaryStoreSize string `json:"pri.store.size,omitempty"`
 }
+
+type MasterNodeAndNodeStateResponse struct {
+	ClusterName string                       `json:"cluster_name,omitempty"`
+	MasterNode  string                       `json:"master_node,omitempty"`
+	Nodes       map[string]NodeStateResponse `json:"nodes,omitempty"`
+}
+
+type NodesStateResponse struct {
+	Nodes map[string]NodeStateResponse `json:"nodes,omitempty"`
+}
+
+type NodeStateResponse struct {
+	Name             string            `json:"name,omitempty"`
+	EphemeralID      string            `json:"ephemeral_id,omitempty"`
+	TransportAddress string            `json:"transport_address,omitempty"`
+	Attributes       map[string]string `json:"attributes,omitempty"`
+}
+
+type StatsNodesResponse struct {
+	Nodes StatsNode `json:"nodes,omitempty"`
+}
+
+type StatsNode struct {
+	Versions []string       `json:"versions,omitempty"`
+	Count    map[string]int `json:"count,omitempty"`
+}

--- a/pkg/utils/comparators/versions.go
+++ b/pkg/utils/comparators/versions.go
@@ -1,0 +1,59 @@
+package comparators
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// CompareVersions will return one of:
+// -1 : if lhs > rhs
+// 0  : if lhs == rhs
+// 1  : if rhs > lhs
+func CompareVersions(lhs, rhs string) int {
+	lVersions := buildVersionArray(lhs)
+	rVersions := buildVersionArray(rhs)
+
+	lLen := len(lVersions)
+	rLen := len(rVersions)
+
+	for i := 0; i < lLen && i < rLen; i++ {
+		if lVersions[i] > rVersions[i] {
+			return -1
+		}
+
+		if lVersions[i] < rVersions[i] {
+			return 1
+		}
+	}
+
+	// check if lhs is a more specific version number (aka newer)
+	if lLen > rLen {
+		return -1
+	}
+
+	// check if rhs is a more specific version number
+	if lLen < rLen {
+		return 1
+	}
+
+	// versions are exactly the same
+	return 0
+}
+
+func buildVersionArray(version string) []int {
+
+	versions := []int{}
+	for _, v := range strings.Split(version, ".") {
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			logrus.Warnf("unable to build version array: %v", err)
+			break
+		}
+
+		versions = append(versions, i)
+	}
+
+	return versions
+}

--- a/pkg/utils/comparators/versions_test.go
+++ b/pkg/utils/comparators/versions_test.go
@@ -1,0 +1,135 @@
+package comparators
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestVersionsEqual(t *testing.T) {
+
+	lhs := "5.6.16"
+	rhs := "5.6.16"
+
+	comparison := CompareVersions(lhs, rhs)
+
+	// if lhs is newer we expect -1
+	// 0 if they're the same
+	// 1 if rhs is newer
+	if comparison != 0 {
+		t.Errorf("Expected %q to be same as %q", rhs, lhs)
+	}
+}
+
+func TestLhsVersionNewer(t *testing.T) {
+
+	lhs := "6.8.1"
+	rhs := "5.6.16"
+
+	comparison := CompareVersions(lhs, rhs)
+
+	// if lhs is newer we expect -1
+	// 0 if they're the same
+	// 1 if rhs is newer
+	if comparison != -1 {
+		t.Errorf("Expected %q to be newer than %q", lhs, rhs)
+	}
+}
+
+func TestRhsVersionNewer(t *testing.T) {
+
+	lhs := "5.6.16"
+	rhs := "6.8.1"
+
+	comparison := CompareVersions(lhs, rhs)
+
+	// if lhs is newer we expect -1
+	// 0 if they're the same
+	// 1 if rhs is newer
+	if comparison != 1 {
+		t.Errorf("Expected %q to be newer than %q", rhs, lhs)
+	}
+}
+
+func TestRhsReleaseVersionMissing(t *testing.T) {
+
+	lhs := "6.8.1"
+	rhs := "6.8"
+
+	comparison := CompareVersions(lhs, rhs)
+
+	// if lhs is newer we expect -1
+	// 0 if they're the same
+	// 1 if rhs is newer
+	if comparison != -1 {
+		t.Errorf("Expected %q to be newer than %q", lhs, rhs)
+	}
+}
+
+func TestRhsMinorVersionMissing(t *testing.T) {
+
+	lhs := "6.8.1"
+	rhs := "6"
+
+	comparison := CompareVersions(lhs, rhs)
+
+	// if lhs is newer we expect -1
+	// 0 if they're the same
+	// 1 if rhs is newer
+	if comparison != -1 {
+		t.Errorf("Expected %q to be newer than %q", lhs, rhs)
+	}
+}
+
+func TestLhsReleaseVersionNewer(t *testing.T) {
+
+	lhs := "6.8.1"
+	rhs := "6.8.0"
+
+	comparison := CompareVersions(lhs, rhs)
+
+	// if lhs is newer we expect -1
+	// 0 if they're the same
+	// 1 if rhs is newer
+	if comparison != -1 {
+		t.Errorf("Expected %q to be newer than %q", lhs, rhs)
+	}
+}
+
+func TestLhsMinorVersionNewer(t *testing.T) {
+
+	lhs := "6.8.1"
+	rhs := "6.0"
+
+	comparison := CompareVersions(lhs, rhs)
+
+	// if lhs is newer we expect -1
+	// 0 if they're the same
+	// 1 if rhs is newer
+	if comparison != -1 {
+		t.Errorf("Expected %q to be newer than %q", lhs, rhs)
+	}
+}
+
+func TestValidVersionArray(t *testing.T) {
+
+	version := "6.8.1"
+	expectedArray := []int{6, 8, 1}
+
+	actualArray := buildVersionArray(version)
+
+	if !reflect.DeepEqual(expectedArray, actualArray) {
+		t.Errorf("Expected: %v \nActual: %v", expectedArray, actualArray)
+	}
+}
+
+func TestInvalidVersionArray(t *testing.T) {
+
+	version := "6.8.a.0"
+	expectedArray := []int{6, 8}
+
+	actualArray := buildVersionArray(version)
+
+	if !reflect.DeepEqual(expectedArray, actualArray) {
+		t.Errorf("Expected: %v \nActual: %v", expectedArray, actualArray)
+	}
+}


### PR DESCRIPTION
Manual cherrypick of:
* https://github.com/openshift/elasticsearch-operator/pull/367
* https://github.com/openshift/elasticsearch-operator/pull/383

367 was opened to address missing port definitions and namespace label selectors on the networkpolicy as well as performing a full cluster restart when upgrading from ES5x to ES6x.

383 removes the use of the network policy due to it working inconsistently, the fact that we do a full cluster restart and assign `primaries` for shard allocation should mitigate any risk that introducing a networkpolicy was going to address.