### PR TITLE
[release-4.3] Bug 1860164: Disable indices level metrics in Prometheu…

### DIFF
--- a/pkg/k8shandler/configuration_tmpl.go
+++ b/pkg/k8shandler/configuration_tmpl.go
@@ -41,6 +41,9 @@ openshift.searchguard:
 
 openshift.kibana.index.mode: {{.KibanaIndexMode}}
 
+prometheus:
+  indices: false
+
 path:
   data: /elasticsearch/persistent/${CLUSTER_NAME}/data
   logs: /elasticsearch/persistent/${CLUSTER_NAME}/logs


### PR DESCRIPTION
…s exporter output

Index level metrics contain high cardinality labels (index names and segment IDs). This can cause issues tto Prometheus and consume a lot of Prometheus storage.

manual cherry-pick of #427