### PR TITLE
Bug 1871737: Upgrade CRD apiVersion apiextensions.k8s.io from v1beta1 to v1

### DIFF
--- a/bundle/manifests/logging.openshift.io_elasticsearches_crd.yaml
+++ b/bundle/manifests/logging.openshift.io_elasticsearches_crd.yaml
@@ -1,27 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: elasticsearches.logging.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.managementState
-    name: Management State
-    type: string
-  - JSONPath: .status.cluster.status
-    name: Health
-    type: string
-  - JSONPath: .status.cluster.numNodes
-    name: Nodes
-    type: integer
-  - JSONPath: .status.cluster.numDataNodes
-    name: Data Nodes
-    type: integer
-  - JSONPath: .status.shardAllocationEnabled
-    name: Shard Allocation
-    type: string
-  - JSONPath: .status.indexManagement.State
-    name: Index Management
-    type: string
   group: logging.openshift.io
   names:
     categories:
@@ -34,241 +15,148 @@ spec:
     - es
     singular: elasticsearch
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Elasticsearch is the Schema for the elasticsearches API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Specification of the desired behavior of the Elasticsearch
-            cluster
-          properties:
-            indexManagement:
-              description: Management spec for indicies
-              nullable: true
-              properties:
-                mappings:
-                  description: Mappings of policies to indicies
-                  items:
-                    description: IndexManagementPolicyMappingSpec maps a management
-                      policy to an index
-                    properties:
-                      aliases:
-                        description: Aliases to apply to a template
-                        items:
-                          type: string
-                        type: array
-                      name:
-                        description: The unique name of the policy mapping
-                        type: string
-                      policyRef:
-                        description: A reference to a defined policy
-                        type: string
-                    type: object
-                  type: array
-                policies:
-                  description: A list of polices for managing an indices
-                  items:
-                    description: IndexManagementPolicySpec is a definition of an index
-                      management policy
-                    properties:
-                      name:
-                        description: The unique name of the policy
-                        type: string
-                      phases:
-                        properties:
-                          delete:
-                            nullable: true
-                            properties:
-                              minAge:
-                                description: The minimum age of an index before it
-                                  should be deleted (e.g. 10d)
-                                pattern: ^([0-9]+)([yMwdhHms]{0,1})$
-                                type: string
-                            required:
-                            - minAge
-                            type: object
-                          hot:
-                            nullable: true
-                            properties:
-                              actions:
-                                properties:
-                                  rollover:
-                                    nullable: true
-                                    properties:
-                                      maxAge:
-                                        description: The maximum age of an index before
-                                          it should be rolled over (e.g. 7d)
-                                        pattern: ^([0-9]+)([yMwdhHms]{0,1})$
-                                        type: string
-                                    required:
-                                    - maxAge
-                                    type: object
-                                type: object
-                            type: object
-                        type: object
-                      pollInterval:
-                        description: How often to check an index meets the desired
-                          criteria (e.g. 1m)
-                        pattern: ^([0-9]+)([yMwdhHms]{0,1})$
-                        type: string
-                    required:
-                    - name
-                    - phases
-                    - pollInterval
-                    type: object
-                  type: array
-              type: object
-            managementState:
-              description: ManagementState indicates whether and how the operator
-                should manage the component. Indicator if the resource is 'Managed'
-                or 'Unmanaged' by the operator.
-              enum:
-              - Managed
-              - Unmanaged
-              type: string
-            nodeSpec:
-              description: Default specification applied to all Elasticsearch nodes
-              properties:
-                image:
-                  description: The image to use for the Elasticsearch nodes
-                  nullable: true
-                  type: string
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: Define which Nodes the Pods are scheduled on.
-                  nullable: true
-                  type: object
-                proxyResources:
-                  description: The resource requirements for the Elasticsearch proxy
-                  nullable: true
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                resources:
-                  description: The resource requirements for the Elasticsearch nodes
-                  nullable: true
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                tolerations:
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-              type: object
-            nodes:
-              description: Specification of the different Elasticsearch nodes
-              items:
-                description: ElasticsearchNode struct represents individual node in
-                  Elasticsearch cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.managementState
+      name: Management State
+      type: string
+    - jsonPath: .status.cluster.status
+      name: Health
+      type: string
+    - jsonPath: .status.cluster.numNodes
+      name: Nodes
+      type: integer
+    - jsonPath: .status.cluster.numDataNodes
+      name: Data Nodes
+      type: integer
+    - jsonPath: .status.shardAllocationEnabled
+      name: Shard Allocation
+      type: string
+    - jsonPath: .status.indexManagement.State
+      name: Index Management
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Elasticsearch is the Schema for the elasticsearches API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired behavior of the Elasticsearch
+              cluster
+            properties:
+              indexManagement:
+                description: Management spec for indicies
+                nullable: true
                 properties:
-                  genUUID:
-                    description: GenUUID will be populated by the operator if not
-                      provided
+                  mappings:
+                    description: Mappings of policies to indicies
+                    items:
+                      description: IndexManagementPolicyMappingSpec maps a management
+                        policy to an index
+                      properties:
+                        aliases:
+                          description: Aliases to apply to a template
+                          items:
+                            type: string
+                          type: array
+                        name:
+                          description: The unique name of the policy mapping
+                          type: string
+                        policyRef:
+                          description: A reference to a defined policy
+                          type: string
+                      type: object
+                    type: array
+                  policies:
+                    description: A list of polices for managing an indices
+                    items:
+                      description: IndexManagementPolicySpec is a definition of an
+                        index management policy
+                      properties:
+                        name:
+                          description: The unique name of the policy
+                          type: string
+                        phases:
+                          properties:
+                            delete:
+                              nullable: true
+                              properties:
+                                minAge:
+                                  description: The minimum age of an index before
+                                    it should be deleted (e.g. 10d)
+                                  pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                                  type: string
+                              required:
+                              - minAge
+                              type: object
+                            hot:
+                              nullable: true
+                              properties:
+                                actions:
+                                  properties:
+                                    rollover:
+                                      nullable: true
+                                      properties:
+                                        maxAge:
+                                          description: The maximum age of an index
+                                            before it should be rolled over (e.g.
+                                            7d)
+                                          pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                                          type: string
+                                      required:
+                                      - maxAge
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        pollInterval:
+                          description: How often to check an index meets the desired
+                            criteria (e.g. 1m)
+                          pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                          type: string
+                      required:
+                      - name
+                      - phases
+                      - pollInterval
+                      type: object
+                    type: array
+                type: object
+              managementState:
+                description: ManagementState indicates whether and how the operator
+                  should manage the component. Indicator if the resource is 'Managed'
+                  or 'Unmanaged' by the operator.
+                enum:
+                - Managed
+                - Unmanaged
+                type: string
+              nodeSpec:
+                description: Default specification applied to all Elasticsearch nodes
+                properties:
+                  image:
+                    description: The image to use for the Elasticsearch nodes
                     nullable: true
                     type: string
-                  nodeCount:
-                    description: Number of nodes to deploy
-                    format: int32
-                    type: integer
                   nodeSelector:
                     additionalProperties:
                       type: string
                     description: Define which Nodes the Pods are scheduled on.
+                    nullable: true
                     type: object
                   proxyResources:
                     description: The resource requirements for the Elasticsearch proxy
+                    nullable: true
                     properties:
                       limits:
                         additionalProperties:
@@ -294,7 +182,7 @@ spec:
                         type: object
                     type: object
                   resources:
-                    description: The resource requirements for the Elasticsearch node
+                    description: The resource requirements for the Elasticsearch nodes
                     nullable: true
                     properties:
                       limits:
@@ -319,32 +207,6 @@ spec:
                           it defaults to Limits if that is explicitly specified, otherwise
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
-                    type: object
-                  roles:
-                    description: The specific Elasticsearch cluster roles the node
-                      should perform
-                    items:
-                      enum:
-                      - master
-                      - client
-                      - data
-                      type: string
-                    type: array
-                  storage:
-                    description: The type of backing storage that should be used for
-                      the node
-                    properties:
-                      size:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: The max storage capacity for the node to provision.
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      storageClassName:
-                        description: 'The name of the storage class to use with creating
-                          the node''s PVC. More info: https://kubernetes.io/docs/concepts/storage/storage-classes/'
-                        type: string
                     type: object
                   tolerations:
                     items:
@@ -387,252 +249,400 @@ spec:
                       type: object
                     type: array
                 type: object
-              type: array
-            redundancyPolicy:
-              description: The policy towards data redundancy to specify the number
-                of redundant primary shards
-              enum:
-              - FullRedundancy
-              - MultipleRedundancy
-              - SingleRedundancy
-              - ZeroRedundancy
-              type: string
-          required:
-          - managementState
-          - redundancyPolicy
-          type: object
-        status:
-          description: ElasticsearchStatus defines the observed state of Elasticsearch
-          properties:
-            cluster:
-              properties:
-                activePrimaryShards:
-                  format: int32
-                  type: integer
-                activeShards:
-                  format: int32
-                  type: integer
-                initializingShards:
-                  format: int32
-                  type: integer
-                numDataNodes:
-                  format: int32
-                  type: integer
-                numNodes:
-                  format: int32
-                  type: integer
-                pendingTasks:
-                  format: int32
-                  type: integer
-                relocatingShards:
-                  format: int32
-                  type: integer
-                status:
-                  type: string
-                unassignedShards:
-                  format: int32
-                  type: integer
-              required:
-              - activePrimaryShards
-              - activeShards
-              - initializingShards
-              - numDataNodes
-              - numNodes
-              - pendingTasks
-              - relocatingShards
-              - status
-              - unassignedShards
-              type: object
-            clusterHealth:
-              type: string
-            conditions:
-              items:
+              nodes:
+                description: Specification of the different Elasticsearch nodes
+                items:
+                  description: ElasticsearchNode struct represents individual node
+                    in Elasticsearch cluster
+                  properties:
+                    genUUID:
+                      description: GenUUID will be populated by the operator if not
+                        provided
+                      nullable: true
+                      type: string
+                    nodeCount:
+                      description: Number of nodes to deploy
+                      format: int32
+                      type: integer
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: Define which Nodes the Pods are scheduled on.
+                      type: object
+                    proxyResources:
+                      description: The resource requirements for the Elasticsearch
+                        proxy
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    resources:
+                      description: The resource requirements for the Elasticsearch
+                        node
+                      nullable: true
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    roles:
+                      description: The specific Elasticsearch cluster roles the node
+                        should perform
+                      items:
+                        enum:
+                        - master
+                        - client
+                        - data
+                        type: string
+                      type: array
+                    storage:
+                      description: The type of backing storage that should be used
+                        for the node
+                      properties:
+                        size:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: The max storage capacity for the node to provision.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        storageClassName:
+                          description: 'The name of the storage class to use with
+                            creating the node''s PVC. More info: https://kubernetes.io/docs/concepts/storage/storage-classes/'
+                          type: string
+                      type: object
+                    tolerations:
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              redundancyPolicy:
+                description: The policy towards data redundancy to specify the number
+                  of redundant primary shards
+                enum:
+                - FullRedundancy
+                - MultipleRedundancy
+                - SingleRedundancy
+                - ZeroRedundancy
+                type: string
+            required:
+            - managementState
+            - redundancyPolicy
+            type: object
+          status:
+            description: ElasticsearchStatus defines the observed state of Elasticsearch
+            properties:
+              cluster:
                 properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Human-readable message indicating details about last
-                      transition.
-                    type: string
-                  reason:
-                    description: Unique, one-word, CamelCase reason for the condition's
-                      last transition.
-                    type: string
+                  activePrimaryShards:
+                    format: int32
+                    type: integer
+                  activeShards:
+                    format: int32
+                    type: integer
+                  initializingShards:
+                    format: int32
+                    type: integer
+                  numDataNodes:
+                    format: int32
+                    type: integer
+                  numNodes:
+                    format: int32
+                    type: integer
+                  pendingTasks:
+                    format: int32
+                    type: integer
+                  relocatingShards:
+                    format: int32
+                    type: integer
                   status:
                     type: string
-                  type:
-                    description: ClusterConditionType is a valid value for ClusterCondition.Type
-                    type: string
+                  unassignedShards:
+                    format: int32
+                    type: integer
                 required:
-                - lastTransitionTime
+                - activePrimaryShards
+                - activeShards
+                - initializingShards
+                - numDataNodes
+                - numNodes
+                - pendingTasks
+                - relocatingShards
                 - status
-                - type
+                - unassignedShards
                 type: object
-              type: array
-            indexManagement:
-              properties:
-                lastUpdated:
-                  format: date-time
-                  type: string
-                mappings:
-                  items:
-                    properties:
-                      conditions:
-                        description: Reasons for the state of the corresponding mapping
-                          for this status
-                        items:
-                          properties:
-                            message:
-                              type: string
-                            reason:
-                              type: string
-                            status:
-                              type: string
-                            type:
-                              type: string
-                          type: object
-                        type: array
-                      lastUpdated:
-                        description: LastUpdated represents the last time that the
-                          status was updated.
-                        format: date-time
-                        type: string
-                      message:
-                        type: string
-                      name:
-                        description: Name of the corresponding mapping for this status
-                        type: string
-                      reason:
-                        type: string
-                      state:
-                        description: State of the corresponding mapping for this status
-                        type: string
-                    type: object
-                  type: array
-                message:
-                  type: string
-                policies:
-                  items:
-                    properties:
-                      conditions:
-                        description: Reasons for the state of the corresponding policy
-                          for this status
-                        items:
-                          properties:
-                            message:
-                              type: string
-                            reason:
-                              type: string
-                            status:
-                              type: string
-                            type:
-                              type: string
-                          type: object
-                        type: array
-                      lastUpdated:
-                        description: LastUpdated represents the last time that the
-                          status was updated.
-                        format: date-time
-                        type: string
-                      message:
-                        description: Message about the corresponding policy
-                        type: string
-                      name:
-                        description: Name of the corresponding policy for this status
-                        type: string
-                      reason:
-                        description: Reasons for the state of the corresponding policy
-                          for this status
-                        type: string
-                      state:
-                        description: State of the corresponding policy for this status
-                        type: string
-                    type: object
-                  type: array
-                reason:
-                  type: string
-                state:
-                  description: IndexManagementState of IndexManagment
-                  type: string
-              type: object
-            nodes:
-              items:
-                description: ElasticsearchNodeStatus represents the status of individual
-                  Elasticsearch node
+              clusterHealth:
+                type: string
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ClusterConditionType is a valid value for ClusterCondition.Type
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              indexManagement:
                 properties:
-                  conditions:
+                  lastUpdated:
+                    format: date-time
+                    type: string
+                  mappings:
                     items:
                       properties:
-                        lastTransitionTime:
-                          description: Last time the condition transitioned from one
-                            status to another.
+                        conditions:
+                          description: Reasons for the state of the corresponding
+                            mapping for this status
+                          items:
+                            properties:
+                              message:
+                                type: string
+                              reason:
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            type: object
+                          type: array
+                        lastUpdated:
+                          description: LastUpdated represents the last time that the
+                            status was updated.
                           format: date-time
                           type: string
                         message:
-                          description: Human-readable message indicating details about
-                            last transition.
+                          type: string
+                        name:
+                          description: Name of the corresponding mapping for this
+                            status
                           type: string
                         reason:
-                          description: Unique, one-word, CamelCase reason for the
-                            condition's last transition.
                           type: string
-                        status:
+                        state:
+                          description: State of the corresponding mapping for this
+                            status
                           type: string
-                        type:
-                          description: ClusterConditionType is a valid value for ClusterCondition.Type
-                          type: string
-                      required:
-                      - lastTransitionTime
-                      - status
-                      - type
                       type: object
                     type: array
-                  deploymentName:
+                  message:
                     type: string
-                  roles:
+                  policies:
                     items:
-                      enum:
-                      - master
-                      - client
-                      - data
+                      properties:
+                        conditions:
+                          description: Reasons for the state of the corresponding
+                            policy for this status
+                          items:
+                            properties:
+                              message:
+                                type: string
+                              reason:
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            type: object
+                          type: array
+                        lastUpdated:
+                          description: LastUpdated represents the last time that the
+                            status was updated.
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message about the corresponding policy
+                          type: string
+                        name:
+                          description: Name of the corresponding policy for this status
+                          type: string
+                        reason:
+                          description: Reasons for the state of the corresponding
+                            policy for this status
+                          type: string
+                        state:
+                          description: State of the corresponding policy for this
+                            status
+                          type: string
+                      type: object
+                    type: array
+                  reason:
+                    type: string
+                  state:
+                    description: IndexManagementState of IndexManagment
+                    type: string
+                type: object
+              nodes:
+                items:
+                  description: ElasticsearchNodeStatus represents the status of individual
+                    Elasticsearch node
+                  properties:
+                    conditions:
+                      items:
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from
+                              one status to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: Human-readable message indicating details
+                              about last transition.
+                            type: string
+                          reason:
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
+                            type: string
+                          status:
+                            type: string
+                          type:
+                            description: ClusterConditionType is a valid value for
+                              ClusterCondition.Type
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    deploymentName:
+                      type: string
+                    roles:
+                      items:
+                        enum:
+                        - master
+                        - client
+                        - data
+                        type: string
+                      type: array
+                    statefulSetName:
+                      type: string
+                    status:
+                      type: string
+                    upgradeStatus:
+                      properties:
+                        scheduledCertRedeploy:
+                          type: string
+                        scheduledRedeploy:
+                          type: string
+                        scheduledUpgrade:
+                          type: string
+                        underUpgrade:
+                          type: string
+                        upgradePhase:
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              pods:
+                additionalProperties:
+                  additionalProperties:
+                    items:
                       type: string
                     type: array
-                  statefulSetName:
-                    type: string
-                  status:
-                    type: string
-                  upgradeStatus:
-                    properties:
-                      scheduledCertRedeploy:
-                        type: string
-                      scheduledRedeploy:
-                        type: string
-                      scheduledUpgrade:
-                        type: string
-                      underUpgrade:
-                        type: string
-                      upgradePhase:
-                        type: string
-                    type: object
+                  type: object
                 type: object
-              type: array
-            pods:
-              additionalProperties:
-                additionalProperties:
-                  items:
-                    type: string
-                  type: array
-                type: object
-              type: object
-            shardAllocationEnabled:
-              type: string
-          type: object
-      type: object
-  version: v1
-  versions:
-  - name: v1
+              shardAllocationEnabled:
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/bundle/manifests/logging.openshift.io_kibanas_crd.yaml
+++ b/bundle/manifests/logging.openshift.io_kibanas_crd.yaml
@@ -1,15 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kibanas.logging.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.managementState
-    name: Management State
-    type: string
-  - JSONPath: .spec.replicas
-    name: Replicas
-    type: integer
   group: logging.openshift.io
   names:
     categories:
@@ -19,195 +12,201 @@ spec:
     plural: kibanas
     singular: kibana
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: Kibana is the Schema for the kibanas API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Specification of the desired behavior of the Kibana
-          properties:
-            managementState:
-              description: Indicator if the resource is 'Managed' or 'Unmanaged' by
-                the operator
-              enum:
-              - Managed
-              - Unmanaged
-              type: string
-            nodeSelector:
-              additionalProperties:
-                type: string
-              description: Define which Nodes the Pods are scheduled on.
-              type: object
-            proxy:
-              description: Specification of the Kibana Proxy component
-              properties:
-                resources:
-                  description: The resource requirements for Kibana proxy
-                  nullable: true
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-              type: object
-            replicas:
-              description: Number of instances to deploy for a Kibana deployment
-              format: int32
-              type: integer
-            resources:
-              description: The resource requirements for Kibana
-              nullable: true
-              properties:
-                limits:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            tolerations:
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
-                properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    format: int64
-                    type: integer
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
-                type: object
-              type: array
-          required:
-          - managementState
-          type: object
-        status:
-          items:
-            description: KibanaStatus defines the observed state of Kibana
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.managementState
+      name: Management State
+      type: string
+    - jsonPath: .spec.replicas
+      name: Replicas
+      type: integer
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Kibana is the Schema for the kibanas API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired behavior of the Kibana
             properties:
-              clusterCondition:
-                additionalProperties:
-                  items:
-                    properties:
-                      lastTransitionTime:
-                        description: Last time the condition transitioned from one
-                          status to another.
-                        format: date-time
-                        type: string
-                      message:
-                        description: Human-readable message indicating details about
-                          last transition.
-                        type: string
-                      reason:
-                        description: Unique, one-word, CamelCase reason for the condition's
-                          last transition.
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        description: ClusterConditionType is a valid value for ClusterCondition.Type
-                        type: string
-                    required:
-                    - lastTransitionTime
-                    - status
-                    - type
-                    type: object
-                  type: array
-                type: object
-              deployment:
+              managementState:
+                description: Indicator if the resource is 'Managed' or 'Unmanaged'
+                  by the operator
+                enum:
+                - Managed
+                - Unmanaged
                 type: string
-              pods:
+              nodeSelector:
                 additionalProperties:
-                  items:
-                    type: string
-                  type: array
-                type: object
-              replicaSets:
-                items:
                   type: string
-                type: array
+                description: Define which Nodes the Pods are scheduled on.
+                type: object
+              proxy:
+                description: Specification of the Kibana Proxy component
+                properties:
+                  resources:
+                    description: The resource requirements for Kibana proxy
+                    nullable: true
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
               replicas:
+                description: Number of instances to deploy for a Kibana deployment
                 format: int32
                 type: integer
+              resources:
+                description: The resource requirements for Kibana
+                nullable: true
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              tolerations:
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            required:
+            - managementState
             type: object
-          type: array
-      type: object
-  version: v1
-  versions:
-  - name: v1
+          status:
+            items:
+              description: KibanaStatus defines the observed state of Kibana
+              properties:
+                clusterCondition:
+                  additionalProperties:
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          description: Last time the condition transitioned from one
+                            status to another.
+                          format: date-time
+                          type: string
+                        message:
+                          description: Human-readable message indicating details about
+                            last transition.
+                          type: string
+                        reason:
+                          description: Unique, one-word, CamelCase reason for the
+                            condition's last transition.
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          description: ClusterConditionType is a valid value for ClusterCondition.Type
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  type: object
+                deployment:
+                  type: string
+                pods:
+                  additionalProperties:
+                    items:
+                      type: string
+                    type: array
+                  type: object
+                replicaSets:
+                  items:
+                    type: string
+                  type: array
+                replicas:
+                  format: int32
+                  type: integer
+              type: object
+            type: array
+        type: object
     served: true
     storage: true
+    subresources: {}

--- a/hack/generate-crd.sh
+++ b/hack/generate-crd.sh
@@ -12,9 +12,9 @@ echo "--------------------------------------------------------------"
 $OPERATOR_SDK generate k8s
 
 echo "--------------------------------------------------------------"
-echo "Generate CRDs for apiVersion v1beta1"
+echo "Generate CRDs for apiVersion v1"
 echo "--------------------------------------------------------------"
-$OPERATOR_SDK generate crds --crd-version v1beta1
+$OPERATOR_SDK generate crds --crd-version v1
 mv deploy/crds/*.yaml "${MANIFESTS_DIR}"
 
 echo "---------------------------------------------------------------"

--- a/manifests/4.6/logging.openshift.io_elasticsearches_crd.yaml
+++ b/manifests/4.6/logging.openshift.io_elasticsearches_crd.yaml
@@ -1,27 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: elasticsearches.logging.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.managementState
-    name: Management State
-    type: string
-  - JSONPath: .status.cluster.status
-    name: Health
-    type: string
-  - JSONPath: .status.cluster.numNodes
-    name: Nodes
-    type: integer
-  - JSONPath: .status.cluster.numDataNodes
-    name: Data Nodes
-    type: integer
-  - JSONPath: .status.shardAllocationEnabled
-    name: Shard Allocation
-    type: string
-  - JSONPath: .status.indexManagement.State
-    name: Index Management
-    type: string
   group: logging.openshift.io
   names:
     categories:
@@ -34,241 +15,148 @@ spec:
     - es
     singular: elasticsearch
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Elasticsearch is the Schema for the elasticsearches API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Specification of the desired behavior of the Elasticsearch
-            cluster
-          properties:
-            indexManagement:
-              description: Management spec for indicies
-              nullable: true
-              properties:
-                mappings:
-                  description: Mappings of policies to indicies
-                  items:
-                    description: IndexManagementPolicyMappingSpec maps a management
-                      policy to an index
-                    properties:
-                      aliases:
-                        description: Aliases to apply to a template
-                        items:
-                          type: string
-                        type: array
-                      name:
-                        description: The unique name of the policy mapping
-                        type: string
-                      policyRef:
-                        description: A reference to a defined policy
-                        type: string
-                    type: object
-                  type: array
-                policies:
-                  description: A list of polices for managing an indices
-                  items:
-                    description: IndexManagementPolicySpec is a definition of an index
-                      management policy
-                    properties:
-                      name:
-                        description: The unique name of the policy
-                        type: string
-                      phases:
-                        properties:
-                          delete:
-                            nullable: true
-                            properties:
-                              minAge:
-                                description: The minimum age of an index before it
-                                  should be deleted (e.g. 10d)
-                                pattern: ^([0-9]+)([yMwdhHms]{0,1})$
-                                type: string
-                            required:
-                            - minAge
-                            type: object
-                          hot:
-                            nullable: true
-                            properties:
-                              actions:
-                                properties:
-                                  rollover:
-                                    nullable: true
-                                    properties:
-                                      maxAge:
-                                        description: The maximum age of an index before
-                                          it should be rolled over (e.g. 7d)
-                                        pattern: ^([0-9]+)([yMwdhHms]{0,1})$
-                                        type: string
-                                    required:
-                                    - maxAge
-                                    type: object
-                                type: object
-                            type: object
-                        type: object
-                      pollInterval:
-                        description: How often to check an index meets the desired
-                          criteria (e.g. 1m)
-                        pattern: ^([0-9]+)([yMwdhHms]{0,1})$
-                        type: string
-                    required:
-                    - name
-                    - phases
-                    - pollInterval
-                    type: object
-                  type: array
-              type: object
-            managementState:
-              description: ManagementState indicates whether and how the operator
-                should manage the component. Indicator if the resource is 'Managed'
-                or 'Unmanaged' by the operator.
-              enum:
-              - Managed
-              - Unmanaged
-              type: string
-            nodeSpec:
-              description: Default specification applied to all Elasticsearch nodes
-              properties:
-                image:
-                  description: The image to use for the Elasticsearch nodes
-                  nullable: true
-                  type: string
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: Define which Nodes the Pods are scheduled on.
-                  nullable: true
-                  type: object
-                proxyResources:
-                  description: The resource requirements for the Elasticsearch proxy
-                  nullable: true
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                resources:
-                  description: The resource requirements for the Elasticsearch nodes
-                  nullable: true
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                tolerations:
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-              type: object
-            nodes:
-              description: Specification of the different Elasticsearch nodes
-              items:
-                description: ElasticsearchNode struct represents individual node in
-                  Elasticsearch cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.managementState
+      name: Management State
+      type: string
+    - jsonPath: .status.cluster.status
+      name: Health
+      type: string
+    - jsonPath: .status.cluster.numNodes
+      name: Nodes
+      type: integer
+    - jsonPath: .status.cluster.numDataNodes
+      name: Data Nodes
+      type: integer
+    - jsonPath: .status.shardAllocationEnabled
+      name: Shard Allocation
+      type: string
+    - jsonPath: .status.indexManagement.State
+      name: Index Management
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Elasticsearch is the Schema for the elasticsearches API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired behavior of the Elasticsearch
+              cluster
+            properties:
+              indexManagement:
+                description: Management spec for indicies
+                nullable: true
                 properties:
-                  genUUID:
-                    description: GenUUID will be populated by the operator if not
-                      provided
+                  mappings:
+                    description: Mappings of policies to indicies
+                    items:
+                      description: IndexManagementPolicyMappingSpec maps a management
+                        policy to an index
+                      properties:
+                        aliases:
+                          description: Aliases to apply to a template
+                          items:
+                            type: string
+                          type: array
+                        name:
+                          description: The unique name of the policy mapping
+                          type: string
+                        policyRef:
+                          description: A reference to a defined policy
+                          type: string
+                      type: object
+                    type: array
+                  policies:
+                    description: A list of polices for managing an indices
+                    items:
+                      description: IndexManagementPolicySpec is a definition of an
+                        index management policy
+                      properties:
+                        name:
+                          description: The unique name of the policy
+                          type: string
+                        phases:
+                          properties:
+                            delete:
+                              nullable: true
+                              properties:
+                                minAge:
+                                  description: The minimum age of an index before
+                                    it should be deleted (e.g. 10d)
+                                  pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                                  type: string
+                              required:
+                              - minAge
+                              type: object
+                            hot:
+                              nullable: true
+                              properties:
+                                actions:
+                                  properties:
+                                    rollover:
+                                      nullable: true
+                                      properties:
+                                        maxAge:
+                                          description: The maximum age of an index
+                                            before it should be rolled over (e.g.
+                                            7d)
+                                          pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                                          type: string
+                                      required:
+                                      - maxAge
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        pollInterval:
+                          description: How often to check an index meets the desired
+                            criteria (e.g. 1m)
+                          pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                          type: string
+                      required:
+                      - name
+                      - phases
+                      - pollInterval
+                      type: object
+                    type: array
+                type: object
+              managementState:
+                description: ManagementState indicates whether and how the operator
+                  should manage the component. Indicator if the resource is 'Managed'
+                  or 'Unmanaged' by the operator.
+                enum:
+                - Managed
+                - Unmanaged
+                type: string
+              nodeSpec:
+                description: Default specification applied to all Elasticsearch nodes
+                properties:
+                  image:
+                    description: The image to use for the Elasticsearch nodes
                     nullable: true
                     type: string
-                  nodeCount:
-                    description: Number of nodes to deploy
-                    format: int32
-                    type: integer
                   nodeSelector:
                     additionalProperties:
                       type: string
                     description: Define which Nodes the Pods are scheduled on.
+                    nullable: true
                     type: object
                   proxyResources:
                     description: The resource requirements for the Elasticsearch proxy
+                    nullable: true
                     properties:
                       limits:
                         additionalProperties:
@@ -294,7 +182,7 @@ spec:
                         type: object
                     type: object
                   resources:
-                    description: The resource requirements for the Elasticsearch node
+                    description: The resource requirements for the Elasticsearch nodes
                     nullable: true
                     properties:
                       limits:
@@ -319,32 +207,6 @@ spec:
                           it defaults to Limits if that is explicitly specified, otherwise
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
-                    type: object
-                  roles:
-                    description: The specific Elasticsearch cluster roles the node
-                      should perform
-                    items:
-                      enum:
-                      - master
-                      - client
-                      - data
-                      type: string
-                    type: array
-                  storage:
-                    description: The type of backing storage that should be used for
-                      the node
-                    properties:
-                      size:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: The max storage capacity for the node to provision.
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      storageClassName:
-                        description: 'The name of the storage class to use with creating
-                          the node''s PVC. More info: https://kubernetes.io/docs/concepts/storage/storage-classes/'
-                        type: string
                     type: object
                   tolerations:
                     items:
@@ -387,252 +249,400 @@ spec:
                       type: object
                     type: array
                 type: object
-              type: array
-            redundancyPolicy:
-              description: The policy towards data redundancy to specify the number
-                of redundant primary shards
-              enum:
-              - FullRedundancy
-              - MultipleRedundancy
-              - SingleRedundancy
-              - ZeroRedundancy
-              type: string
-          required:
-          - managementState
-          - redundancyPolicy
-          type: object
-        status:
-          description: ElasticsearchStatus defines the observed state of Elasticsearch
-          properties:
-            cluster:
-              properties:
-                activePrimaryShards:
-                  format: int32
-                  type: integer
-                activeShards:
-                  format: int32
-                  type: integer
-                initializingShards:
-                  format: int32
-                  type: integer
-                numDataNodes:
-                  format: int32
-                  type: integer
-                numNodes:
-                  format: int32
-                  type: integer
-                pendingTasks:
-                  format: int32
-                  type: integer
-                relocatingShards:
-                  format: int32
-                  type: integer
-                status:
-                  type: string
-                unassignedShards:
-                  format: int32
-                  type: integer
-              required:
-              - activePrimaryShards
-              - activeShards
-              - initializingShards
-              - numDataNodes
-              - numNodes
-              - pendingTasks
-              - relocatingShards
-              - status
-              - unassignedShards
-              type: object
-            clusterHealth:
-              type: string
-            conditions:
-              items:
+              nodes:
+                description: Specification of the different Elasticsearch nodes
+                items:
+                  description: ElasticsearchNode struct represents individual node
+                    in Elasticsearch cluster
+                  properties:
+                    genUUID:
+                      description: GenUUID will be populated by the operator if not
+                        provided
+                      nullable: true
+                      type: string
+                    nodeCount:
+                      description: Number of nodes to deploy
+                      format: int32
+                      type: integer
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: Define which Nodes the Pods are scheduled on.
+                      type: object
+                    proxyResources:
+                      description: The resource requirements for the Elasticsearch
+                        proxy
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    resources:
+                      description: The resource requirements for the Elasticsearch
+                        node
+                      nullable: true
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    roles:
+                      description: The specific Elasticsearch cluster roles the node
+                        should perform
+                      items:
+                        enum:
+                        - master
+                        - client
+                        - data
+                        type: string
+                      type: array
+                    storage:
+                      description: The type of backing storage that should be used
+                        for the node
+                      properties:
+                        size:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: The max storage capacity for the node to provision.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        storageClassName:
+                          description: 'The name of the storage class to use with
+                            creating the node''s PVC. More info: https://kubernetes.io/docs/concepts/storage/storage-classes/'
+                          type: string
+                      type: object
+                    tolerations:
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              redundancyPolicy:
+                description: The policy towards data redundancy to specify the number
+                  of redundant primary shards
+                enum:
+                - FullRedundancy
+                - MultipleRedundancy
+                - SingleRedundancy
+                - ZeroRedundancy
+                type: string
+            required:
+            - managementState
+            - redundancyPolicy
+            type: object
+          status:
+            description: ElasticsearchStatus defines the observed state of Elasticsearch
+            properties:
+              cluster:
                 properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Human-readable message indicating details about last
-                      transition.
-                    type: string
-                  reason:
-                    description: Unique, one-word, CamelCase reason for the condition's
-                      last transition.
-                    type: string
+                  activePrimaryShards:
+                    format: int32
+                    type: integer
+                  activeShards:
+                    format: int32
+                    type: integer
+                  initializingShards:
+                    format: int32
+                    type: integer
+                  numDataNodes:
+                    format: int32
+                    type: integer
+                  numNodes:
+                    format: int32
+                    type: integer
+                  pendingTasks:
+                    format: int32
+                    type: integer
+                  relocatingShards:
+                    format: int32
+                    type: integer
                   status:
                     type: string
-                  type:
-                    description: ClusterConditionType is a valid value for ClusterCondition.Type
-                    type: string
+                  unassignedShards:
+                    format: int32
+                    type: integer
                 required:
-                - lastTransitionTime
+                - activePrimaryShards
+                - activeShards
+                - initializingShards
+                - numDataNodes
+                - numNodes
+                - pendingTasks
+                - relocatingShards
                 - status
-                - type
+                - unassignedShards
                 type: object
-              type: array
-            indexManagement:
-              properties:
-                lastUpdated:
-                  format: date-time
-                  type: string
-                mappings:
-                  items:
-                    properties:
-                      conditions:
-                        description: Reasons for the state of the corresponding mapping
-                          for this status
-                        items:
-                          properties:
-                            message:
-                              type: string
-                            reason:
-                              type: string
-                            status:
-                              type: string
-                            type:
-                              type: string
-                          type: object
-                        type: array
-                      lastUpdated:
-                        description: LastUpdated represents the last time that the
-                          status was updated.
-                        format: date-time
-                        type: string
-                      message:
-                        type: string
-                      name:
-                        description: Name of the corresponding mapping for this status
-                        type: string
-                      reason:
-                        type: string
-                      state:
-                        description: State of the corresponding mapping for this status
-                        type: string
-                    type: object
-                  type: array
-                message:
-                  type: string
-                policies:
-                  items:
-                    properties:
-                      conditions:
-                        description: Reasons for the state of the corresponding policy
-                          for this status
-                        items:
-                          properties:
-                            message:
-                              type: string
-                            reason:
-                              type: string
-                            status:
-                              type: string
-                            type:
-                              type: string
-                          type: object
-                        type: array
-                      lastUpdated:
-                        description: LastUpdated represents the last time that the
-                          status was updated.
-                        format: date-time
-                        type: string
-                      message:
-                        description: Message about the corresponding policy
-                        type: string
-                      name:
-                        description: Name of the corresponding policy for this status
-                        type: string
-                      reason:
-                        description: Reasons for the state of the corresponding policy
-                          for this status
-                        type: string
-                      state:
-                        description: State of the corresponding policy for this status
-                        type: string
-                    type: object
-                  type: array
-                reason:
-                  type: string
-                state:
-                  description: IndexManagementState of IndexManagment
-                  type: string
-              type: object
-            nodes:
-              items:
-                description: ElasticsearchNodeStatus represents the status of individual
-                  Elasticsearch node
+              clusterHealth:
+                type: string
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ClusterConditionType is a valid value for ClusterCondition.Type
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              indexManagement:
                 properties:
-                  conditions:
+                  lastUpdated:
+                    format: date-time
+                    type: string
+                  mappings:
                     items:
                       properties:
-                        lastTransitionTime:
-                          description: Last time the condition transitioned from one
-                            status to another.
+                        conditions:
+                          description: Reasons for the state of the corresponding
+                            mapping for this status
+                          items:
+                            properties:
+                              message:
+                                type: string
+                              reason:
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            type: object
+                          type: array
+                        lastUpdated:
+                          description: LastUpdated represents the last time that the
+                            status was updated.
                           format: date-time
                           type: string
                         message:
-                          description: Human-readable message indicating details about
-                            last transition.
+                          type: string
+                        name:
+                          description: Name of the corresponding mapping for this
+                            status
                           type: string
                         reason:
-                          description: Unique, one-word, CamelCase reason for the
-                            condition's last transition.
                           type: string
-                        status:
+                        state:
+                          description: State of the corresponding mapping for this
+                            status
                           type: string
-                        type:
-                          description: ClusterConditionType is a valid value for ClusterCondition.Type
-                          type: string
-                      required:
-                      - lastTransitionTime
-                      - status
-                      - type
                       type: object
                     type: array
-                  deploymentName:
+                  message:
                     type: string
-                  roles:
+                  policies:
                     items:
-                      enum:
-                      - master
-                      - client
-                      - data
+                      properties:
+                        conditions:
+                          description: Reasons for the state of the corresponding
+                            policy for this status
+                          items:
+                            properties:
+                              message:
+                                type: string
+                              reason:
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            type: object
+                          type: array
+                        lastUpdated:
+                          description: LastUpdated represents the last time that the
+                            status was updated.
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message about the corresponding policy
+                          type: string
+                        name:
+                          description: Name of the corresponding policy for this status
+                          type: string
+                        reason:
+                          description: Reasons for the state of the corresponding
+                            policy for this status
+                          type: string
+                        state:
+                          description: State of the corresponding policy for this
+                            status
+                          type: string
+                      type: object
+                    type: array
+                  reason:
+                    type: string
+                  state:
+                    description: IndexManagementState of IndexManagment
+                    type: string
+                type: object
+              nodes:
+                items:
+                  description: ElasticsearchNodeStatus represents the status of individual
+                    Elasticsearch node
+                  properties:
+                    conditions:
+                      items:
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from
+                              one status to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: Human-readable message indicating details
+                              about last transition.
+                            type: string
+                          reason:
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
+                            type: string
+                          status:
+                            type: string
+                          type:
+                            description: ClusterConditionType is a valid value for
+                              ClusterCondition.Type
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    deploymentName:
+                      type: string
+                    roles:
+                      items:
+                        enum:
+                        - master
+                        - client
+                        - data
+                        type: string
+                      type: array
+                    statefulSetName:
+                      type: string
+                    status:
+                      type: string
+                    upgradeStatus:
+                      properties:
+                        scheduledCertRedeploy:
+                          type: string
+                        scheduledRedeploy:
+                          type: string
+                        scheduledUpgrade:
+                          type: string
+                        underUpgrade:
+                          type: string
+                        upgradePhase:
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              pods:
+                additionalProperties:
+                  additionalProperties:
+                    items:
                       type: string
                     type: array
-                  statefulSetName:
-                    type: string
-                  status:
-                    type: string
-                  upgradeStatus:
-                    properties:
-                      scheduledCertRedeploy:
-                        type: string
-                      scheduledRedeploy:
-                        type: string
-                      scheduledUpgrade:
-                        type: string
-                      underUpgrade:
-                        type: string
-                      upgradePhase:
-                        type: string
-                    type: object
+                  type: object
                 type: object
-              type: array
-            pods:
-              additionalProperties:
-                additionalProperties:
-                  items:
-                    type: string
-                  type: array
-                type: object
-              type: object
-            shardAllocationEnabled:
-              type: string
-          type: object
-      type: object
-  version: v1
-  versions:
-  - name: v1
+              shardAllocationEnabled:
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/manifests/4.6/logging.openshift.io_kibanas_crd.yaml
+++ b/manifests/4.6/logging.openshift.io_kibanas_crd.yaml
@@ -1,15 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kibanas.logging.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.managementState
-    name: Management State
-    type: string
-  - JSONPath: .spec.replicas
-    name: Replicas
-    type: integer
   group: logging.openshift.io
   names:
     categories:
@@ -19,195 +12,201 @@ spec:
     plural: kibanas
     singular: kibana
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: Kibana is the Schema for the kibanas API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Specification of the desired behavior of the Kibana
-          properties:
-            managementState:
-              description: Indicator if the resource is 'Managed' or 'Unmanaged' by
-                the operator
-              enum:
-              - Managed
-              - Unmanaged
-              type: string
-            nodeSelector:
-              additionalProperties:
-                type: string
-              description: Define which Nodes the Pods are scheduled on.
-              type: object
-            proxy:
-              description: Specification of the Kibana Proxy component
-              properties:
-                resources:
-                  description: The resource requirements for Kibana proxy
-                  nullable: true
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-              type: object
-            replicas:
-              description: Number of instances to deploy for a Kibana deployment
-              format: int32
-              type: integer
-            resources:
-              description: The resource requirements for Kibana
-              nullable: true
-              properties:
-                limits:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            tolerations:
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
-                properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    format: int64
-                    type: integer
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
-                type: object
-              type: array
-          required:
-          - managementState
-          type: object
-        status:
-          items:
-            description: KibanaStatus defines the observed state of Kibana
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.managementState
+      name: Management State
+      type: string
+    - jsonPath: .spec.replicas
+      name: Replicas
+      type: integer
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Kibana is the Schema for the kibanas API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired behavior of the Kibana
             properties:
-              clusterCondition:
-                additionalProperties:
-                  items:
-                    properties:
-                      lastTransitionTime:
-                        description: Last time the condition transitioned from one
-                          status to another.
-                        format: date-time
-                        type: string
-                      message:
-                        description: Human-readable message indicating details about
-                          last transition.
-                        type: string
-                      reason:
-                        description: Unique, one-word, CamelCase reason for the condition's
-                          last transition.
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        description: ClusterConditionType is a valid value for ClusterCondition.Type
-                        type: string
-                    required:
-                    - lastTransitionTime
-                    - status
-                    - type
-                    type: object
-                  type: array
-                type: object
-              deployment:
+              managementState:
+                description: Indicator if the resource is 'Managed' or 'Unmanaged'
+                  by the operator
+                enum:
+                - Managed
+                - Unmanaged
                 type: string
-              pods:
+              nodeSelector:
                 additionalProperties:
-                  items:
-                    type: string
-                  type: array
-                type: object
-              replicaSets:
-                items:
                   type: string
-                type: array
+                description: Define which Nodes the Pods are scheduled on.
+                type: object
+              proxy:
+                description: Specification of the Kibana Proxy component
+                properties:
+                  resources:
+                    description: The resource requirements for Kibana proxy
+                    nullable: true
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
               replicas:
+                description: Number of instances to deploy for a Kibana deployment
                 format: int32
                 type: integer
+              resources:
+                description: The resource requirements for Kibana
+                nullable: true
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              tolerations:
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            required:
+            - managementState
             type: object
-          type: array
-      type: object
-  version: v1
-  versions:
-  - name: v1
+          status:
+            items:
+              description: KibanaStatus defines the observed state of Kibana
+              properties:
+                clusterCondition:
+                  additionalProperties:
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          description: Last time the condition transitioned from one
+                            status to another.
+                          format: date-time
+                          type: string
+                        message:
+                          description: Human-readable message indicating details about
+                            last transition.
+                          type: string
+                        reason:
+                          description: Unique, one-word, CamelCase reason for the
+                            condition's last transition.
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          description: ClusterConditionType is a valid value for ClusterCondition.Type
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  type: object
+                deployment:
+                  type: string
+                pods:
+                  additionalProperties:
+                    items:
+                      type: string
+                    type: array
+                  type: object
+                replicaSets:
+                  items:
+                    type: string
+                  type: array
+                replicas:
+                  format: int32
+                  type: integer
+              type: object
+            type: array
+        type: object
     served: true
     storage: true
+    subresources: {}


### PR DESCRIPTION
### Description
This PR addresses a recommended upgrade of the `apiVersion` of cluster-logging-operator managed CRDs from `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1`. Former is deprecated in upcoming k8s release 1.19 and very likely removed in 1.20. In extent addressing this upgrade sooner than later frees the operator upgrade procedure from limbo to enable installation of version `N` on an OCP cluster version `N-1`, where the cluster version has dropped the deprecated versions.

**Depends on:** #442

### Notes for the reviewer

This PR needs to get rebased after #442 is merged. Please consider only the last **two** commits!

/cc @ewolinetz @blockloop 