### PR TITLE
Bug 1849564: Update kibana status for ready pods

### DIFF
--- a/manifests/4.6/logging.openshift.io_kibanas_crd.yaml
+++ b/manifests/4.6/logging.openshift.io_kibanas_crd.yaml
@@ -209,4 +209,5 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}

--- a/pkg/apis/logging/v1/kibana_types.go
+++ b/pkg/apis/logging/v1/kibana_types.go
@@ -62,6 +62,7 @@ type KibanaStatus struct {
 // Kibana is the Schema for the kibanas API
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=kibanas,categories=logging,scope=Namespaced
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Management State",JSONPath=".spec.managementState",type=string
 // +kubebuilder:printcolumn:name="Replicas",JSONPath=".spec.replicas",type=integer
 type Kibana struct {

--- a/pkg/k8shandler/kibana/reconciler.go
+++ b/pkg/k8shandler/kibana/reconciler.go
@@ -93,33 +93,7 @@ func Reconcile(requestCluster *kibana.Kibana, requestClient client.Client, esCli
 		return err
 	}
 
-	kibanaStatus, err := clusterKibanaRequest.getKibanaStatus()
-	cluster := clusterKibanaRequest.cluster
-
-	if err != nil {
-		return fmt.Errorf("Failed to get Kibana status for %q: %w", cluster.Name, err)
-	}
-
-	printUpdateMessage := true
-	retryErr := retry.RetryOnConflict(retry.DefaultRetry,
-		func() error {
-			if !compareKibanaStatus(kibanaStatus,
-				cluster.Status) {
-				if printUpdateMessage {
-					log.Info("Updating status of Kibana")
-					printUpdateMessage = false
-				}
-				cluster.Status = kibanaStatus
-				return clusterKibanaRequest.UpdateStatus(cluster)
-			}
-			return nil
-		})
-	if retryErr != nil {
-		return fmt.Errorf("Failed to update Kibana status for %q: %w", cluster.Name, retryErr)
-	}
-	log.Info("Kibana status successfully updated")
-
-	return nil
+	return clusterKibanaRequest.UpdateStatus()
 }
 
 func GetProxyConfig(r client.Client) (*configv1.Proxy, error) {


### PR DESCRIPTION
### Description
This PR addresses two issues with updating the kibana status:
1. Usage of the kibana status subresource in go code while missing activation in the CRD.
2. Reconciling the status field along the pod lifecycle and not once during creation time.

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1849564

/cc @ewolinetz @blockloop 