### PR TITLE
Bug 1866019: Remove space from joining deleting indices call

### DIFF
--- a/pkg/indexmanagement/scripts.go
+++ b/pkg/indexmanagement/scripts.go
@@ -59,7 +59,7 @@ indices = [index for index in r if int(r[index]['settings']['index']['creation_d
 if "$writeIndex" in indices:
   indices.remove("$writeIndex")
 for i in range(0, len(indices), 25):
-  print(', '.join(indices[i:i+25]))
+  print(','.join(indices[i:i+25]))
 END
 )
 indices=$(echo "${indices}"  | python -c "$CMD")


### PR DESCRIPTION
This PR further updates https://bugzilla.redhat.com/show_bug.cgi?id=1868675 by removing the space when crafting the url for deleting indices