### PR TITLE
Bug 1876236: Drop unused tuned.openshift.io/elasticsearch annotation

### DIFF
--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -343,13 +343,12 @@ func newEnvVars(nodeName, clusterName, instanceRam string, roleMap map[api.Elast
 func newLabels(clusterName, nodeName string, roleMap map[api.ElasticsearchNodeRole]bool) map[string]string {
 
 	return map[string]string{
-		"es-node-client":                   strconv.FormatBool(roleMap[api.ElasticsearchRoleClient]),
-		"es-node-data":                     strconv.FormatBool(roleMap[api.ElasticsearchRoleData]),
-		"es-node-master":                   strconv.FormatBool(roleMap[api.ElasticsearchRoleMaster]),
-		"cluster-name":                     clusterName,
-		"component":                        "elasticsearch",
-		"tuned.openshift.io/elasticsearch": "true",
-		"node-name":                        nodeName,
+		"es-node-client": strconv.FormatBool(roleMap[api.ElasticsearchRoleClient]),
+		"es-node-data":   strconv.FormatBool(roleMap[api.ElasticsearchRoleData]),
+		"es-node-master": strconv.FormatBool(roleMap[api.ElasticsearchRoleMaster]),
+		"cluster-name":   clusterName,
+		"component":      "elasticsearch",
+		"node-name":      nodeName,
 	}
 }
 


### PR DESCRIPTION
### Description
This PR remove the obsolete annotation `tuned.openshift.io/elasticsearch` since release 4.4. The old tuning profile for setting `vm.max_map_count: 262144` is now already part of the defaults and thus obsolete.

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1876236

/cc @ewolinetz @blockloop 