### PR TITLE
Refactor E2E tests to separate test cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ uninstall:
 RANDOM_SUFFIX:=$(shell echo $$RANDOM)
 TEST_NAMESPACE?="e2e-test-${RANDOM_SUFFIX}"
 test-e2e-olm: DEPLOYMENT_NAMESPACE="${TEST_NAMESPACE}"
-test-e2e-olm: gen-example-certs 
+test-e2e-olm:
 	TEST_NAMESPACE=${TEST_NAMESPACE} hack/test-e2e-olm.sh
 
 elasticsearch-catalog: elasticsearch-catalog-build elasticsearch-catalog-deploy

--- a/hack/testing-olm/test-200-verify-es-metrics-access.sh
+++ b/hack/testing-olm/test-200-verify-es-metrics-access.sh
@@ -52,6 +52,7 @@ if [ "${DO_SETUP:-true}" == "true" ] ; then
   export ELASTICSEARCH_OPERATOR_NAMESPACE=${TEST_NAMESPACE}
   deploy_elasticsearch_operator
 
+  expect_success "${repo_dir}/hack/cert_generation.sh /tmp/example-secrets ${TEST_NAMESPACE} elasticsearch"
   expect_success "${repo_dir}/hack/deploy-example-secrets.sh  ${TEST_NAMESPACE}"
   expect_success "oc -n ${TEST_NAMESPACE} create -f ${repo_dir}/hack/cr.yaml"
 

--- a/hack/testing-olm/test-657-im-block-autocreate-for-write-suffix.sh
+++ b/hack/testing-olm/test-657-im-block-autocreate-for-write-suffix.sh
@@ -48,6 +48,7 @@ if [ "${DO_SETUP:-true}" == "true" ] ; then
   export ELASTICSEARCH_OPERATOR_NAMESPACE=${TEST_NAMESPACE}
   deploy_elasticsearch_operator
   #deploy elasticsearch cluster
+  expect_success "${repo_dir}/hack/cert_generation.sh /tmp/example-secrets ${TEST_NAMESPACE} elasticsearch"
   expect_success "${repo_dir}/hack/deploy-example-secrets.sh  ${TEST_NAMESPACE}"
   expect_success "oc -n ${TEST_NAMESPACE} create -f ${repo_dir}/hack/cr.yaml"
 

--- a/pkg/elasticsearch/client.go
+++ b/pkg/elasticsearch/client.go
@@ -34,6 +34,8 @@ const (
 )
 
 type Client interface {
+	ClusterName() string
+
 	// Cluster Settings API
 	GetClusterNodeVersions() ([]string, error)
 	GetThresholdEnabled() (bool, error)
@@ -117,6 +119,10 @@ func NewClient(cluster, namespace string, client k8sclient.Client) Client {
 
 func (ec *esClient) SetSendRequestFn(fn FnEsSendRequest) {
 	ec.fnSendEsRequest = fn
+}
+
+func (ec *esClient) ClusterName() string {
+	return ec.cluster
 }
 
 func sendEsRequest(cluster, namespace string, payload *EsRequest, client k8sclient.Client) {

--- a/pkg/k8shandler/kibana/reconciler.go
+++ b/pkg/k8shandler/kibana/reconciler.go
@@ -117,7 +117,8 @@ func reconcileKibana(requestCluster *kibana.Kibana, requestClient client.Client,
 		return err
 	}
 
-	if err := clusterKibanaRequest.createOrUpdateKibanaDeployment(proxyConfig); err != nil {
+	clusterName := esClient.ClusterName()
+	if err := clusterKibanaRequest.createOrUpdateKibanaDeployment(proxyConfig, clusterName); err != nil {
 		return err
 	}
 
@@ -243,7 +244,7 @@ func (clusterRequest *KibanaRequest) deleteKibana5Deployment() error {
 	return nil
 }
 
-func (clusterRequest *KibanaRequest) createOrUpdateKibanaDeployment(proxyConfig *configv1.Proxy) (err error) {
+func (clusterRequest *KibanaRequest) createOrUpdateKibanaDeployment(proxyConfig *configv1.Proxy, clusterName string) (err error) {
 	kibanaTrustBundle := &v1.ConfigMap{}
 
 	// Create cluster proxy trusted CA bundle.
@@ -256,7 +257,7 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaDeployment(proxyConfig 
 
 	kibanaPodSpec := newKibanaPodSpec(
 		clusterRequest,
-		fmt.Sprintf("elasticsearch.%s.svc.cluster.local", clusterRequest.cluster.Namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", clusterName, clusterRequest.cluster.Namespace),
 		proxyConfig,
 		kibanaTrustBundle,
 	)

--- a/test/e2e-olm/elasticsearch_test.go
+++ b/test/e2e-olm/elasticsearch_test.go
@@ -1,37 +1,206 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
+	loggingv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
 	"github.com/openshift/elasticsearch-operator/test/utils"
+
+	"github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/types"
-
-	goctx "context"
-
-	elasticsearch "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
-	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestElasticsearch(t *testing.T) {
+func TestElasticsearchCluster(t *testing.T) {
 	registerSchemes(t)
-	t.Run("elasticsearch-group", func(t *testing.T) {
-		t.Run("Cluster", ElasticsearchCluster)
-	})
+	t.Run("Single node", singleNodeTest)
+	t.Run("Multiple nodes", multipleNodesTest)
+	t.Run("Scale up nodes", scaleUpNodesTest)
+	t.Run("Multiple nodes with a single non-data node", multipleNodesWithNonDataNodeTest)
+	t.Run("Full cluster redeploy", fullClusterRedeployTest)
+	t.Run("Rolling restart", rollingRestartTest)
+	t.Run("Invalid master count", invalidMasterCountTest)
 }
 
-func elasticsearchFullClusterTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
-	namespace, err := ctx.GetNamespace()
+func singleNodeTest(t *testing.T) {
+	f := test.Global
+
+	ctx := test.NewContext(t)
+	namespace, err := ctx.GetWatchNamespace()
 	if err != nil {
-		return fmt.Errorf("Could not get namespace: %v", err)
+		t.Fatal(err)
+	}
+	t.Logf("Found namespace: %v", namespace)
+
+	esUUID := utils.GenerateUUID()
+	t.Logf("Using UUID for elasticsearch CR: %v", esUUID)
+
+	if err = createElasticsearchSecret(t, f, ctx, esUUID); err != nil {
+		t.Fatal(err)
 	}
 
 	dataUUID := utils.GenerateUUID()
 	t.Logf("Using GenUUID for data nodes: %v", dataUUID)
+
+	// Create CR with a single node with client, data and master roles
+	cr, err := createElasticsearchCR(t, f, ctx, esUUID, dataUUID, 1)
+	if err != nil {
+		t.Fatalf("could not create exampleElasticsearch: %v", err)
+	}
+
+	dplName := fmt.Sprintf("elasticsearch-%v-cdm-%v-1", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatalf("timed out waiting for first node deployment %v: %v", dplName, err)
+	}
+
+	ctx.Cleanup()
+	e2eutil.WaitForDeletion(t, f.Client.Client, cr, cleanupRetryInterval, cleanupTimeout)
+	t.Log("Finished successfully")
+}
+
+func multipleNodesTest(t *testing.T) {
+	f := test.Global
+
+	ctx := test.NewContext(t)
+	namespace, err := ctx.GetWatchNamespace()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Found namespace: %v", namespace)
+
+	esUUID := utils.GenerateUUID()
+	t.Logf("Using UUID for elasticsearch CR: %v", esUUID)
+
+	if err = createElasticsearchSecret(t, f, ctx, esUUID); err != nil {
+		t.Fatal(err)
+	}
+
+	dataUUID := utils.GenerateUUID()
+	t.Logf("Using GenUUID for data nodes: %v", dataUUID)
+
+	// Create CR with two nodes sharing client, data and master roles
+	cr, err := createElasticsearchCR(t, f, ctx, esUUID, dataUUID, 2)
+	if err != nil {
+		t.Fatalf("could not create exampleElasticsearch: %v", err)
+	}
+
+	dplName := fmt.Sprintf("elasticsearch-%v-cdm-%v-1", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatalf("timed out waiting for first node deployment %v: %v", dplName, err)
+	}
+
+	dplName = fmt.Sprintf("elasticsearch-%v-cdm-%v-2", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatalf("timed out waiting for second node deployment %v: %v", dplName, err)
+	}
+
+	ctx.Cleanup()
+	e2eutil.WaitForDeletion(t, f.Client.Client, cr, cleanupRetryInterval, cleanupTimeout)
+	t.Log("Finished successfully")
+}
+
+func scaleUpNodesTest(t *testing.T) {
+	f := test.Global
+
+	ctx := test.NewContext(t)
+	namespace, err := ctx.GetWatchNamespace()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Found namespace: %v", namespace)
+
+	esUUID := utils.GenerateUUID()
+	t.Logf("Using UUID for elasticsearch CR: %v", esUUID)
+
+	if err = createElasticsearchSecret(t, f, ctx, esUUID); err != nil {
+		t.Fatal(err)
+	}
+
+	dataUUID := utils.GenerateUUID()
+	t.Logf("Using GenUUID for data nodes: %v", dataUUID)
+
+	// Create CR with one node sharing client, data and master roles
+	cr, err := createElasticsearchCR(t, f, ctx, esUUID, dataUUID, 1)
+	if err != nil {
+		t.Fatalf("could not create exampleElasticsearch: %v", err)
+	}
+
+	dplName := fmt.Sprintf("elasticsearch-%v-cdm-%v-1", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatalf("timed out waiting for first node deployment %v: %v", dplName, err)
+	}
+
+	t.Log("Adding a new data node")
+	cr.Spec.Nodes[0].NodeCount = int32(2)
+
+	if err := updateElasticsearchSpec(t, f, cr); err != nil {
+		t.Fatalf("could not update elasticsearch CR with an additional data node: %v", err)
+	}
+
+	dplName = fmt.Sprintf("elasticsearch-%v-cdm-%v-1", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatalf("timed out waiting for first node deployment %v: %v", dplName, err)
+	}
+
+	dplName = fmt.Sprintf("elasticsearch-%v-cdm-%v-2", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatalf("timed out waiting for second node deployment %v: %v", dplName, err)
+	}
+
+	ctx.Cleanup()
+	e2eutil.WaitForDeletion(t, f.Client.Client, cr, cleanupRetryInterval, cleanupTimeout)
+	t.Log("Finished successfully")
+}
+
+func multipleNodesWithNonDataNodeTest(t *testing.T) {
+	f := test.Global
+
+	ctx := test.NewContext(t)
+	namespace, err := ctx.GetWatchNamespace()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Found namespace: %v", namespace)
+
+	esUUID := utils.GenerateUUID()
+	t.Logf("Using UUID for elasticsearch CR: %v", esUUID)
+
+	if err = createElasticsearchSecret(t, f, ctx, esUUID); err != nil {
+		t.Fatal(err)
+	}
+
+	dataUUID := utils.GenerateUUID()
+	t.Logf("Using GenUUID for data nodes: %v", dataUUID)
+
+	// Create CR with two nodes sharing client, data and master roles
+	cr, err := createElasticsearchCR(t, f, ctx, esUUID, dataUUID, 2)
+	if err != nil {
+		t.Fatalf("could not create exampleElasticsearch: %v", err)
+	}
+
+	dplName := fmt.Sprintf("elasticsearch-%v-cdm-%v-1", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatalf("timed out waiting for first node deployment %v: %v", dplName, err)
+	}
+
+	dplName = fmt.Sprintf("elasticsearch-%v-cdm-%v-2", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatalf("timed out waiting for second node deployment %v: %v", dplName, err)
+	}
 
 	nonDataUUID := utils.GenerateUUID()
 	t.Logf("Using GenUUID for non data nodes: %v", nonDataUUID)
@@ -39,121 +208,95 @@ func elasticsearchFullClusterTest(t *testing.T, f *framework.Framework, ctx *fra
 	storageClassName := "gp2"
 	storageClassSize := resource.MustParse("2G")
 
-	esNonDataNode := elasticsearch.ElasticsearchNode{
-		Roles: []elasticsearch.ElasticsearchNodeRole{
-			elasticsearch.ElasticsearchRoleClient,
-			elasticsearch.ElasticsearchRoleMaster,
+	esNonDataNode := loggingv1.ElasticsearchNode{
+		Roles: []loggingv1.ElasticsearchNodeRole{
+			loggingv1.ElasticsearchRoleClient,
+			loggingv1.ElasticsearchRoleMaster,
 		},
 		NodeCount: int32(1),
-		Storage: elasticsearch.ElasticsearchStorageSpec{
+		Storage: loggingv1.ElasticsearchStorageSpec{
 			StorageClassName: &storageClassName,
 			Size:             &storageClassSize,
 		},
 		GenUUID: &nonDataUUID,
 	}
 
-	exampleElasticsearch, err := createElasticsearchCR(t, f, ctx, dataUUID)
-	if err != nil {
-		return fmt.Errorf("could not create exampleElasticsearch: %v", err)
+	t.Log("Adding non-data node")
+	cr.Spec.Nodes = append(cr.Spec.Nodes, esNonDataNode)
+
+	if err := updateElasticsearchSpec(t, f, cr); err != nil {
+		t.Fatalf("could not update elasticsearch CR with an additional non-data node: %v", err)
 	}
 
-	deploymentName := fmt.Sprintf("elasticsearch-cdm-%v-1", dataUUID)
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, deploymentName, 1, retryInterval, timeout)
+	statefulSetName := fmt.Sprintf("elasticsearch-%v-cm-%v", esUUID, nonDataUUID)
+	err = utils.WaitForStatefulset(t, f.KubeClient, namespace, statefulSetName, 1, retryInterval, timeout)
 	if err != nil {
-		return fmt.Errorf("timed out waiting for initial Deployment %v: %v", deploymentName, err)
-	}
-	t.Log("Created initial deployment")
-
-	// Scale up current node
-	// then look for elasticsearch-cdm-0-2 and prior node
-	t.Log("Scaling up the current node...")
-	exampleName := types.NamespacedName{Name: elasticsearchCRName, Namespace: namespace}
-	if err = f.Client.Get(goctx.TODO(), exampleName, exampleElasticsearch); err != nil {
-		return fmt.Errorf("failed to get exampleElasticsearch: %v", err)
-	}
-	exampleElasticsearch.Spec.Nodes[0].NodeCount = int32(2)
-	t.Logf("Updating Elasticsearch CR: %v", exampleElasticsearch)
-	err = f.Client.Update(goctx.TODO(), exampleElasticsearch)
-	if err != nil {
-		return fmt.Errorf("could not update exampleElasticsearch with 2 replicas: %v", err)
-	}
-
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, fmt.Sprintf("elasticsearch-cdm-%v-1", dataUUID), 1, retryInterval, timeout)
-	if err != nil {
-		return fmt.Errorf("timed out waiting for Deployment %v: %v", fmt.Sprintf("elasticsearch-cdm-%v-1", dataUUID), err)
-	}
-
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, fmt.Sprintf("elasticsearch-cdm-%v-2", dataUUID), 1, retryInterval, timeout)
-	if err != nil {
-		return fmt.Errorf("timed out waiting for Deployment %v: %v", fmt.Sprintf("elasticsearch-cdm-%v-2", dataUUID), err)
-	}
-	t.Log("Created additional deployment")
-
-	if err = f.Client.Get(goctx.TODO(), exampleName, exampleElasticsearch); err != nil {
-		return fmt.Errorf("failed to get exampleElasticsearch: %v", err)
-	}
-	t.Log("Adding another node")
-	exampleElasticsearch.Spec.Nodes = append(exampleElasticsearch.Spec.Nodes, esNonDataNode)
-	err = f.Client.Update(goctx.TODO(), exampleElasticsearch)
-	if err != nil {
-		return fmt.Errorf("could not update exampleElasticsearch with an additional node: %v", err)
-	}
-
-	// Create another node
-	// then look for elasticsearch-cdm-1-1 and prior nodes
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, fmt.Sprintf("elasticsearch-cdm-%v-1", dataUUID), 1, retryInterval, timeout)
-	if err != nil {
-		return fmt.Errorf("timed out waiting for Deployment %v: %v", fmt.Sprintf("elasticsearch-cdm-%v-1", dataUUID), err)
-	}
-
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, fmt.Sprintf("elasticsearch-cdm-%v-2", dataUUID), 1, retryInterval, timeout)
-	if err != nil {
-		return fmt.Errorf("timed out waiting for Deployment %v: %v", fmt.Sprintf("elasticsearch-cdm-%v-1", dataUUID), err)
-	}
-
-	err = utils.WaitForStatefulset(t, f.KubeClient, namespace, fmt.Sprintf("elasticsearch-cm-%v", nonDataUUID), 1, retryInterval, timeout)
-	if err != nil {
-		return fmt.Errorf("timed out waiting for Statefulset %v: %v", fmt.Sprintf("elasticsearch-cm-%v", nonDataUUID), err)
+		t.Fatalf("timed out waiting for non-data node %v: %v", statefulSetName, err)
 	}
 	t.Log("Created non-data statefulset")
 
-	// Scale up to SingleRedundancy
-	if err = f.Client.Get(goctx.TODO(), exampleName, exampleElasticsearch); err != nil {
-		return fmt.Errorf("failed to get exampleElasticsearch: %v", err)
-	}
+	ctx.Cleanup()
+	e2eutil.WaitForDeletion(t, f.Client.Client, cr, cleanupRetryInterval, cleanupTimeout)
+	t.Log("Finished successfully")
+}
 
-	exampleElasticsearch.Spec.RedundancyPolicy = elasticsearch.SingleRedundancy
-	t.Logf("Updating redundancy policy to %v", exampleElasticsearch.Spec.RedundancyPolicy)
-	err = f.Client.Update(goctx.TODO(), exampleElasticsearch)
+func fullClusterRedeployTest(t *testing.T) {
+	f := test.Global
+
+	ctx := test.NewContext(t)
+	namespace, err := ctx.GetWatchNamespace()
 	if err != nil {
-		return fmt.Errorf("could not update exampleElasticsearch to be SingleRedundancy: %v", err)
+		t.Fatal(err)
+	}
+	t.Logf("Found namespace: %v", namespace)
+
+	esUUID := utils.GenerateUUID()
+	t.Logf("Using UUID for elasticsearch CR: %v", esUUID)
+
+	if err = createElasticsearchSecret(t, f, ctx, esUUID); err != nil {
+		t.Fatal(err)
 	}
 
-	/*
-		FIXME: this is commented out as we currently do not run our e2e tests in a container on the test cluster
-		 to be added back in as a follow up
-		err = utils.WaitForIndexTemplateReplicas(t, f.KubeClient, namespace, "elasticsearch", 1, retryInterval, timeout)
-		if err != nil {
-			return fmt.Errorf("timed out waiting for all index templates to have correct replica count")
-		}
+	dataUUID := utils.GenerateUUID()
+	t.Logf("Using GenUUID for data nodes: %v", dataUUID)
 
-		err = utils.WaitForIndexReplicas(t, f.KubeClient, namespace, "elasticsearch", 1, retryInterval, timeout)
-		if err != nil {
-			return fmt.Errorf("timed out waiting for all indices to have correct replica count")
-		}
-	*/
+	// Create CR with two nodes sharing client, data and master roles
+	cr, err := createElasticsearchCR(t, f, ctx, esUUID, dataUUID, 2)
+	if err != nil {
+		t.Fatalf("could not create exampleElasticsearch: %v", err)
+	}
+
+	dplName := fmt.Sprintf("elasticsearch-%v-cdm-%v-1", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatalf("timed out waiting for first node deployment %v: %v", dplName, err)
+	}
+
+	dplName = fmt.Sprintf("elasticsearch-%v-cdm-%v-2", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatalf("timed out waiting for second node deployment %v: %v", dplName, err)
+	}
+
+	// Scale up to SingleRedundancy
+	cr.Spec.RedundancyPolicy = loggingv1.SingleRedundancy
+
+	t.Logf("Updating redundancy policy to %v", cr.Spec.RedundancyPolicy)
+	if err := updateElasticsearchSpec(t, f, cr); err != nil {
+		t.Fatalf("could not update elasticsearch CR to be SingleRedundancy: %v", err)
+	}
 
 	// Update the secret to force a full cluster redeploy
-	err = updateElasticsearchSecret(t, f, ctx)
+	err = updateElasticsearchSecret(t, f, ctx, esUUID)
 	if err != nil {
-		return fmt.Errorf("Unable to update secret")
+		t.Fatalf("Unable to update secret")
 	}
 
 	//FIXME: Update the WaitForCondition methods
 
 	// wait for pods to have "redeploy for certs" condition as true?
-	//desiredCondition := elasticsearch.ElasticsearchNodeUpgradeStatus{
-	//	ScheduledForCertRedeploy: v1.ConditionTrue,
+	//desiredCondition := loggingv1.ElasticsearchNodeUpgradeStatus{
+	//	ScheduledForCertRedeploy: corev1.ConditionTrue,
 	//}
 	//
 	//err = utils.WaitForNodeStatusCondition(t, f, namespace, elasticsearchCRName, desiredCondition, retryInterval, time.Second*300)
@@ -164,9 +307,9 @@ func elasticsearchFullClusterTest(t *testing.T, f *framework.Framework, ctx *fra
 	//}
 	//
 	//// then wait for conditions to be gone
-	//desiredClusterCondition := elasticsearch.ClusterCondition{
-	//	Type:   elasticsearch.Restarting,
-	//	Status: v1.ConditionFalse,
+	//desiredClusterCondition := loggingv1.ClusterCondition{
+	//	Type:   loggingv1.Restarting,
+	//	Status: corev1.ConditionFalse,
 	//}
 	//
 	//err = utils.WaitForClusterStatusCondition(t, f, namespace, elasticsearchCRName, desiredClusterCondition, retryInterval, time.Second*300)
@@ -176,75 +319,92 @@ func elasticsearchFullClusterTest(t *testing.T, f *framework.Framework, ctx *fra
 	//	return fmt.Errorf("Timed out waiting for full cluster restart to complete")
 	//}
 
-	// ensure all prior nodes are ready again
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, fmt.Sprintf("elasticsearch-cdm-%v-1", dataUUID), 1, retryInterval, timeout)
+	t.Log("Waiting for redeployment after secret update")
+
+	// Increase redeploy timeout on full cluster redeploy until min masters available
+	redeployTimeout := time.Second * 600
+
+	dplName = fmt.Sprintf("elasticsearch-%v-cdm-%v-1", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, redeployTimeout)
 	if err != nil {
-		return fmt.Errorf("timed out waiting for Deployment %v: %v", fmt.Sprintf("elasticsearch-cdm-%v-1", dataUUID), err)
+		t.Fatalf("timed out waiting for first node deployment %v: %v", dplName, err)
 	}
 
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, fmt.Sprintf("elasticsearch-cdm-%v-2", dataUUID), 1, retryInterval, timeout)
+	dplName = fmt.Sprintf("elasticsearch-%v-cdm-%v-2", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, redeployTimeout)
 	if err != nil {
-		return fmt.Errorf("timed out waiting for Deployment %v: %v", fmt.Sprintf("elasticsearch-cdm-%v-1", dataUUID), err)
+		t.Fatalf("timed out waiting for second node deployment %v: %v", dplName, err)
 	}
 
-	err = utils.WaitForStatefulset(t, f.KubeClient, namespace, fmt.Sprintf("elasticsearch-cm-%v", nonDataUUID), 1, retryInterval, timeout)
+	ctx.Cleanup()
+	e2eutil.WaitForDeletion(t, f.Client.Client, cr, cleanupRetryInterval, cleanupTimeout)
+	t.Log("Finished successfully")
+}
+
+func rollingRestartTest(t *testing.T) {
+	f := test.Global
+
+	ctx := test.NewContext(t)
+	namespace, err := ctx.GetWatchNamespace()
 	if err != nil {
-		return fmt.Errorf("timed out waiting for Statefulset %v: %v", fmt.Sprintf("elasticsearch-cm-%v", nonDataUUID), err)
+		t.Fatal(err)
+	}
+	t.Logf("Found namespace: %v", namespace)
+
+	esUUID := utils.GenerateUUID()
+	t.Logf("Using UUID for elasticsearch CR: %v", esUUID)
+
+	if err = createElasticsearchSecret(t, f, ctx, esUUID); err != nil {
+		t.Fatal(err)
 	}
 
-	// Incorrect scale up and verify we don't see a 4th master created
-	if err = f.Client.Get(goctx.TODO(), exampleName, exampleElasticsearch); err != nil {
-		return fmt.Errorf("failed to get exampleElasticsearch: %v", err)
-	}
-	exampleElasticsearch.Spec.Nodes[1].NodeCount = int32(2)
-	err = f.Client.Update(goctx.TODO(), exampleElasticsearch)
+	dataUUID := utils.GenerateUUID()
+	t.Logf("Using GenUUID for data nodes: %v", dataUUID)
+
+	// Create CR with two nodes sharing client, data and master roles
+	cr, err := createElasticsearchCR(t, f, ctx, esUUID, dataUUID, 2)
 	if err != nil {
-		return fmt.Errorf("could not update exampleElasticsearch with an additional statefulset replica: %v", err)
+		t.Fatalf("could not create exampleElasticsearch: %v", err)
 	}
 
-	err = utils.WaitForStatefulset(t, f.KubeClient, namespace, fmt.Sprintf("elasticsearch-cm-%v", nonDataUUID), 2, retryInterval, time.Second*30)
-	if err == nil {
-		return fmt.Errorf("unexpected statefulset replica count for %v found", fmt.Sprintf("elasticsearch-cm-%v", nonDataUUID))
+	dplName := fmt.Sprintf("elasticsearch-%v-cdm-%v-1", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatalf("timed out waiting for first node deployment %v: %v", dplName, err)
 	}
 
-	if err = f.Client.Get(goctx.TODO(), exampleName, exampleElasticsearch); err != nil {
-		return fmt.Errorf("failed to get exampleElasticsearch: %v", err)
-	}
-
-	for _, condition := range exampleElasticsearch.Status.Conditions {
-		if condition.Type == elasticsearch.InvalidMasters {
-			if condition.Status == v1.ConditionFalse ||
-				condition.Status == "" {
-				return fmt.Errorf("unexpected status condition for elasticsearch found: %v", condition.Status)
-			}
-		}
+	dplName = fmt.Sprintf("elasticsearch-%v-cdm-%v-2", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatalf("timed out waiting for second node deployment %v: %v", dplName, err)
 	}
 
 	// Update the resource spec for the cluster
-	oldMemValue := exampleElasticsearch.Spec.Spec.Resources.Limits.Memory()
+	oldMemValue := cr.Spec.Spec.Resources.Limits.Memory()
 
-	memValue := resource.MustParse("1.5Gi")
-	cpuValue := resource.MustParse("100m")
-	exampleElasticsearch.Spec.Spec.Resources = v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceMemory: memValue,
+	memValue := resource.MustParse("1536Mi")
+	cpuValue := resource.MustParse("200m")
+	desiredResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: memValue,
 		},
-		Requests: v1.ResourceList{
-			v1.ResourceCPU:    cpuValue,
-			v1.ResourceMemory: memValue,
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    cpuValue,
+			corev1.ResourceMemory: memValue,
 		},
 	}
 
 	t.Log("Updating Limits.Memory and Requests.Memory to trigger a rolling restart")
 	t.Logf("Updating from %s to %s", oldMemValue.String(), memValue.String())
-	err = f.Client.Update(goctx.TODO(), exampleElasticsearch)
-	if err != nil {
-		return fmt.Errorf("could not update exampleElasticsearch with an additional statefulset replica: %v", err)
+
+	cr.Spec.Spec.Resources = desiredResources
+	if err := updateElasticsearchSpec(t, f, cr); err != nil {
+		t.Fatalf("could not update elasticsearch CR to be SingleRedundancy: %v", err)
 	}
 
 	// wait for node to not be ready (restart is happening)
-	/*desiredCondition := elasticsearch.ElasticsearchNodeUpgradeStatus{
-		UnderUpgrade: v1.ConditionTrue,
+	/*desiredCondition := loggingv1.ElasticsearchNodeUpgradeStatus{
+		UnderUpgrade: corev1.ConditionTrue,
 	}*/
 
 	// This doesn't work correctly because we don't update the cluster status until we've failed out
@@ -256,63 +416,69 @@ func elasticsearchFullClusterTest(t *testing.T, f *framework.Framework, ctx *fra
 		return fmt.Errorf("Timed out waiting for full cluster restart to begin")
 	}*/
 
-	// due to gap mentioned above -- pause here for a few seconds to let the operator do its thing?
-	time.Sleep(10 * time.Second)
+	t.Log("Waiting for restart after resource requests/limits update")
 
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, fmt.Sprintf("elasticsearch-cdm-%v-1", dataUUID), 1, retryInterval, timeout)
+	// Increase restart timeout on full cluster redeploy until min masters available
+	restartTimeout := time.Second * 600
+
+	dplName = fmt.Sprintf("elasticsearch-%v-cdm-%v-1", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, restartTimeout)
 	if err != nil {
-		return fmt.Errorf("timed out waiting for Deployment %v: %v", fmt.Sprintf("elasticsearch-cdm-%v-1", dataUUID), err)
+		t.Fatalf("timed out waiting for first ready node deployment  %v: %v", dplName, err)
 	}
 
-	// ensure all prior nodes are ready again
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, fmt.Sprintf("elasticsearch-cdm-%v-1", dataUUID), 1, retryInterval, timeout)
+	dplName = fmt.Sprintf("elasticsearch-%v-cdm-%v-2", esUUID, dataUUID)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, dplName, 1, retryInterval, restartTimeout)
 	if err != nil {
-		return fmt.Errorf("timed out waiting for Deployment %v: %v", fmt.Sprintf("elasticsearch-cdm-%v-1", dataUUID), err)
-	}
-
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, fmt.Sprintf("elasticsearch-cdm-%v-2", dataUUID), 1, retryInterval, timeout)
-	if err != nil {
-		return fmt.Errorf("timed out waiting for Deployment %v: %v", fmt.Sprintf("elasticsearch-cdm-%v-1", dataUUID), err)
-	}
-
-	err = utils.WaitForStatefulset(t, f.KubeClient, namespace, fmt.Sprintf("elasticsearch-cm-%v", nonDataUUID), 1, retryInterval, timeout)
-	if err != nil {
-		return fmt.Errorf("timed out waiting for Statefulset %v: %v", fmt.Sprintf("elasticsearch-cm-%v", nonDataUUID), err)
+		t.Fatalf("timed out waiting for second ready node deployment %v: %v", dplName, err)
 	}
 
 	ctx.Cleanup()
+	e2eutil.WaitForDeletion(t, f.Client.Client, cr, cleanupRetryInterval, cleanupTimeout)
 	t.Log("Finished successfully")
-	return nil
 }
 
-func ElasticsearchCluster(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
-	/*
-		err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-		if err != nil {
-			t.Fatalf("failed to initialize cluster resources: %v", err)
-		}
-		t.Log("Initialized cluster resources")
-	*/
-	namespace, err := ctx.GetNamespace()
+func invalidMasterCountTest(t *testing.T) {
+	f := test.Global
+
+	ctx := test.NewContext(t)
+	namespace, err := ctx.GetWatchNamespace()
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Logf("Found namespace: %v", namespace)
 
-	// get global framework variables
-	f := framework.Global
-	// wait for elasticsearch-operator to be ready
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "elasticsearch-operator", 1, retryInterval, timeout)
+	esUUID := utils.GenerateUUID()
+	t.Logf("Using UUID for elasticsearch CR: %v", esUUID)
+
+	if err = createElasticsearchSecret(t, f, ctx, esUUID); err != nil {
+		t.Fatal(err)
+	}
+
+	dataUUID := utils.GenerateUUID()
+	t.Logf("Using GenUUID for data nodes: %v", dataUUID)
+
+	// Create CR with invalid case: four nodes all sharing client, data and master roles
+	cr, err := createElasticsearchCR(t, f, ctx, esUUID, dataUUID, 4)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("could not create exampleElasticsearch: %v", err)
 	}
 
-	if err = createElasticsearchSecret(t, f, ctx); err != nil {
-		t.Fatal(err)
+	key := client.ObjectKey{Name: cr.GetName(), Namespace: cr.GetNamespace()}
+	if err := f.Client.Get(context.TODO(), key, cr); err != nil {
+		t.Fatalf("failed to get updated CR: %s", key)
 	}
 
-	if err = elasticsearchFullClusterTest(t, f, ctx); err != nil {
-		t.Fatal(err)
+	for _, condition := range cr.Status.Conditions {
+		if condition.Type == loggingv1.InvalidMasters {
+			if condition.Status == corev1.ConditionFalse ||
+				condition.Status == "" {
+				t.Errorf("unexpected status condition for elasticsearch found: %v", condition.Status)
+			}
+		}
 	}
+
+	ctx.Cleanup()
+	e2eutil.WaitForDeletion(t, f.Client.Client, cr, cleanupRetryInterval, cleanupTimeout)
+	t.Log("Finished successfully")
 }

--- a/test/e2e-olm/kibana_test.go
+++ b/test/e2e-olm/kibana_test.go
@@ -41,13 +41,18 @@ func KibanaDeployment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = createElasticsearchSecret(t, f, ctx); err != nil {
+	esUUID := utils.GenerateUUID()
+	t.Logf("Using UUID for elasticsearch CR: %v", esUUID)
+
+	dataUUID := utils.GenerateUUID()
+	t.Logf("Using GenUUID for data nodes: %v", dataUUID)
+
+	if err = createElasticsearchSecret(t, f, ctx, esUUID); err != nil {
 		t.Fatal(err)
 	}
 
-	uuid := utils.GenerateUUID()
-	esDeploymentName := fmt.Sprintf("elasticsearch-cdm-%v-1", uuid)
-	_, err = createElasticsearchCR(t, f, ctx, uuid)
+	esDeploymentName := fmt.Sprintf("elasticsearch-%v-cdm-%v-1", esUUID, dataUUID)
+	_, err = createElasticsearchCR(t, f, ctx, esUUID, dataUUID, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,11 +62,11 @@ func KibanaDeployment(t *testing.T) {
 		t.Errorf("timed out waiting for Deployment %q: %v", esDeploymentName, err)
 	}
 
-	if err = createKibanaSecret(f, ctx); err != nil {
+	if err = createKibanaSecret(f, ctx, esUUID); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = createKibanaProxySecret(f, ctx); err != nil {
+	if err = createKibanaProxySecret(f, ctx, esUUID); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/e2e-olm/main_test.go
+++ b/test/e2e-olm/main_test.go
@@ -3,9 +3,9 @@ package e2e
 import (
 	"testing"
 
-	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/operator-framework/operator-sdk/pkg/test"
 )
 
 func TestMain(m *testing.M) {
-	framework.MainEntry(m)
+	test.MainEntry(m)
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -10,21 +10,21 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/openshift/elasticsearch-operator/pkg/elasticsearch"
-	"github.com/openshift/elasticsearch-operator/pkg/utils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	goctx "context"
+	loggingv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+	"github.com/openshift/elasticsearch-operator/pkg/elasticsearch"
+	"github.com/openshift/elasticsearch-operator/pkg/utils"
 
-	api "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
-	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/operator-framework/operator-sdk/pkg/test"
 )
 
 func GetFileContents(filePath string) []byte {
@@ -37,8 +37,8 @@ func GetFileContents(filePath string) []byte {
 	return contents
 }
 
-func ConfigMap(name, namespace string, labels, data map[string]string) *v1.ConfigMap {
-	return &v1.ConfigMap{
+func ConfigMap(name, namespace string, labels, data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -48,11 +48,11 @@ func ConfigMap(name, namespace string, labels, data map[string]string) *v1.Confi
 	}
 }
 
-func Secret(secretName string, namespace string, data map[string][]byte) *v1.Secret {
-	return &v1.Secret{
+func Secret(secretName string, namespace string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
-			APIVersion: v1.SchemeGroupVersion.String(),
+			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
@@ -63,14 +63,39 @@ func Secret(secretName string, namespace string, data map[string][]byte) *v1.Sec
 	}
 }
 
-func WaitForNodeStatusCondition(t *testing.T, f *framework.Framework, namespace, name string, condition api.ElasticsearchNodeUpgradeStatus, retryInterval, timeout time.Duration) error {
-	elasticsearchCR := &api.Elasticsearch{}
+func WaitForPods(t *testing.T, f *test.Framework, namespace string, labels map[string]string, retryInterval, timeout time.Duration) (*corev1.PodList, error) {
+	pods := &corev1.PodList{}
+
+	err := wait.Poll(retryInterval, timeout, func() (bool, error) {
+		opts := []client.ListOption{
+			client.InNamespace(namespace),
+			client.MatchingLabels(labels),
+		}
+		err := f.Client.Client.List(context.TODO(), pods, opts...)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, err
+			}
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return pods, nil
+}
+
+func WaitForNodeStatusCondition(t *testing.T, f *test.Framework, namespace, name string, condition loggingv1.ElasticsearchNodeUpgradeStatus, retryInterval, timeout time.Duration) error {
+	elasticsearchCR := &loggingv1.Elasticsearch{}
 	elasticsearchName := types.NamespacedName{Name: name, Namespace: namespace}
 
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
-		err = f.Client.Get(goctx.TODO(), elasticsearchName, elasticsearchCR)
+		err = f.Client.Get(context.TODO(), elasticsearchName, elasticsearchCR)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
+			if errors.IsNotFound(err) {
 				t.Logf("Waiting for availability of %s elasticsearch\n", name)
 				return false, nil
 			}
@@ -103,14 +128,14 @@ func WaitForNodeStatusCondition(t *testing.T, f *framework.Framework, namespace,
 	return nil
 }
 
-func WaitForClusterStatusCondition(t *testing.T, f *framework.Framework, namespace, name string, condition api.ClusterCondition, retryInterval, timeout time.Duration) error {
-	elasticsearchCR := &api.Elasticsearch{}
+func WaitForClusterStatusCondition(t *testing.T, f *test.Framework, namespace, name string, condition loggingv1.ClusterCondition, retryInterval, timeout time.Duration) error {
+	elasticsearchCR := &loggingv1.Elasticsearch{}
 	elasticsearchName := types.NamespacedName{Name: name, Namespace: namespace}
 
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
-		err = f.Client.Get(goctx.TODO(), elasticsearchName, elasticsearchCR)
+		err = f.Client.Get(context.TODO(), elasticsearchName, elasticsearchCR)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
+			if errors.IsNotFound(err) {
 				t.Logf("Waiting for availability of %s elasticsearch\n", name)
 				return false, nil
 			}
@@ -139,11 +164,37 @@ func WaitForClusterStatusCondition(t *testing.T, f *framework.Framework, namespa
 	return nil
 }
 
+func WaitForReadyDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, replicas int,
+	retryInterval, timeout time.Duration) error {
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		deployment, err := kubeclient.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				t.Logf("Waiting for availability of Deployment: %s in Namespace: %s \n", name, namespace)
+				return false, nil
+			}
+			return false, err
+		}
+
+		if int(deployment.Status.ReadyReplicas) >= replicas {
+			return true, nil
+		}
+		t.Logf("Waiting for full readiness of %s deployment (%d/%d)\n", name,
+			deployment.Status.ReadyReplicas, replicas)
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	t.Logf("Deployment ready (%d/%d)\n", replicas, replicas)
+	return nil
+}
+
 func WaitForStatefulset(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, replicas int, retryInterval, timeout time.Duration) error {
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		statefulset, err := kubeclient.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			if apierrors.IsNotFound(err) {
+			if errors.IsNotFound(err) {
 				t.Logf("Waiting for availability of %s statefulset\n", name)
 				return false, nil
 			}
@@ -255,7 +306,7 @@ func WaitForIndexReplicas(t *testing.T, kubeclient kubernetes.Interface, namespa
 	return nil
 }
 
-func getMockedSecret(clusterName, namespace string) *v1.Secret {
+func getMockedSecret(clusterName, namespace string) *corev1.Secret {
 	return Secret(
 		clusterName,
 		namespace,


### PR DESCRIPTION
This PR addresses the fragility of our E2E tests for elasticsearch cluster reconciliation. The present state consists of multiple E2E test cases glued together using the same elasticsearch cluster. This approach yields breaks test isolation. The new state isolates each test case by:
* Providing cleanup after each test case
* Using independent CR instances (e.g. `elasticsearch-$UUID`) and cluster deployments (e.g. `elasticsearch-$UUID-{cd,cdm}-$nodeUUID-...`)
* Usinge independent CR secrets and unique certificates per test case
* Continues to run test cases sequentially to keep resource usage on CI to the old levels. The preference is one cluster at a time thus one test case at a time.

/cc @ewolinetz 