### PR TITLE
Optimizing cluster.go workflow

### DIFF
--- a/hack/deploy-example-secrets.sh
+++ b/hack/deploy-example-secrets.sh
@@ -14,3 +14,14 @@ oc -n $namespace create secret generic elasticsearch  \
 	--from-file=/tmp/example-secrets/logging-es.key \
 	--from-file=/tmp/example-secrets/logging-es.crt
 
+oc -n $namespace delete secret kibana ||:
+oc -n $namespace create secret generic kibana  \
+	--from-file=ca=/tmp/example-secrets/ca.crt \
+	--from-file=key=/tmp/example-secrets/system.logging.kibana.key \
+	--from-file=cert=/tmp/example-secrets/system.logging.kibana.crt
+
+oc -n $namespace delete secret kibana-proxy ||:
+oc -n $namespace create secret generic kibana-proxy  \
+	--from-literal=session-secret=abcdefghijklmnopqrstuvwxyz123456 \
+	--from-file=server-key=/tmp/example-secrets/kibana-internal.key \
+	--from-file=server-cert=/tmp/example-secrets/kibana-internal.crt

--- a/hack/kibana-cr.yaml
+++ b/hack/kibana-cr.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: logging.openshift.io/v1
+kind: Kibana
+metadata:
+  name: kibana
+spec:
+  managementState: Managed
+  replicas: 1
+  resources:
+    limits:
+      memory: 736Mi
+    requests:
+      cpu: 100m
+      memory: 736Mi

--- a/hack/testing-olm/test-001-operator-sdk-e2e.sh
+++ b/hack/testing-olm/test-001-operator-sdk-e2e.sh
@@ -57,4 +57,4 @@ TEST_WATCH_NAMESPACE=${TEST_NAMESPACE} \
     -globalMan test/files/dummycrd.yaml \
     -v \
     -parallel=1 \
-   -timeout 1200s
+   -timeout 1500s

--- a/hack/testing-olm/test-657-im-block-autocreate-for-write-suffix.sh
+++ b/hack/testing-olm/test-657-im-block-autocreate-for-write-suffix.sh
@@ -1,7 +1,7 @@
 set -euo pipefail
 
 if [ -n "${DEBUG:-}" ]; then
-    set -x
+  set -x
 fi
 
 KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config}

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -109,12 +109,6 @@ func (node *deploymentNode) state() api.ElasticsearchNodeStatus {
 		rolloutForUpdate = v1.ConditionTrue
 	}
 
-	// check if the configmapHash changed
-	/*newConfigmapHash := getConfigmapDataHash(node.clusterName, node.self.Namespace)
-	if newConfigmapHash != node.configmapHash {
-		rolloutForReload = v1.ConditionTrue
-	}*/
-
 	// check for a case where our hash is missing -- operator restarted?
 	newSecretHash := getSecretDataHash(node.clusterName, node.self.Namespace, node.client)
 	if node.secretHash == "" {

--- a/pkg/k8shandler/elasticsearch.go
+++ b/pkg/k8shandler/elasticsearch.go
@@ -1,0 +1,93 @@
+package k8shandler
+
+import (
+	api "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+	"github.com/sirupsen/logrus"
+)
+
+// this function should be called before we try doing operations to make sure all our nodes are
+// first ready
+func (er *ElasticsearchRequest) ClusterReady() bool {
+	// bypass using Status -- check all our pods first, make sure they're all 'Ready'
+	podStates := er.GetCurrentPodStateMap()
+
+	if len(podStates) == 0 {
+		// we have no pods in the cluster -- it can't be ready
+		return false
+	}
+
+	for _, stateMap := range podStates {
+		if len(stateMap[api.PodStateTypeNotReady]) > 0 || len(stateMap[api.PodStateTypeFailed]) > 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// this function should be called before we try doing operations to make sure any of our nodes
+// are first ready
+func (er *ElasticsearchRequest) AnyNodeReady() bool {
+	podStates := er.GetCurrentPodStateMap()
+
+	for _, stateMap := range podStates {
+		if len(stateMap[api.PodStateTypeReady]) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (er *ElasticsearchRequest) updateMinMasters() {
+	// do as best effort -- whenever we create a node update min masters (if required)
+	if er.AnyNodeReady() {
+		cluster := er.cluster
+		esClient := er.esClient
+
+		currentMasterCount, err := esClient.GetMinMasterNodes()
+		if err != nil {
+			logrus.Debugf("Unable to get current min master count for cluster %q in namespace %q", cluster.Name, cluster.Namespace)
+		}
+
+		desiredMasterCount := getMasterCount(cluster)/2 + 1
+		currentNodeCount, err := esClient.GetClusterNodeCount()
+		if err != nil {
+			logrus.Warnf("Unable to get cluster node count for cluster %q in namespace %q: %s", cluster.Name, cluster.Namespace, err.Error())
+		}
+
+		// check that we have the required number of master nodes in the cluster...
+		if currentNodeCount >= desiredMasterCount {
+			if currentMasterCount != desiredMasterCount {
+				if _, setErr := esClient.SetMinMasterNodes(desiredMasterCount); setErr != nil {
+					logrus.Debugf("Unable to set min master count to %d for cluster %q in namespace %q", desiredMasterCount, cluster.Name, cluster.Namespace)
+				}
+			}
+		}
+	}
+}
+
+func (er *ElasticsearchRequest) tryEnsureAllShardAllocation() {
+	if er.AnyNodeReady() {
+		if ok, err := er.esClient.SetShardAllocation(api.ShardAllocationAll); !ok {
+			logrus.Warnf("Unable to enable shard allocation for cluster %q in namespace %q: %v", er.cluster.Name, er.cluster.Namespace, err)
+		}
+	}
+}
+
+func (er *ElasticsearchRequest) tryEnsureNoTransitiveShardAllocations() {
+	if er.AnyNodeReady() {
+		if success, err := er.esClient.ClearTransientShardAllocation(); !success {
+			logrus.Warnf("Unable to clear transient shard allocation for cluster %q in namespace %q: %s", er.cluster.Namespace, er.cluster.Namespace, err.Error())
+		}
+	}
+}
+
+func (er *ElasticsearchRequest) updateReplicas() {
+	if er.ClusterReady() {
+		replicaCount := int32(calculateReplicaCount(er.cluster))
+		if err := er.esClient.UpdateReplicaCount(replicaCount); err != nil {
+			logrus.Warnf("Unable to update replica count for cluster %q in namespace %q: %v", er.cluster.Namespace, er.cluster.Namespace, err)
+		}
+	}
+}

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -102,12 +102,6 @@ func (node *statefulSetNode) state() api.ElasticsearchNodeStatus {
 		rolloutForUpdate = v1.ConditionTrue
 	}
 
-	// check if the configmapHash changed
-	/*newConfigmapHash := getConfigmapDataHash(node.clusterName, node.self.Namespace)
-	if newConfigmapHash != node.configmapHash {
-		rolloutForReload = v1.ConditionTrue
-	}*/
-
 	// check for a case where our hash is missing -- operator restarted?
 	newSecretHash := getSecretDataHash(node.clusterName, node.self.Namespace, node.client)
 	if node.secretHash == "" {

--- a/pkg/k8shandler/util_test.go
+++ b/pkg/k8shandler/util_test.go
@@ -134,52 +134,6 @@ func TestSelectorsCommonOverwritten(t *testing.T) {
 	}
 }
 
-func TestNoRedundancyPolicySpecified(t *testing.T) {
-
-	esCR := &api.Elasticsearch{
-		Spec: api.ElasticsearchSpec{},
-	}
-
-	isValid := isValidRedundancyPolicy(esCR)
-
-	if !isValid {
-		t.Errorf("Expected default policy of SingleRedundancy to be used, incorrectly flagged as invalid")
-	}
-
-}
-
-func TestValidRedundancyPolicySpecified(t *testing.T) {
-
-	esCR := &api.Elasticsearch{
-		Spec: api.ElasticsearchSpec{
-			RedundancyPolicy: api.FullRedundancy,
-		},
-	}
-
-	isValid := isValidRedundancyPolicy(esCR)
-
-	if !isValid {
-		t.Error("Expected FullRedundancy to be valid, flagged as invalid")
-	}
-
-}
-
-func TestInvalidRedundancyPolicySpecified(t *testing.T) {
-
-	esCR := &api.Elasticsearch{
-		Spec: api.ElasticsearchSpec{
-			RedundancyPolicy: "NoRedundancy",
-		},
-	}
-
-	isValid := isValidRedundancyPolicy(esCR)
-
-	if isValid {
-		t.Error("Expected NoRedundancy to be flagged as invalid, was found to be valid")
-	}
-
-}
-
 func TestValidNoNodesSpecified(t *testing.T) {
 
 	esCR := &api.Elasticsearch{
@@ -198,12 +152,6 @@ func TestValidNoNodesSpecified(t *testing.T) {
 
 	if !isValid {
 		t.Error("Expected no nodes defined to be flagged as valid, was found to be invalid data count")
-	}
-
-	isValid = isValidRedundancyPolicy(esCR)
-
-	if !isValid {
-		t.Error("Expected no nodes defined to be flagged as valid, was found to be invalid redundancy policy")
 	}
 
 	if ok, msg := hasValidUUIDs(esCR); !ok {

--- a/test/e2e-olm/elasticsearch_test.go
+++ b/test/e2e-olm/elasticsearch_test.go
@@ -327,7 +327,7 @@ func fullClusterRedeployTest(t *testing.T) {
 		t.Fatalf("timed out waiting for second node deployment %v: %v", dplName, err)
 	}
 
-	pods, err := utils.WaitForRolloutComplete(t, f, namespace, matchingLabels, initPodNames, retryInterval, redeployTimeout)
+	pods, err := utils.WaitForRolloutComplete(t, f, namespace, matchingLabels, initPodNames, 2, retryInterval, redeployTimeout)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -441,7 +441,7 @@ func rollingRestartTest(t *testing.T) {
 		t.Fatalf("timed out waiting for second ready node deployment %v: %v", dplName, err)
 	}
 
-	pods, err := utils.WaitForRolloutComplete(t, f, namespace, matchingLabels, initPodNames, retryInterval, restartTimeout)
+	pods, err := utils.WaitForRolloutComplete(t, f, namespace, matchingLabels, initPodNames, 2, retryInterval, restartTimeout)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -88,7 +88,7 @@ func WaitForPods(t *testing.T, f *test.Framework, namespace string, labels map[s
 	return pods, nil
 }
 
-func WaitForRolloutComplete(t *testing.T, f *test.Framework, namespace string, labels map[string]string, excludePods []string, retryInterval, timeout time.Duration) (*corev1.PodList, error) {
+func WaitForRolloutComplete(t *testing.T, f *test.Framework, namespace string, labels map[string]string, excludePods []string, expectedPodCount int, retryInterval, timeout time.Duration) (*corev1.PodList, error) {
 	pods := &corev1.PodList{}
 	opts := []client.ListOption{
 		client.InNamespace(namespace),
@@ -121,7 +121,7 @@ func WaitForRolloutComplete(t *testing.T, f *test.Framework, namespace string, l
 			}
 		}
 
-		if len(pods.Items) == readyPods {
+		if readyPods == expectedPodCount && len(pods.Items) == readyPods {
 			return true, nil
 		}
 


### PR DESCRIPTION
This PR attempts to optimize the flow within `k8shandler/cluster.go` to be easier to read and be more reactive to changes required for the cluster.

Addresses https://issues.redhat.com/browse/LOG-791