### PR TITLE
Bug 1878032: Update cluster status after populating nodes

### DIFF
--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -54,6 +54,13 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateElasticsearchClu
 	if success, err := esClient.ClearTransientShardAllocation(); !success {
 		logrus.Warnf("Unable to clear transient shard allocation for %q %q: %v", elasticsearchRequest.cluster.Namespace, elasticsearchRequest.cluster.Namespace, err)
 	}
+
+	// Update the cluster status immediately to refresh status.nodes
+	// before progressing with any unschedulable nodes.
+	// Ensures that deleted nodes
+	if err := elasticsearchRequest.UpdateClusterStatus(); err != nil {
+		return err
+	}
 	progressUnshedulableNodes(elasticsearchRequest.cluster)
 	err = elasticsearchRequest.performCertClusterRestart()
 	if err != nil {


### PR DESCRIPTION
### Description
This PR addresses a manual backport of #481 for `release-4.5` because of [merge conflicts](https://github.com/openshift/elasticsearch-operator/pull/481#issuecomment-690743106).

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1878032

/cc @ewolinetz @lukas-vlcek 