### PR TITLE
Bug 1856502: Fixing rollout of nodes when proxy resources are updated

### DIFF
--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -221,7 +221,8 @@ func (node *deploymentNode) checkPodSpecMatches(labels map[string]string) bool {
 	matches := false
 
 	for _, pod := range podList.Items {
-		if !ArePodSpecDifferent(node.self.Spec.Template.Spec, pod.Spec, false) {
+		// follow pattern used in other places of "current, desired"
+		if !ArePodSpecDifferent(pod.Spec, node.self.Spec.Template.Spec, false) {
 			matches = true
 		}
 	}
@@ -273,24 +274,30 @@ func (node *deploymentNode) setPaused(paused bool) error {
 }
 
 func (node *deploymentNode) setReplicaCount(replicas int32) error {
+
+	nodeCopy := &apps.Deployment{}
+
 	nretries := -1
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		nretries++
-		if getErr := node.client.Get(context.TODO(), types.NamespacedName{Name: node.self.Name, Namespace: node.self.Namespace}, &node.self); getErr != nil {
+		if getErr := node.client.Get(context.TODO(), types.NamespacedName{Name: node.self.Name, Namespace: node.self.Namespace}, nodeCopy); getErr != nil {
 			logrus.Debugf("Could not get Elasticsearch node resource %v: %v", node.self.Name, getErr)
 			return getErr
 		}
 
-		if *node.self.Spec.Replicas == replicas {
+		if *nodeCopy.Spec.Replicas == replicas {
 			return nil
+		}
+
+		nodeCopy.Spec.Replicas = &replicas
+
+		if updateErr := node.client.Update(context.TODO(), nodeCopy); updateErr != nil {
+			logrus.Debugf("Failed to update node resource %v: %v", node.self.Name, updateErr)
+			return updateErr
 		}
 
 		node.self.Spec.Replicas = &replicas
 
-		if updateErr := node.client.Update(context.TODO(), &node.self); updateErr != nil {
-			logrus.Debugf("Failed to update node resource %v: %v", node.self.Name, updateErr)
-			return updateErr
-		}
 		return nil
 	})
 	if retryErr != nil {

--- a/pkg/k8shandler/podtemplate.go
+++ b/pkg/k8shandler/podtemplate.go
@@ -52,33 +52,35 @@ func ArePodSpecDifferent(lhs, rhs v1.PodSpec, strictTolerations bool) bool {
 		found := false
 
 		for _, rContainer := range rhs.Containers {
-			// Only compare the images of containers with the same name
-			if lContainer.Name == rContainer.Name {
-				found = true
+			// Only compare containers with the same name
+			if lContainer.Name != rContainer.Name {
+				continue
+			}
 
-				if lContainer.Image != rContainer.Image {
-					//logrus.Debugf("Resource '%s' has different container image than desired", node.self.Name)
-					changed = true
-				}
+			found = true
 
-				if !comparators.EnvValueEqual(lContainer.Env, rContainer.Env) {
-					//logger.Debugf("Setting Container %q EnvVars to desired: %v", nodeContainer.Name, nodeContainer.Env)
-					changed = true
-				}
+			if lContainer.Image != rContainer.Image {
+				//logrus.Debugf("Resource '%s' has different container image than desired", node.self.Name)
+				changed = true
+			}
 
-				if !reflect.DeepEqual(lContainer.Args, rContainer.Args) {
-					//logger.Debugf("Container Args are different between current and desired for %s", nodeContainer.Name)
-					changed = true
-				}
+			if !comparators.EnvValueEqual(lContainer.Env, rContainer.Env) {
+				//logger.Debugf("Setting Container %q EnvVars to desired: %v", nodeContainer.Name, nodeContainer.Env)
+				changed = true
+			}
 
-				if !reflect.DeepEqual(lContainer.Ports, rContainer.Ports) {
-					//logger.Debugf("Container Ports are different between current and desired for %s", nodeContainer.Name)
-					changed = true
-				}
+			if !reflect.DeepEqual(lContainer.Args, rContainer.Args) {
+				//logger.Debugf("Container Args are different between current and desired for %s", nodeContainer.Name)
+				changed = true
+			}
 
-				if different, _ := utils.CompareResources(lContainer.Resources, rContainer.Resources); different {
-					changed = true
-				}
+			if !reflect.DeepEqual(lContainer.Ports, rContainer.Ports) {
+				//logger.Debugf("Container Ports are different between current and desired for %s", nodeContainer.Name)
+				changed = true
+			}
+
+			if different, _ := utils.CompareResources(lContainer.Resources, rContainer.Resources); different {
+				changed = true
 			}
 		}
 

--- a/pkg/k8shandler/podtemplate_test.go
+++ b/pkg/k8shandler/podtemplate_test.go
@@ -375,4 +375,118 @@ var _ = Describe("podtemplate", func() {
 			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeTrue())
 		})
 	})
+
+	Context("proxy memory request resource change", func() {
+		JustBeforeEach(func() {
+
+			proxyContainer := v1.Container{
+				Name: "testProxyContainer",
+				Resources: v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+						v1.ResourceCPU:    resource.MustParse("600m"),
+					},
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+						v1.ResourceCPU:    resource.MustParse("600m"),
+					},
+				},
+				Image: expectedImageName,
+			}
+
+			lhs = v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						nodeContainer,
+						proxyContainer,
+					},
+				},
+			}
+
+			proxyContainer2 := v1.Container{
+				Name: "testProxyContainer",
+				Resources: v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+						v1.ResourceCPU:    resource.MustParse("600m"),
+					},
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("2Gi"),
+						v1.ResourceCPU:    resource.MustParse("600m"),
+					},
+				},
+				Image: expectedImageName,
+			}
+
+			rhs = v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						nodeContainer,
+						proxyContainer2,
+					},
+				},
+			}
+		})
+
+		It("should recognize a request memory change", func() {
+			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeTrue())
+		})
+	})
+
+	Context("proxy memory limit resource change", func() {
+		JustBeforeEach(func() {
+
+			proxyContainer := v1.Container{
+				Name: "testProxyContainer",
+				Resources: v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+						v1.ResourceCPU:    resource.MustParse("600m"),
+					},
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+						v1.ResourceCPU:    resource.MustParse("600m"),
+					},
+				},
+				Image: expectedImageName,
+			}
+
+			lhs = v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						nodeContainer,
+						proxyContainer,
+					},
+				},
+			}
+
+			proxyContainer2 := v1.Container{
+				Name: "testProxyContainer",
+				Resources: v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("2Gi"),
+						v1.ResourceCPU:    resource.MustParse("600m"),
+					},
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+						v1.ResourceCPU:    resource.MustParse("600m"),
+					},
+				},
+				Image: expectedImageName,
+			}
+
+			rhs = v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						nodeContainer,
+						proxyContainer2,
+					},
+				},
+			}
+		})
+
+		It("should recognize a limit memory change", func() {
+			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeTrue())
+		})
+	})
 })

--- a/pkg/k8shandler/util.go
+++ b/pkg/k8shandler/util.go
@@ -106,11 +106,12 @@ func areTolerationsSame(lhs, rhs []v1.Toleration) bool {
 	return containsSameTolerations(lhs, rhs)
 }
 
-// containsSameTolerations checks that the tolerations in lhs are all contained within rhs
+// containsSameTolerations checks that the tolerations in rhs are all contained within lhs
+// this follows our other patterns of "current, desired"
 func containsSameTolerations(lhs, rhs []v1.Toleration) bool {
 
-	for _, lhsToleration := range lhs {
-		if !containsToleration(lhsToleration, rhs) {
+	for _, rhsToleration := range rhs {
+		if !containsToleration(rhsToleration, lhs) {
 			return false
 		}
 	}

--- a/pkg/utils/resources.go
+++ b/pkg/utils/resources.go
@@ -13,28 +13,29 @@ import (
 func CompareResources(current, desired v1.ResourceRequirements) (bool, v1.ResourceRequirements) {
 
 	changed := false
+	desiredResources := *current.DeepCopy()
 
 	if desired.Limits.Cpu().Cmp(*current.Limits.Cpu()) != 0 {
-		current.Limits[v1.ResourceCPU] = *desired.Limits.Cpu()
+		desiredResources.Limits[v1.ResourceCPU] = *desired.Limits.Cpu()
 		changed = true
 	}
 	// Check memory limits
 	if desired.Limits.Memory().Cmp(*current.Limits.Memory()) != 0 {
-		current.Limits[v1.ResourceMemory] = *desired.Limits.Memory()
+		desiredResources.Limits[v1.ResourceMemory] = *desired.Limits.Memory()
 		changed = true
 	}
 	// Check CPU requests
 	if desired.Requests.Cpu().Cmp(*current.Requests.Cpu()) != 0 {
-		current.Requests[v1.ResourceCPU] = *desired.Requests.Cpu()
+		desiredResources.Requests[v1.ResourceCPU] = *desired.Requests.Cpu()
 		changed = true
 	}
 	// Check memory requests
 	if desired.Requests.Memory().Cmp(*current.Requests.Memory()) != 0 {
-		current.Requests[v1.ResourceMemory] = *desired.Requests.Memory()
+		desiredResources.Requests[v1.ResourceMemory] = *desired.Requests.Memory()
 		changed = true
 	}
 
-	return changed, current
+	return changed, desiredResources
 }
 
 func AreResourcesDifferent(current, desired interface{}) bool {


### PR DESCRIPTION
To address: https://bugzilla.redhat.com/show_bug.cgi?id=1856502

While detecting if our proxy resources have been correctly applied and present in the running pod we would see the `desired` changes get lost and match the `current` values. So we would get a false positive that changes have been correctly rolled out.