### PR TITLE
Bug 1869117: fixing alerts formatting, add unit test to validate

### DIFF
--- a/files/prometheus_alerts.yml
+++ b/files/prometheus_alerts.yml
@@ -66,22 +66,22 @@
     "labels":
       "severity": warning
 
-      - "alert": "ElasticsearchNodeDiskWatermarkReached"
-      "annotations":
-        "message": "Disk Flood Stage Watermark Reached at {{ $labels.node }} node in {{ $labels.cluster }} cluster. Every index having a shard allocated on this node is enforced a read-only block. The index block is automatically released when the disk utilization falls below the high watermark."
-        "summary": "Disk Flood Stage Watermark Reached - disk saturation is {{ $value }}%"
-      "expr": |
-        sum by (cluster, instance, node) (
-          round(
-            (1 - (
-              es_fs_path_available_bytes /
-              es_fs_path_total_bytes
-            )
-          ) * 100, 0.001)
-        ) > es_cluster_routing_allocation_disk_watermark_flood_stage_pct
-      "for": "5m"
-      "labels":
-        "severity": critical
+  - "alert": "ElasticsearchNodeDiskWatermarkReached"
+    "annotations":
+      "message": "Disk Flood Stage Watermark Reached at {{ $labels.node }} node in {{ $labels.cluster }} cluster. Every index having a shard allocated on this node is enforced a read-only block. The index block is automatically released when the disk utilization falls below the high watermark."
+      "summary": "Disk Flood Stage Watermark Reached - disk saturation is {{ $value }}%"
+    "expr": |
+      sum by (cluster, instance, node) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+    "for": "5m"
+    "labels":
+      "severity": critical
 
   - "alert": "ElasticsearchJVMHeapUseHigh"
     "annotations":

--- a/pkg/k8shandler/prometheus_rule_test.go
+++ b/pkg/k8shandler/prometheus_rule_test.go
@@ -1,0 +1,33 @@
+package k8shandler
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	rulePath  = "../../files/prometheus_rules.yml"
+	alertPath = "../../files/prometheus_alerts.yml"
+)
+
+var _ = Describe("prometheusrules", func() {
+	defer GinkgoRecover()
+
+	Context("rules", func() {
+		It("should build without errors", func() {
+
+			_, err := ruleSpec(rulePath)
+
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("alerts", func() {
+		It("should build without errors", func() {
+
+			_, err := ruleSpec(alertPath)
+
+			Expect(err).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1869117

Alerts file was incorrectly formatted which caused failures when trying to parse the yaml file.
Added unit tests to catch this in the future.

Nice to have (currently investigating if possible with our unit tests) would be to also validate the PromQL

/cc @blockloop 