### PR TITLE
updating to label ns instead of annotate

### DIFF
--- a/olm_deploy/scripts/operator-install.sh
+++ b/olm_deploy/scripts/operator-install.sh
@@ -11,7 +11,7 @@ else
 fi
 
 set +e
-oc annotate ns/${ELASTICSEARCH_OPERATOR_NAMESPACE} openshift.io/cluster-monitoring=true
+oc label ns/${ELASTICSEARCH_OPERATOR_NAMESPACE} openshift.io/cluster-monitoring=true --overwrite
 set -e
 
 


### PR DESCRIPTION
This addresses the issue that we need to use labels instead of annotations to allow metrics to be collected for a particular namespace.