### PR TITLE
Bug 1848696: disable system_call_filter check on non-amd64 architectures

### DIFF
--- a/pkg/k8shandler/configmaps.go
+++ b/pkg/k8shandler/configmaps.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"runtime"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
@@ -31,6 +32,7 @@ type esYmlStruct struct {
 	EsUnicastHost         string
 	NodeQuorum            string
 	RecoverExpectedShards string
+	SystemCallFilter      string
 }
 
 type log4j2PropertiesStruct struct {
@@ -68,6 +70,7 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateConfigMaps() (er
 		strconv.Itoa(dataNodeCount),
 		strconv.Itoa(dataNodeCount),
 		strconv.Itoa(calculateReplicaCount(dpl)),
+		strconv.FormatBool(runtime.GOARCH == "amd64"),
 		logConfig,
 	)
 
@@ -117,11 +120,11 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateConfigMaps() (er
 	return nil
 }
 
-func renderData(kibanaIndexMode, esUnicastHost, nodeQuorum, recoverExpectedShards, primaryShardsCount, replicaShardsCount string, logConfig LogConfig) (error, map[string]string) {
+func renderData(kibanaIndexMode, esUnicastHost, nodeQuorum, recoverExpectedShards, primaryShardsCount, replicaShardsCount, systemCallFilter string, logConfig LogConfig) (error, map[string]string) {
 
 	data := map[string]string{}
 	buf := &bytes.Buffer{}
-	if err := renderEsYml(buf, kibanaIndexMode, esUnicastHost, nodeQuorum, recoverExpectedShards); err != nil {
+	if err := renderEsYml(buf, kibanaIndexMode, esUnicastHost, nodeQuorum, recoverExpectedShards, systemCallFilter); err != nil {
 		return err, data
 	}
 	data[esConfig] = buf.String()
@@ -143,9 +146,9 @@ func renderData(kibanaIndexMode, esUnicastHost, nodeQuorum, recoverExpectedShard
 
 // newConfigMap returns a v1.ConfigMap object
 func newConfigMap(configMapName, namespace string, labels map[string]string,
-	kibanaIndexMode, esUnicastHost, nodeQuorum, recoverExpectedShards, primaryShardsCount, replicaShardsCount string, logConfig LogConfig) *v1.ConfigMap {
+	kibanaIndexMode, esUnicastHost, nodeQuorum, recoverExpectedShards, primaryShardsCount, replicaShardsCount, systemCallFilter string, logConfig LogConfig) *v1.ConfigMap {
 
-	err, data := renderData(kibanaIndexMode, esUnicastHost, nodeQuorum, recoverExpectedShards, primaryShardsCount, replicaShardsCount, logConfig)
+	err, data := renderData(kibanaIndexMode, esUnicastHost, nodeQuorum, recoverExpectedShards, primaryShardsCount, replicaShardsCount, systemCallFilter, logConfig)
 	if err != nil {
 		return nil
 	}
@@ -189,7 +192,7 @@ func configMapContentChanged(old, new *v1.ConfigMap) bool {
 	return false
 }
 
-func renderEsYml(w io.Writer, kibanaIndexMode, esUnicastHost, nodeQuorum, recoverExpectedShards string) error {
+func renderEsYml(w io.Writer, kibanaIndexMode, esUnicastHost, nodeQuorum, recoverExpectedShards, systemCallFilter string) error {
 	t := template.New("elasticsearch.yml")
 	config := esYmlTmpl
 	t, err := t.Parse(config)
@@ -201,6 +204,7 @@ func renderEsYml(w io.Writer, kibanaIndexMode, esUnicastHost, nodeQuorum, recove
 		EsUnicastHost:         esUnicastHost,
 		NodeQuorum:            nodeQuorum,
 		RecoverExpectedShards: recoverExpectedShards,
+		SystemCallFilter:      systemCallFilter,
 	}
 
 	return t.Execute(w, esy)

--- a/pkg/k8shandler/configuration_tmpl.go
+++ b/pkg/k8shandler/configuration_tmpl.go
@@ -4,6 +4,9 @@ const esYmlTmpl = `
 cluster:
   name: ${CLUSTER_NAME}
 
+bootstrap:
+  system_call_filter: {{.SystemCallFilter}}
+
 node:
   name: ${DC_NAME}
   master: ${IS_MASTER}

--- a/pkg/k8shandler/confimaps_test.go
+++ b/pkg/k8shandler/confimaps_test.go
@@ -15,10 +15,13 @@ var _ = Describe("configmaps", func() {
 	Describe("#renderEsYml", func() {
 		It("should produce an elasticsearch.yml for our managed elasticsearch instance", func() {
 			result := &bytes.Buffer{}
-			Expect(renderEsYml(result, "", "my.unicast.host", "7", "4")).To(BeNil(), "Exp. no errors when rendering the configuration")
+			Expect(renderEsYml(result, "", "my.unicast.host", "7", "4", "false")).To(BeNil(), "Exp. no errors when rendering the configuration")
 			helpers.ExpectYaml(result.String()).ToEqual(`
 cluster:
   name: ${CLUSTER_NAME}
+
+bootstrap:
+  system_call_filter: false
 
 node:
   name: ${DC_NAME}


### PR DESCRIPTION
This bootstrap check requires architecture-specific supporting code in ElasticSearch, which upstream has outright refused to accept.

Fixing here instead of in logging-elasticsearch based on feedback in https://github.com/openshift/origin-aggregated-logging/pull/1927