### PR TITLE
Bug 1875478: Rename console link section Monitoring to Observability

### DIFF
--- a/pkg/k8shandler/kibana/consolelink.go
+++ b/pkg/k8shandler/kibana/consolelink.go
@@ -17,7 +17,7 @@ func NewConsoleLink(name, href string) *consolev1.ConsoleLink {
 				Href: href,
 			},
 			ApplicationMenu: &consolev1.ApplicationMenuSpec{
-				Section: "Monitoring",
+				Section: "Observability",
 			},
 		},
 	}

--- a/pkg/k8shandler/kibana/kibana_test.go
+++ b/pkg/k8shandler/kibana/kibana_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Reconciling", func() {
 						Href: "https://",
 					},
 					ApplicationMenu: &consolev1.ApplicationMenuSpec{
-						Section: "Monitoring",
+						Section: "Observability",
 					},
 				},
 			}


### PR DESCRIPTION
This PR addresses a minor issue in placing the Logging inside the application launcher on a dedicated general purpose section named "Observability" instead of "Monitoring".

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1875478

/cc @ewolinetz @blockloop @sichvoge 