### PR TITLE
Bug 1850546: Add support label for s390x & ppc64le

### DIFF
--- a/manifests/4.6/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
@@ -5,6 +5,10 @@ kind: ClusterServiceVersion
 metadata:
   name: elasticsearch-operator.v4.6.0
   namespace: placeholder
+  labels:
+    "operatorframework.io/arch.amd64": supported
+    "operatorframework.io/arch.ppc64le": supported
+    "operatorframework.io/arch.s390x": supported
   annotations:
     "operatorframework.io/suggested-namespace": openshift-operators-redhat
     "operatorframework.io/cluster-monitoring": "true"


### PR DESCRIPTION
In order for the elasticsearch-operator to be correctly filtered in
the OperatorHub for s390x and ppc64le we need to add the correct arch
label as supported.