### PR TITLE
[release-4.5] Bug 1859991: Disable indices level metrics in Prometheus exporter output

### DIFF
--- a/pkg/k8shandler/configuration_tmpl.go
+++ b/pkg/k8shandler/configuration_tmpl.go
@@ -32,6 +32,9 @@ path:
   data: /elasticsearch/persistent/${CLUSTER_NAME}/data
   logs: /elasticsearch/persistent/${CLUSTER_NAME}/logs
 
+prometheus:
+  indices: false
+
 opendistro_security:
   authcz.admin_dn:
   - CN=system.admin,OU=OpenShift,O=Logging

--- a/pkg/k8shandler/confimaps_test.go
+++ b/pkg/k8shandler/confimaps_test.go
@@ -48,6 +48,9 @@ path:
   data: /elasticsearch/persistent/${CLUSTER_NAME}/data
   logs: /elasticsearch/persistent/${CLUSTER_NAME}/logs
 
+prometheus:
+  indices: false
+
 opendistro_security:
   authcz.admin_dn:
   - CN=system.admin,OU=OpenShift,O=Logging


### PR DESCRIPTION
Index level metrics contain high cardinality labels (index names and segment IDs). This can cause issues tto Prometheus and consume a lot of Prometheus storage.

manual cherry-pick of https://github.com/openshift/elasticsearch-operator/pull/427