### PR TITLE
Bug 1852889: Bump minKubeVersion to 1.18.3

### DIFF
--- a/manifests/4.6/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
@@ -79,7 +79,7 @@ metadata:
 spec:
   version: 4.6.0
   displayName: Elasticsearch Operator
-  minKubeVersion: 1.17.1
+  minKubeVersion: 1.18.3
 
   description: |
     The Elasticsearch Operator for OKD provides a means for configuring and managing an Elasticsearch cluster for use in tracing and cluster logging.


### PR DESCRIPTION
This PR addresses a bump of minKubeVersion to 1.18.3 because elasticsearch-operator is using client-go 1.18.x-only APIs and complies with 1.18.x upstream deprecation removals (See #291)

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1852889