### PR TITLE
[release-4.5] Bug 1860135: Assume average log message is 1K

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -3,15 +3,16 @@ package constants
 import "github.com/openshift/elasticsearch-operator/pkg/utils"
 
 const (
-	ProxyName                  = "cluster"
-	TrustedCABundleKey         = "ca-bundle.crt"
-	TrustedCABundleMountDir    = "/etc/pki/ca-trust/extracted/pem/"
-	TrustedCABundleMountFile   = "tls-ca-bundle.pem"
-	InjectTrustedCABundleLabel = "config.openshift.io/inject-trusted-cabundle"
-	TrustedCABundleHashName    = "logging.openshift.io/hash"
-	KibanaTrustedCAName        = "kibana-trusted-ca-bundle"
-	SecretHashPrefix           = "logging.openshift.io/"
-	ElasticsearchDefaultImage  = "quay.io/openshift/origin-logging-elasticsearch6"
+	ProxyName                   = "cluster"
+	TrustedCABundleKey          = "ca-bundle.crt"
+	TrustedCABundleMountDir     = "/etc/pki/ca-trust/extracted/pem/"
+	TrustedCABundleMountFile    = "tls-ca-bundle.pem"
+	InjectTrustedCABundleLabel  = "config.openshift.io/inject-trusted-cabundle"
+	TrustedCABundleHashName     = "logging.openshift.io/hash"
+	KibanaTrustedCAName         = "kibana-trusted-ca-bundle"
+	SecretHashPrefix            = "logging.openshift.io/"
+	ElasticsearchDefaultImage   = "quay.io/openshift/origin-logging-elasticsearch6"
+	TheoreticalShardMaxSizeInMB = 40960
 )
 
 var (

--- a/pkg/indexmanagement/converters.go
+++ b/pkg/indexmanagement/converters.go
@@ -5,12 +5,13 @@ import (
 	"strconv"
 
 	apis "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+	"github.com/openshift/elasticsearch-operator/pkg/constants"
 	"github.com/openshift/elasticsearch-operator/pkg/logger"
 )
 
 func calculateConditions(policy apis.IndexManagementPolicySpec, primaryShards int32) rolloverConditions {
-	// 40GB = 40960 1M messages
-	maxDoc := 40960 * primaryShards
+	// 40GB = 40960 1K messages
+	maxDoc := constants.TheoreticalShardMaxSizeInMB * 1000 * primaryShards
 	maxSize := defaultShardSize * primaryShards
 	maxAge := ""
 	if policy.Phases.Hot != nil && policy.Phases.Hot.Actions.Rollover != nil {

--- a/pkg/indexmanagement/converters_test.go
+++ b/pkg/indexmanagement/converters_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	apis "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+	"github.com/openshift/elasticsearch-operator/pkg/constants"
 )
 
 var _ = Describe("Index Management", func() {
@@ -14,7 +15,7 @@ var _ = Describe("Index Management", func() {
 
 	Describe("#crontabScheduleFor", func() {
 
-		It("should error if the timeunit is not convertable", func() {
+		It("should error if the timeunit is not convertible", func() {
 			_, err := crontabScheduleFor(apis.TimeUnit("15wk"))
 			Expect(err).To(Not(BeNil()), "Invalid time units should fail")
 		})
@@ -55,10 +56,10 @@ var _ = Describe("Index Management", func() {
 			It("should restrict the index to 40Gb per shard", func() {
 				Expect(conditions.MaxSize).To(Equal("120gb"))
 			})
-			It("should restrict the index to 40960 docs per primary shard", func() {
-				Expect(conditions.MaxDocs).To(Equal(40960 * primaryShards))
+			It("should restrict the index to (TheoreticalShardMaxSizeInMB * 1000) docs per primary shard", func() {
+				Expect(conditions.MaxDocs).To(Equal(constants.TheoreticalShardMaxSizeInMB * 1000 * primaryShards))
 			})
-			It("should restrict the age to that defined by policy managment", func() {
+			It("should restrict the age to that defined by policy management", func() {
 				Expect(conditions.MaxAge).To(Equal(string(policy.Phases.Hot.Actions.Rollover.MaxAge)))
 			})
 			It("should ignore the age if the hot phase is not defined", func() {
@@ -66,7 +67,7 @@ var _ = Describe("Index Management", func() {
 				conditions = calculateConditions(policy, primaryShards)
 				Expect(conditions.MaxAge).To(Equal(""))
 			})
-			It("should ignore the age if the hot phase rollover actin is not defined", func() {
+			It("should ignore the age if the hot phase rollover action is not defined", func() {
 				policy.Phases.Hot.Actions.Rollover = nil
 				conditions = calculateConditions(policy, primaryShards)
 				Expect(conditions.MaxAge).To(Equal(""))
@@ -97,25 +98,25 @@ var _ = Describe("Index Management", func() {
 				Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 				Expect(value).To(BeEquivalentTo(uint64(7257600000)))
 			})
-			It("should succed for 'days'", func() {
+			It("should succeed for 'days'", func() {
 				value, err := calculateMillisForTimeUnit(apis.TimeUnit("12d"))
 				Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 				Expect(value).To(BeEquivalentTo(uint64(1036800000)))
 			})
-			It("should succed for 'hours'", func() {
+			It("should succeed for 'hours'", func() {
 				for _, unit := range []string{"12h", "12H"} {
 					value, err := calculateMillisForTimeUnit(apis.TimeUnit(unit))
 					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 					Expect(value).To(BeEquivalentTo(uint64(43200000)))
 				}
 			})
-			It("should succed for 'minutes'", func() {
+			It("should succeed for 'minutes'", func() {
 				value, err := calculateMillisForTimeUnit(apis.TimeUnit("12m"))
 				Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 				Expect(value).To(BeEquivalentTo(uint64(720000)))
 
 			})
-			It("should succed for 'seconds'", func() {
+			It("should succeed for 'seconds'", func() {
 				value, err := calculateMillisForTimeUnit(apis.TimeUnit("12s"))
 				Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 				Expect(value).To(BeEquivalentTo(uint64(12000)))


### PR DESCRIPTION
The IndexManagement is configured to rollover index if any of existing conditions is met. We have
conditions on index size, number of document and age. Currently the condition on number of documents
in the index was calculated assuming the size of individual document (a single log) is up to 1M.
This is oversized for most of the real cases and is causing the index to be rolled over when 120.000
documents are stored in the index (given 3/1 prim/replicas sharding). This can easily lead to 10 new
infra indices per hour (about 300mb size each) on an "idle" OCP cluster.

We update the condition to assume average size of individual log is a lot less (~1K). But in general this is not about assumed size of individual log message but about increasing the number of documents stored in index before maxSize rollover condition is met.

manual cherry-pick of #425