### PR TITLE
Bug 1866019: Add more error checking to delete script

### DIFF
--- a/pkg/indexmanagement/scripts.go
+++ b/pkg/indexmanagement/scripts.go
@@ -18,7 +18,9 @@ cat /tmp/response.txt
 exit 1
 `
 const deleteScript = `
-set -euo pipefail
+set -uo pipefail
+ERRORS=/tmp/errors.txt
+echo "" > $ERRORS
 
 writeIndices=$(curl -s $ES_SERVICE/${POLICY_MAPPING}-*/_alias/${POLICY_MAPPING}-write \
   --cacert /etc/indexmanagement/keys/admin-ca \
@@ -35,12 +37,21 @@ from __future__ import print_function
 import json,sys
 r=json.load(sys.stdin)
 alias="${POLICY_MAPPING}-write"
-indices = [index for index in r if r[index]['aliases'][alias]['is_write_index']]
-if len(indices) > 0:
-  print(indices[0])
+try:
+  indices = [index for index in r if r[index]['aliases'][alias]['is_write_index']]
+  if len(indices) > 0:
+    print(indices[0])
+except:
+  e = sys.exc_info()[0]
+  sys.stderr.write("Error trying to determine the 'write' index from '%r': %r" % (r,e))
+  sys.exit(1)
 END
 )
-writeIndex=$(echo "${writeIndices}" | python -c "$CMD")
+writeIndex=$(echo "${writeIndices}" | python -c "$CMD" 2>>$ERRORS)
+if [ "$?" != "0" ] ; then
+  cat $ERRORS
+  exit 1
+fi
 
 
 indices=$(curl -s $ES_SERVICE/${POLICY_MAPPING}/_settings/index.creation_date \
@@ -55,14 +66,39 @@ CMD=$(cat <<END
 from __future__ import print_function
 import json,sys
 r=json.load(sys.stdin)
-indices = [index for index in r if int(r[index]['settings']['index']['creation_date']) < $minAgeFromEpoc ]
+indices = []
+for index in r:
+  try:
+    if 'settings' in r[index]:
+      settings = r[index]['settings']
+      if 'index' in settings:
+        meta = settings['index']
+        if 'creation_date' in meta:
+          creation_date = meta['creation_date']
+          if int(creation_date) < $minAgeFromEpoc:
+            indices.append(index)
+        else:
+          sys.stderr.write("'creation_date' missing from index settings: %r" % (meta))
+      else:
+        sys.stderr.write("'index' missing from setting: %r" % (settings))
+    else:
+      sys.stderr.write("'settings' missing for %r" % (index))
+  except:
+    e = sys.exc_info()[0]
+    sys.stderr.write("Error trying to evaluate index from '%r': %r" % (r,e))
 if "$writeIndex" in indices:
   indices.remove("$writeIndex")
 for i in range(0, len(indices), 25):
   print(','.join(indices[i:i+25]))
 END
 )
-indices=$(echo "${indices}"  | python -c "$CMD")
+indices=$(echo "${indices}"  | python -c "$CMD" 2>>$ERRORS)
+if [ "$?" != "0" ] ; then
+  cat $ERRORS
+  exit 1
+fi
+# Dump any findings to stdout but don't error
+cat $ERRORS
   
 if [ "${indices}" == "" ] ; then
     echo No indices to delete


### PR DESCRIPTION
This PR:
* Adds error checking to exit delete script if response is not a dict
* Walks the response tree checking for expected keys

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1866019