### PR TITLE
make tests less verbose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ image:
 	fi
 
 test-unit:
-	@go test -v ./pkg/... ./cmd/...
+	@go test ./pkg/... ./cmd/...
 
 deploy: deploy-image
 	LOCAL_IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY=127.0.0.1:5000/openshift/elasticsearch-operator-registry \

--- a/hack/testing-olm/test-001-operator-sdk-e2e.sh
+++ b/hack/testing-olm/test-001-operator-sdk-e2e.sh
@@ -55,6 +55,5 @@ TEST_WATCH_NAMESPACE=${TEST_NAMESPACE} \
     -root=$(pwd) \
     -kubeconfig=${KUBECONFIG} \
     -globalMan test/files/dummycrd.yaml \
-    -v \
     -parallel=1 \
    -timeout 1500s


### PR DESCRIPTION
Removing the `-v` flag from `go test` prevents Go from printing any of the 
t.Log messages unless the test fails. 