### PR TITLE
Update CRD apiVersion to apiextensions.k8s.io/v1

### DIFF
--- a/manifests/4.6/elasticsearches.crd.yaml
+++ b/manifests/4.6/elasticsearches.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: elasticsearches.logging.openshift.io
@@ -10,46 +10,152 @@ spec:
     plural: elasticsearches
     singular: elasticsearch
   scope: Namespaced
-  version: v1
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          description: Specification of the desired behavior of the Elasticsearch cluster
-          type: object
-          properties:
-            managementState:
-              description: Indicator if the resource is 'Managed' or 'Unmanaged' by the operator
-              type: string
-              enum:
-              - "Managed"
-              - "Unmanaged"
-            redundancyPolicy:
-              description: The policy towards data redundancy to specify the number of redundant primary shards
-              type: string
-              enum:
-              - "FullRedundancy"
-              - "MultipleRedundancy"
-              - "SingleRedundancy"
-              - "ZeroRedundancy"
-            nodes:
-              description: Specification of the different Elasticsearch nodes
-              type: array
-              items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            description: Specification of the desired behavior of the Elasticsearch cluster
+            type: object
+            properties:
+              managementState:
+                description: Indicator if the resource is 'Managed' or 'Unmanaged' by the operator
+                type: string
+                enum:
+                - "Managed"
+                - "Unmanaged"
+              redundancyPolicy:
+                description: The policy towards data redundancy to specify the number of redundant primary shards
+                type: string
+                enum:
+                - "FullRedundancy"
+                - "MultipleRedundancy"
+                - "SingleRedundancy"
+                - "ZeroRedundancy"
+              nodes:
+                description: Specification of the different Elasticsearch nodes
+                type: array
+                items:
+                  type: object
+                  properties:
+                    roles:
+                      description: The specific Elasticsearch cluster roles the node should perform
+                      type: array
+                      items:
+                        type: string
+                    nodeCount:
+                      description: Number of nodes to deploy
+                      format: int32
+                      type: integer
+                    resources:
+                      description: The resource requirements for the Elasticsearch node
+                      type: object
+                      nullable: true
+                      properties:
+                        limits:
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                          nullable: true
+                        requests:
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified, otherwise
+                            to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                          nullable: true
+                    nodeSelector:
+                      description: Define which Nodes the Pods are scheduled on.
+                      type: object
+                    tolerations:
+                      type: array
+                      items:
+                        type: object
+                    storage:
+                      description: The type of backing storage that should be used for the node
+                      type: object
+                      properties:
+                        storageClassName:
+                          description: The name of the storage class to use with creating the node's PVC
+                          type: string
+                        size:
+                          description: The max storage capacity for the node
+                          type: string
+                    genUUID:
+                      type: string
+                      nullable: true
+              indexManagement:
+                description: Management spec for indicies
                 type: object
+                nullable: true
                 properties:
-                  roles:
-                    description: The specific Elasticsearch cluster roles the node should perform
+                  policies:
+                    description: A list of polices for managing an indices
                     type: array
                     items:
-                      type: string
-                  nodeCount:
-                    description: Number of nodes to deploy
-                    format: int32
-                    type: integer
+                      type: object
+                      properties:
+                        name:
+                          description: The unique name of the policy
+                          type: string
+                        pollInterval:
+                          description: How often to check an index meets the desired criteria (e.g. 1m)
+                          type: string
+                        phases:
+                          type: object
+                          properties:
+                            delete:
+                              type: object
+                              nullable: true
+                              properties:
+                                minAge:
+                                  description: The minimum age of an index before it should be deleted (e.g. 10d)
+                                  type: string
+                            hot:
+                              type: object
+                              nullable: true
+                              properties:
+                                actions:
+                                  type: object
+                                  properties:
+                                    rollover:
+                                      type: object
+                                      nullable: true 
+                                      properties:
+                                        maxAge:
+                                          description: The maximum age of an index before it should be rolled over (e.g. 7d)
+                                          type: string
+                  mappings:
+                    description: Mappings of policies to indicies
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          description: The unique name of the policy mapping
+                          type: string
+                        policyRef:
+                          description: A reference to a defined policy
+                          type: string
+                        aliases:
+                          description: Aliases to apply to a template
+                          type: array
+                          items:
+                            type: string
+              nodeSpec:
+                description: Default specification applied to all Elasticsearch nodes
+                type: object
+                properties:
+                  image:
+                    description: The image to use for the Elasticsearch nodes
+                    type: string
+                    nullable: true
                   resources:
-                    description: The resource requirements for the Elasticsearch node
+                    description: The resource requirements for the Elasticsearch nodes
                     type: object
                     nullable: true
                     properties:
@@ -65,114 +171,11 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                         nullable: true
-                  nodeSelector:
-                    description: Define which Nodes the Pods are scheduled on.
-                    type: object
                   tolerations:
                     type: array
                     items:
                       type: object
-                  storage:
-                    description: The type of backing storage that should be used for the node
+                  nodeSelector:
+                    description: Define which Nodes the Pods are scheduled on.
                     type: object
-                    properties:
-                      storageClassName:
-                        description: The name of the storage class to use with creating the node's PVC
-                        type: string
-                      size:
-                        description: The max storage capacity for the node
-                        type: string
-                  genUUID:
-                    type: string
                     nullable: true
-            indexManagement:
-              description: Management spec for indicies
-              type: object
-              nullable: true
-              properties:
-                policies:
-                  description: A list of polices for managing an indices
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      name:
-                        description: The unique name of the policy
-                        type: string
-                      pollInterval:
-                        description: How often to check an index meets the desired criteria (e.g. 1m)
-                        type: string
-                      phases:
-                        type: object
-                        properties:
-                          delete:
-                            type: object
-                            nullable: true
-                            properties:
-                              minAge:
-                                description: The minimum age of an index before it should be deleted (e.g. 10d)
-                                type: string
-                          hot:
-                            type: object
-                            nullable: true
-                            properties:
-                              actions:
-                                type: object
-                                properties:
-                                  rollover:
-                                    type: object
-                                    nullable: true 
-                                    properties:
-                                      maxAge:
-                                        description: The maximum age of an index before it should be rolled over (e.g. 7d)
-                                        type: string
-                mappings:
-                  description: Mappings of policies to indicies
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      name:
-                        description: The unique name of the policy mapping
-                        type: string
-                      policyRef:
-                        description: A reference to a defined policy
-                        type: string
-                      aliases:
-                        description: Aliases to apply to a template
-                        type: array
-                        items:
-                          type: string
-            nodeSpec:
-              description: Default specification applied to all Elasticsearch nodes
-              type: object
-              properties:
-                image:
-                  description: The image to use for the Elasticsearch nodes
-                  type: string
-                  nullable: true
-                resources:
-                  description: The resource requirements for the Elasticsearch nodes
-                  type: object
-                  nullable: true
-                  properties:
-                    limits:
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                      nullable: true
-                    requests:
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                      nullable: true
-                tolerations:
-                  type: array
-                  items:
-                    type: object
-                nodeSelector:
-                  description: Define which Nodes the Pods are scheduled on.
-                  type: object
-                  nullable: true

--- a/manifests/4.6/kibanas.crd.yaml
+++ b/manifests/4.6/kibanas.crd.yaml
@@ -1,10 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kibanas.logging.openshift.io
 spec:
-  subresources:
-    status: {}
   group: logging.openshift.io
   names:
     kind: Kibana
@@ -12,54 +10,59 @@ spec:
     plural: kibanas
     singular: kibana
   scope: Namespaced
-  version: v1
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          description: Specification of the desired behavior of the Kibana
-          properties:
-            resources:
-              type: object
-              description: The resource requirements for Kibana
-              nullable: true
-              properties:
-                limits:
-                  type: object
-                  description: 'Limits describes the maximum amount of compute
-                    resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  nullable: true
-                requests:
-                  type: object
-                  nullable: true
-                  description: 'Requests describes the minimum amount of compute
-                    resources required. If Requests is omitted for a container,
-                    it defaults to Limits if that is explicitly specified, otherwise
-                    to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-            replicas:
-              type: integer
-              description: Number of instances to deploy for a Kibana deployment
-              format: int32
-            proxySpec:
-              type: object
-              description: Specification of the Kibana Proxy component
-              properties:
-                resources:
-                  type: object
-                  description: The resource requirements for Kibana
-                  nullable: true
-                  properties:
-                    limits:
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                      nullable: true
-                    requests:
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                      nullable: true
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: Specification of the desired behavior of the Kibana
+            properties:
+              resources:
+                type: object
+                description: The resource requirements for Kibana
+                nullable: true
+                properties:
+                  limits:
+                    type: object
+                    description: 'Limits describes the maximum amount of compute
+                      resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    nullable: true
+                  requests:
+                    type: object
+                    nullable: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+              replicas:
+                type: integer
+                description: Number of instances to deploy for a Kibana deployment
+                format: int32
+              proxySpec:
+                type: object
+                description: Specification of the Kibana Proxy component
+                properties:
+                  resources:
+                    type: object
+                    description: The resource requirements for Kibana
+                    nullable: true
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                        nullable: true
+                      requests:
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                        nullable: true


### PR DESCRIPTION
This PR is a follow-up to #291 to address the missing update of CRD apiVersion to `apiextensions.k8s.io/v1`.

**Depends for upgrade verification on:** #314 