### PR TITLE
Bug 1845539: Update olm.skipRange constraint to 4.4.0-0

### DIFF
--- a/manifests/4.5/elasticsearch-operator.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/elasticsearch-operator.v4.5.0.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
     containerImage: quay.io/openshift/origin-elasticsearch-operator:latest
     createdAt: 2019-02-20T08:00:00Z
     support: AOS Cluster Logging, Jaeger
-    olm.skipRange: ">=4.4.0 <4.5.0"
+    olm.skipRange: ">=4.4.0-0 <4.5.0"
     alm-examples: |-
         [
             {

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -7,8 +7,8 @@ updates:
     # replace entire version line, otherwise would replace {MAJOR}.{MINOR}.0 anywhere
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
-    - search: 'olm.skipRange: ">=4.4.0 <{MAJOR}.{MINOR}.0"'
-      replace: 'olm.skipRange: ">=4.4.0 <{FULL_VER}"'
+    - search: 'olm.skipRange: ">=4.4.0-0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.4.0-0 <{FULL_VER}"'
   - file: "elasticsearch-operator.package.yaml"
     update_list:
     - search: "currentCSV: elasticsearch-operator.v{MAJOR}.{MINOR}.0"


### PR DESCRIPTION
To address: https://bugzilla.redhat.com/show_bug.cgi?id=1845539

**Needs backport:** release-4.5