### PR TITLE
Bug 1880926: Stop rescheduling non-existing nodes

### DIFF
--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -332,9 +332,11 @@ func (node *deploymentNode) waitForNodeLeaveCluster() (error, bool) {
 }
 
 func (node *deploymentNode) isMissing() bool {
-	getNode := &apps.Deployment{}
-	if getErr := node.client.Get(context.TODO(), types.NamespacedName{Name: node.name(), Namespace: node.self.Namespace}, getNode); getErr != nil {
-		if errors.IsNotFound(getErr) {
+	obj := &apps.Deployment{}
+	key := types.NamespacedName{Name: node.name(), Namespace: node.self.Namespace}
+
+	if err := node.client.Get(context.TODO(), key, obj); err != nil {
+		if errors.IsNotFound(err) {
 			return true
 		}
 	}

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -263,9 +263,11 @@ func (n *statefulSetNode) replicaCount() (int32, error) {
 }
 
 func (n *statefulSetNode) isMissing() bool {
-	getNode := &apps.StatefulSet{}
-	if getErr := n.client.Get(context.TODO(), types.NamespacedName{Name: n.name(), Namespace: n.self.Namespace}, getNode); getErr != nil {
-		if errors.IsNotFound(getErr) {
+	obj := &apps.StatefulSet{}
+	key := types.NamespacedName{Name: n.name(), Namespace: n.self.Namespace}
+
+	if err := n.client.Get(context.TODO(), key, obj); err != nil {
+		if errors.IsNotFound(err) {
 			return true
 		}
 	}

--- a/pkg/k8shandler/status.go
+++ b/pkg/k8shandler/status.go
@@ -61,7 +61,9 @@ func (er *ElasticsearchRequest) UpdateClusterStatus() error {
 
 	clusterStatus.Pods = rolePodStateMap(cluster.Namespace, cluster.Name, er.client)
 	updateStatusConditions(clusterStatus)
-	er.updateNodeConditions(clusterStatus)
+	if err := er.updateNodeConditions(clusterStatus); err != nil {
+		return err
+	}
 
 	if !reflect.DeepEqual(clusterStatus, cluster.Status) {
 		nretries := -1
@@ -240,9 +242,10 @@ func isPodReady(pod v1.Pod) bool {
 	return true
 }
 
-func (er *ElasticsearchRequest) updateNodeConditions(status *api.ElasticsearchStatus) {
+func (er *ElasticsearchRequest) updateNodeConditions(status *api.ElasticsearchStatus) error {
 	esClient := er.esClient
 	cluster := er.cluster
+
 	// Get all pods based on status.Nodes[] and check their conditions
 	// get pod with label 'node-name=node.getName()'
 	thresholdEnabled := false
@@ -261,147 +264,183 @@ func (er *ElasticsearchRequest) updateNodeConditions(status *api.ElasticsearchSt
 	}
 
 	ll := er.L()
-	for nodeIndex := range status.Nodes {
-		node := &status.Nodes[nodeIndex]
-		ll = ll.WithValues("node", node)
+	for nodeIndex, nodeStatus := range status.Nodes {
+		nodeStatus := &nodeStatus
 
+		ll = ll.WithValues("node", nodeStatus)
 		nodeName := "unknown name"
-		if node.DeploymentName != "" {
-			nodeName = node.DeploymentName
+		if nodeStatus.DeploymentName != "" {
+			nodeName = nodeStatus.DeploymentName
 		} else {
-			if node.StatefulSetName != "" {
-				nodeName = node.StatefulSetName
+			if nodeStatus.StatefulSetName != "" {
+				nodeName = nodeStatus.StatefulSetName
 			}
 		}
 
-		nodePodList, _ := GetPodList(
-			cluster.Namespace,
-			map[string]string{
-				"component":    "elasticsearch",
-				"cluster-name": cluster.Name,
-				"node-name":    nodeName,
-			},
-			er.client,
-		)
-		for _, nodePod := range nodePodList.Items {
+		matchingLabels := map[string]string{
+			"component":    "elasticsearch",
+			"cluster-name": cluster.GetName(),
+			"node-name":    nodeName,
+		}
 
-			isUnschedulable := false
-			for _, podCondition := range nodePod.Status.Conditions {
-				if podCondition.Type == v1.PodScheduled && podCondition.Status == v1.ConditionFalse {
-					podCondition.Type = v1.PodReasonUnschedulable
-					podCondition.Status = v1.ConditionTrue
-					updatePodUnschedulableCondition(node, podCondition)
-					isUnschedulable = true
-				}
-			}
+		nodePodList, err := GetPodList(cluster.GetNamespace(), matchingLabels, er.client)
+		if err != nil {
+			return err
+		}
 
-			if isUnschedulable {
-				continue
-			}
-			updatePodUnschedulableCondition(node, v1.PodCondition{
-				Status: v1.ConditionFalse,
-			})
+		er.pruneStatus(status, nodeIndex, nodeName, nodePodList.Items)
+		er.updatePodNodeConditions(nodeName, nodeStatus, nodePodList.Items, thresholdEnabled)
+	}
 
-			// if the pod can't be scheduled we shouldn't enter here
-			for _, containerStatus := range nodePod.Status.ContainerStatuses {
-				if containerStatus.Name == "elasticsearch" {
-					if containerStatus.State.Waiting != nil {
-						updatePodNotReadyCondition(
-							node,
-							api.ESContainerWaiting,
-							containerStatus.State.Waiting.Reason,
-							containerStatus.State.Waiting.Message,
-						)
-					} else {
-						updatePodNotReadyCondition(
-							node,
-							api.ESContainerWaiting,
-							"",
-							"",
-						)
-					}
-					if containerStatus.State.Terminated != nil {
-						updatePodNotReadyCondition(
-							node,
-							api.ESContainerTerminated,
-							containerStatus.State.Terminated.Reason,
-							containerStatus.State.Terminated.Message,
-						)
-					} else {
-						updatePodNotReadyCondition(
-							node,
-							api.ESContainerTerminated,
-							"",
-							"",
-						)
-					}
-				}
-				if containerStatus.Name == "proxy" {
-					if containerStatus.State.Waiting != nil {
-						updatePodNotReadyCondition(
-							node,
-							api.ProxyContainerWaiting,
-							containerStatus.State.Waiting.Reason,
-							containerStatus.State.Waiting.Message,
-						)
-					} else {
-						updatePodNotReadyCondition(
-							node,
-							api.ProxyContainerWaiting,
-							"",
-							"",
-						)
-					}
-					if containerStatus.State.Terminated != nil {
-						updatePodNotReadyCondition(
-							node,
-							api.ProxyContainerTerminated,
-							containerStatus.State.Terminated.Reason,
-							containerStatus.State.Terminated.Message,
-						)
-					} else {
-						updatePodNotReadyCondition(
-							node,
-							api.ProxyContainerTerminated,
-							"",
-							"",
-						)
+	return nil
+}
+
+func (er *ElasticsearchRequest) pruneStatus(status *api.ElasticsearchStatus, nodeIndex int, nodeName string, pods []v1.Pod) {
+	clusterNodes := nodes[nodeMapKey(er.cluster.GetName(), er.cluster.GetNamespace())]
+	nodeStatus := status.Nodes[nodeIndex]
+	ll := er.L().WithValues("node", nodeStatus)
+
+	for _, node := range clusterNodes {
+		if nodeName == node.name() && node.isMissing() {
+			ll.Info("Pruning node status")
+			// Prune node status list for non existing nodes
+			status.Nodes = append(status.Nodes[:nodeIndex], status.Nodes[nodeIndex+1:]...)
+
+			if len(pods) == 0 {
+				for nodeRole, podStateMap := range status.Pods {
+					for podState, podNames := range podStateMap {
+						for idx, podName := range podNames {
+							if strings.HasPrefix(podName, nodeName) {
+								// Prune pod state maps for non existing pods
+								status.Pods[nodeRole][podState] = append(podNames[:idx], podNames[idx+1:]...)
+							}
+						}
 					}
 				}
 			}
+		}
+	}
+}
 
-			if !thresholdEnabled {
-				// disk threshold is not enabled, continue to next node
-				continue
+func (er *ElasticsearchRequest) updatePodNodeConditions(nodeName string, nodeStatus *api.ElasticsearchNodeStatus, pods []v1.Pod, thresholdEnabled bool) {
+	ll := er.L().WithValues("node", nodeStatus)
+
+	for _, nodePod := range pods {
+		isUnschedulable := false
+		for _, podCondition := range nodePod.Status.Conditions {
+			if podCondition.Type == v1.PodScheduled && podCondition.Status == v1.ConditionFalse {
+				podCondition.Type = v1.PodReasonUnschedulable
+				podCondition.Status = v1.ConditionTrue
+				updatePodUnschedulableCondition(nodeStatus, podCondition)
+				isUnschedulable = true
 			}
+		}
 
-			usage, percent, err := esClient.GetNodeDiskUsage(nodeName)
-			if err != nil {
-				ll.Info("Unable to get disk usage", "error", err)
-				continue
-			}
+		if isUnschedulable {
+			continue
+		}
+		updatePodUnschedulableCondition(nodeStatus, v1.PodCondition{
+			Status: v1.ConditionFalse,
+		})
 
-			if exceedsLowWatermark(usage, percent) {
-				if exceedsHighWatermark(usage, percent) {
-					updatePodNodeStorageCondition(
-						node,
-						"Disk Watermark High",
-						fmt.Sprintf("Disk storage usage for node is %vb (%v%%). Shards will be relocated from this node.", usage, percent),
+		// if the pod can't be scheduled we shouldn't enter here
+		for _, containerStatus := range nodePod.Status.ContainerStatuses {
+			if containerStatus.Name == "elasticsearch" {
+				if containerStatus.State.Waiting != nil {
+					updatePodNotReadyCondition(
+						nodeStatus,
+						api.ESContainerWaiting,
+						containerStatus.State.Waiting.Reason,
+						containerStatus.State.Waiting.Message,
 					)
 				} else {
-					updatePodNodeStorageCondition(
-						node,
-						"Disk Watermark Low",
-						fmt.Sprintf("Disk storage usage for node is %vb (%v%%). Shards will be not be allocated on this node.", usage, percent),
+					updatePodNotReadyCondition(
+						nodeStatus,
+						api.ESContainerWaiting,
+						"",
+						"",
 					)
 				}
-			} else {
-				if percent > float64(0.0) {
-					// if we were able to pull the usage but it isn't above the thresholds -- clear the status message
-					updatePodNodeStorageCondition(node, "", "")
+				if containerStatus.State.Terminated != nil {
+					updatePodNotReadyCondition(
+						nodeStatus,
+						api.ESContainerTerminated,
+						containerStatus.State.Terminated.Reason,
+						containerStatus.State.Terminated.Message,
+					)
+				} else {
+					updatePodNotReadyCondition(
+						nodeStatus,
+						api.ESContainerTerminated,
+						"",
+						"",
+					)
 				}
 			}
+			if containerStatus.Name == "proxy" {
+				if containerStatus.State.Waiting != nil {
+					updatePodNotReadyCondition(
+						nodeStatus,
+						api.ProxyContainerWaiting,
+						containerStatus.State.Waiting.Reason,
+						containerStatus.State.Waiting.Message,
+					)
+				} else {
+					updatePodNotReadyCondition(
+						nodeStatus,
+						api.ProxyContainerWaiting,
+						"",
+						"",
+					)
+				}
+				if containerStatus.State.Terminated != nil {
+					updatePodNotReadyCondition(
+						nodeStatus,
+						api.ProxyContainerTerminated,
+						containerStatus.State.Terminated.Reason,
+						containerStatus.State.Terminated.Message,
+					)
+				} else {
+					updatePodNotReadyCondition(
+						nodeStatus,
+						api.ProxyContainerTerminated,
+						"",
+						"",
+					)
+				}
+			}
+		}
 
+		if !thresholdEnabled {
+			// disk threshold is not enabled, continue to next node
+			continue
+		}
+
+		usage, percent, err := er.esClient.GetNodeDiskUsage(nodeName)
+		if err != nil {
+			ll.Info("Unable to get disk usage", "error", err)
+			continue
+		}
+
+		if exceedsLowWatermark(usage, percent) {
+			if exceedsHighWatermark(usage, percent) {
+				updatePodNodeStorageCondition(
+					nodeStatus,
+					"Disk Watermark High",
+					fmt.Sprintf("Disk storage usage for node is %vb (%v%%). Shards will be relocated from this node.", usage, percent),
+				)
+			} else {
+				updatePodNodeStorageCondition(
+					nodeStatus,
+					"Disk Watermark Low",
+					fmt.Sprintf("Disk storage usage for node is %vb (%v%%). Shards will be not be allocated on this node.", usage, percent),
+				)
+			}
+		} else {
+			if percent > float64(0.0) {
+				// if we were able to pull the usage but it isn't above the thresholds -- clear the status message
+				updatePodNodeStorageCondition(nodeStatus, "", "")
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description
This PR is addressing the case where deployments/statefulsets for Elasticsearch nodes are not existing although the last recorded status registered them as unschedulable. This event may happen during cluster upgrades where OCP cluster nodes become unavailable and in turn ES cluster nodes unschedulable for a period of time. During a cluster upgrade deployments/statefulset may get deleted and recreated because their owner references get deleted and recreated.

In more detail the implementation takes into account that deployments/statefulsets may not exist anymore and stops addressing them as unschedulable and re-creates anew. The rationale to re-create the nodes immediately in `progressUnschedulableNodes` is to bypass the need to actively change the node status from `Unschedulable` to something like `ScheduledForRedeploy` to get re-creates. This sounds like a code smell misusing the redeploy routines.

/cc @blockloop @ewolinetz 
/assign @ewolinetz 
/cherry-pick release-4.5
 
#### Links
- Bugzilla:  https://bugzilla.redhat.com/show_bug.cgi?id=1880926
