### PR TITLE
Bug 1867461: Remove cookie-refresh flag for kibana-proxy

### DIFF
--- a/pkg/k8shandler/kibana/reconciler.go
+++ b/pkg/k8shandler/kibana/reconciler.go
@@ -554,7 +554,6 @@ func newKibanaPodSpec(cluster *KibanaRequest, elasticsearchName string, proxyCon
 		fmt.Sprintf("-client-id=system:serviceaccount:%s:kibana", cluster.cluster.Namespace),
 		"-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token",
 		"-cookie-secret-file=/secret/session-secret",
-		"-cookie-refresh=10s",
 		"-cookie-expire=24h",
 		"-skip-provider-button",
 		"-upstream=http://localhost:5601",


### PR DESCRIPTION
This PR reverts partially #467 to remove the cookie refresh, because the oauth server does not support refresh tokens.

/cc @ewolinetz @blockloop 