### PR TITLE
Revert "Bug 1852889: Bump minKubeVersion to 1.18.3"

### DIFF
--- a/manifests/4.6/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ metadata:
 spec:
   version: 4.6.0
   displayName: Elasticsearch Operator
-  minKubeVersion: 1.18.3
+  minKubeVersion: 1.17.1
 
   description: |
     The Elasticsearch Operator for OKD provides a means for configuring and managing an Elasticsearch cluster for use in tracing and cluster logging.

--- a/manifests/4.6/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ metadata:
 spec:
   version: 4.6.0
   displayName: Elasticsearch Operator
-  minKubeVersion: 1.17.1
+  minKubeVersion: 1.17.0
 
   description: |
     The Elasticsearch Operator for OKD provides a means for configuring and managing an Elasticsearch cluster for use in tracing and cluster logging.


### PR DESCRIPTION
### Description
This PR reverts commit aa421b4defc37caf35c10054b4c00e9549ea77e7 and in extend downgrades the `minKubeVersion` to `1.17.0`, because apiserver on CI is still on `v1.17.0-alpha.0.7867+649a587b0a0f5d-dirty`