### PR TITLE
[WIP] feat(scripts): add percent script

### DIFF
--- a/hack/extract-percent-script.sh
+++ b/hack/extract-percent-script.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+cd $(dirname "${BASH_SOURCE[0]}")
+
+# to use it in the best way, pipe output to `pbcopy` to save it in the paste buffer
+# on the other end, run the command `echo > dest_script.sh && vi dest_script.sh`
+# in it paste the data from the paste buffer and save
+
+cat ../pkg/indexmanagement/scripts.go | \
+	 awk 'NR>90' | \
+	 sed '$d' | \
+	 sed '$d'| \
+	 sed '$d'| \
+	 sed '$d'| \
+	 sed '$d'| \
+	 sed '$d'| \
+	 sed '$d'

--- a/pkg/indexmanagement/scripts.go
+++ b/pkg/indexmanagement/scripts.go
@@ -106,7 +106,7 @@ END
 )
 writeIndex=$(echo "${writeIndices}" | python -c "$CMD")
 
-nodeResources=$(curl -s $ES_SERVICE/_nodes/stats/os
+nodeResources=$(curl -s $ES_SERVICE/_nodes/stats/os \
   --cacert /etc/indexmanagement/keys/admin-ca \
   -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
   -HContent-Type:application/json)
@@ -131,7 +131,7 @@ END
 )
 bytesToDelete=$(echo "${nodeResources}" | python -c "$CMD")
 
-storeSizes=$(curl -s $ES_SERVICE/_stats/store
+storeSizes=$(curl -s $ES_SERVICE/_stats/store \
   --cacert /etc/indexmanagement/keys/admin-ca \
   -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
   -HContent-Type:application/json)

--- a/pkg/indexmanagement/scripts.go
+++ b/pkg/indexmanagement/scripts.go
@@ -12,7 +12,7 @@ code=$(curl -s "$ES_SERVICE/${POLICY_MAPPING}-write/_rollover?pretty" \
   -o /tmp/response.txt \
   -d $decoded)
 if [ "$code" == "200" ] ; then
-  exit 0 
+  exit 0
 fi
 cat /tmp/response.txt
 exit 1
@@ -31,7 +31,7 @@ r=json.load(sys.stdin)
 alias="${POLICY_MAPPING}-write"
 indices = [index for index in r if r[index]['aliases'][alias]['is_write_index']]
 if len(indices) > 0:
-  print indices[0] 
+  print indices[0]
 END
 )
 writeIndex=$(echo "${writeIndices}" | python -c "$CMD")
@@ -55,7 +55,7 @@ print ','.join(indices)
 END
 )
 indices=$(echo "${indices}"  | python -c "$CMD")
-  
+
 if [ "${indices}" == "" ] ; then
     echo No indices to delete
     exit 0
@@ -78,7 +78,139 @@ cat /tmp/response.txt
 exit 1
 `
 
+// percentScript is supposed to delete until a percentage given by MAX_PERCENT
+// the script will sort all of the indices based on time and delete the oldest ones
+// calculations of current size are done by the '/_nodes/stats/os' API
+//
+// to Run this you should do th following:
+// TODO(rogreen) So far I was able to run the following without full success:
+// 1. copy the script to the elasticsearch master node
+// 2. try to run in with `ES_SERVICE=https://localhost:9200 POLICY_MAPPING=<INDEX_NAME> bash -x test.sh`
+// 3. see it fails
+const percentScript = `
+set -euo pipefail
+
+writeIndices=$(curl -s $ES_SERVICE/${POLICY_MAPPING}-*/_alias/${POLICY_MAPPING}-write \
+  --cacert /etc/indexmanagement/keys/admin-ca \
+  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  -HContent-Type:application/json)
+
+CMD=$(cat <<END
+import json,sys
+r=json.load(sys.stdin)
+alias="${POLICY_MAPPING}-write"
+indices = [index for index in r if r[index]['aliases'][alias]['is_write_index']]
+if len(indices) > 0:
+  print indices[0]
+END
+)
+writeIndex=$(echo "${writeIndices}" | python -c "$CMD")
+
+nodeResources=$(curl -s $ES_SERVICE/_nodes/stats/os
+  --cacert /etc/indexmanagement/keys/admin-ca \
+  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  -HContent-Type:application/json)
+
+CMD=$(cat <<END
+import json,sys
+r=json.load(sys.stdin)
+node_sizes = [(node['name'], node['os']['mem']['free_percent'], node['os']['mem']['free_in_bytes']) for node in r['nodes']]
+highest_percent=0
+highest_bytes=0
+for node_size in node_sizes:
+  node_name, node_percent, node_bytes = node_size
+  if node_percent > "${MAX_PERCENT}" and node_percent > highest_percent:
+    highest_percent = node_percent
+    highest_bytes = node_bytes
+
+max_bytes = (highest_bytes / ( highest_percent / 100 ) ) * ("${MAX_PERCENT}" / 100)
+bytes_to_delete = highest_bytes - max_bytes
+print(bytes_to_delete)
+
+END
+)
+bytesToDelete=$(echo "${nodeResources}" | python -c "$CMD")
+
+storeSizes=$(curl -s $ES_SERVICE/_stats/store
+  --cacert /etc/indexmanagement/keys/admin-ca \
+  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  -HContent-Type:application/json)
+
+CMD=$(cat <<END
+import json,sys
+r=json.load(sys.stdin)
+print(json.dumps(r.indices))
+END
+)
+sizeOfIndices=$(echo "${storeSizes}" | python -c "$CMD")
+
+indices=$(curl -s $ES_SERVICE/${POLICY_MAPPING}/_settings/index.creation_date \
+  --cacert /etc/indexmanagement/keys/admin-ca \
+  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  -HContent-Type:application/json)
+
+CMD=$(cat <<END
+import json,sys
+r = json.load(sys.stdin)
+
+# Join sizeOfIndices and indices dictionaries based on index name
+r.update(json.loads("${sizeOfIndices}"))
+
+# Convert to list to allow maintaining sort order
+rl = [ i for i in r ]
+
+# getCreationDate takes an index and extracts the creation date
+getCreationDate = lambda x: return int(x['settings']['index']['creation_date'])
+
+rl.sort(key=getCreationDate)
+
+# getSizeInBytes takes an index and extracts it's size in bytes
+getSizeInBytes = lambda x: return x['indices']['total']['store']['size_in_bytes']
+
+totalSize = 0
+lastPos = -1
+for pos, index in enumerate(rl):
+  currentSize = getSizeInBytes(index)
+  # sum up all the sizes to see if they pass the threshold, bytesToDelete.
+  if totalSize + currentSize < "${bytesToDelete}":
+    totalSize += currentSize
+    lastPos = pos
+  else
+    break
+
+if "$writeIndex" in rl:
+  rl.remove("$writeIndex")
+
+# take only the indices up to threshold and print with comma seperator
+print(','.join(rl[:lastPos]))
+END
+)
+indices=$(echo "${indices}"  | python -c "$CMD")
+
+CMD=$(cat <<END
+import json,sys
+r=json.load(sys.stdin)
+END
+)
+indices=$(echo "${indices}"  | python -c "$CMD")
+
+code=$(curl -s $ES_SERVICE/${indices}?pretty \
+  -w "%{response_code}" \
+  --cacert /etc/indexmanagement/keys/admin-ca \
+  -HContent-Type:application/json \
+  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  -o /tmp/response.txt \
+  -XDELETE )
+
+if [ "$code" == "200" ] ; then
+  exit 0
+fi
+cat /tmp/response.txt
+exit 1
+`
+
 var scriptMap = map[string]string{
 	"delete":   deleteScript,
+	"percent":  percentScript,
 	"rollover": rolloverScript,
 }


### PR DESCRIPTION
DISCALIMER: I am new to `elasticsearch-operator` I just created the script and used parts of the code from the `delete` job.

Goals:
- targeted to  ES6 (OCP4.5 and up)
- deletion will be based on PolicyMapping ( all indices under that alias )
- similar operation to the `delete` script

Non-Goals:
This proposal is **not** a clusterwide deletion of indices

The proposed CRD schema I suggest:
```
spec:
  indexManagement:
    policies:
    - name: infra-policy
      pollInterval: 1m
      phases:
        hot:
          actions:
            rollover:
              maxAge:   2m
        delete:
          minAge: 5m
          maxUtilization: 20 // This should be in a percentage
```

How the script is implemented so far:

1. Get indices from PolicyMapping (same as `delete`)
0. Get write index (same as `delete`)
0. Get cluster size
0. Get indices in reverse order  (same as `delete`)
0. Join with indices based on size
0. take indices until the threshold is passed
0. Delete indices  (same as `delete`)

this currently is working on all of the cluster resources (aka `_nodes/stats/os`) but could be reformatted to a different format if wanted

the drawback is that if there is a single index consuming all of the data it will be deleted and no data will remain in ES

Things left to do:
- [ ] add CR support to this operation
- [ ] decide how the percentage cronjobs will be set to avoid race condition