### PR TITLE
require less resources for e2e testing

### DIFF
--- a/test/e2e-olm/elasticsearch_test.go
+++ b/test/e2e-olm/elasticsearch_test.go
@@ -404,12 +404,13 @@ func rollingRestartTest(t *testing.T) {
 	// Update the resource spec for the cluster
 	oldMemValue := cr.Spec.Spec.Resources.Limits.Memory()
 
-	memValue := resource.MustParse("1536Mi")
-	cpuValue := resource.MustParse("200m")
+	memValue := cr.Spec.Spec.Resources.Requests.Memory().DeepCopy()
+	memValue.Add(resource.MustParse("1Mi"))
+	cpuValue := cr.Spec.Spec.Resources.Requests.Cpu().DeepCopy()
+	cpuValue.Add(resource.MustParse("1m"))
+
 	desiredResources := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: memValue,
-		},
+		Limits: cr.Spec.Spec.Resources.Limits,
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    cpuValue,
 			corev1.ResourceMemory: memValue,

--- a/test/e2e-olm/utils.go
+++ b/test/e2e-olm/utils.go
@@ -64,7 +64,7 @@ func createElasticsearchCR(t *testing.T, f *test.Framework, ctx *test.Context, e
 	}
 
 	cpuValue := resource.MustParse("256m")
-	memValue := resource.MustParse("2Gi")
+	memValue := resource.MustParse("1Gi")
 
 	storageClassName := "gp2"
 	storageClassSize := resource.MustParse("2Gi")
@@ -102,7 +102,7 @@ func createElasticsearchCR(t *testing.T, f *test.Framework, ctx *test.Context, e
 				Image: "",
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						corev1.ResourceMemory: memValue,
+						corev1.ResourceMemory: resource.MustParse("5Gi"),
 					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    cpuValue,


### PR DESCRIPTION
I believe some of our CI tests are failing because of limited resources.
I believe we have our resource requests set too high for these tests.

/cc @ewolinetz 
/assign @ewolinetz 