### PR TITLE
[release-4.4] Bug 1855316: Add support label for s390x & ppc64le

### DIFF
--- a/manifests/4.4/elasticsearch-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/elasticsearch-operator.v4.4.0.clusterserviceversion.yaml
@@ -5,6 +5,10 @@ kind: ClusterServiceVersion
 metadata:
   name: elasticsearch-operator.v4.4.0
   namespace: placeholder
+  labels:
+    "operatorframework.io/arch.amd64": supported
+    "operatorframework.io/arch.ppc64le": supported
+    "operatorframework.io/arch.s390x": supported
   annotations:
     "operatorframework.io/suggested-namespace": openshift-operators-redhat
     "operatorframework.io/cluster-monitoring": "true"


### PR DESCRIPTION
In order for the elasticsearch-operator to be correctly filtered in
the OperatorHub for s390x and ppc64le we need to add the correct arch
label as supported.

(cherry picked from commit 1a0cb8ffc8ab1a1865cd9ac463ea5d85e64427bf)