### PR TITLE
[release-4.5] Bug 1881957: updating EO to adopt an existing cluster if cr nodes uuid is nil

### DIFF
--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -603,7 +603,7 @@ func newVolumeSource(clusterName, nodeName, namespace string, node api.Elasticse
 			StorageClassName: specVol.StorageClassName,
 		}
 
-		err := createOrUpdatePersistentVolumeClaim(volSpec, claimName, namespace, client)
+		err := createOrUpdatePersistentVolumeClaim(volSpec, claimName, namespace, clusterName, client)
 		if err != nil {
 			logrus.Errorf("Unable to create PersistentVolumeClaim: %v", err)
 		}

--- a/pkg/k8shandler/migrations/kibana5to6.go
+++ b/pkg/k8shandler/migrations/kibana5to6.go
@@ -25,7 +25,6 @@ func (mr *migrationRequest) reIndexKibana5to6() error {
 	}
 
 	if mr.migrationCompleted() {
-		logrus.Infof("migration completed: re-indexing %q to %q", kibanaIndex, kibana6Index)
 		return nil
 	}
 

--- a/pkg/k8shandler/persistentvolumeclaims.go
+++ b/pkg/k8shandler/persistentvolumeclaims.go
@@ -3,48 +3,91 @@ package k8shandler
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func createOrUpdatePersistentVolumeClaim(pvc v1.PersistentVolumeClaimSpec, newName, namespace string, client client.Client) error {
+func createOrUpdatePersistentVolumeClaim(pvc v1.PersistentVolumeClaimSpec, newName, namespace, clusterName string, client client.Client) error {
 
 	// for some reason if the PVC already exists but creating it again would violate
 	// quota we get an error regarding quota not that it already exists
 	// so check to see if it already exists
-	claim := &v1.PersistentVolumeClaim{}
+	claim := createPersistentVolumeClaim(newName, namespace, clusterName, pvc)
 
-	if getErr := client.Get(context.TODO(), types.NamespacedName{Name: newName, Namespace: namespace}, claim); getErr != nil {
-		if errors.IsNotFound(getErr) {
-			claim = createPersistentVolumeClaim(newName, namespace, pvc)
-			err := client.Create(context.TODO(), claim)
-			if err != nil {
-				if !errors.IsAlreadyExists(err) {
-					return fmt.Errorf("Unable to create PVC: %v", err)
-				}
+	current := &v1.PersistentVolumeClaim{}
+	err := client.Get(context.TODO(), types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}, current)
+	if err == nil {
+		return updatePersistentVolumeClaim(claim, client)
+	}
+
+	if !errors.IsNotFound(err) {
+		logrus.Errorf("Could not get PVC %q: %v", newName, err)
+		return err
+	}
+
+	err = client.Create(context.TODO(), claim)
+	if err == nil {
+		return nil
+	}
+
+	if !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("unable to create PVC: %w", err)
+	}
+
+	return updatePersistentVolumeClaim(claim, client)
+}
+
+func updatePersistentVolumeClaim(claim *v1.PersistentVolumeClaim, client client.Client) error {
+
+	current := &v1.PersistentVolumeClaim{}
+
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := client.Get(context.TODO(), types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}, current); err != nil {
+			if errors.IsNotFound(err) {
+				// the object doesn't exist -- it was likely culled
+				// recreate it on the next time through if necessary
+				return nil
 			}
-		} else {
-			logrus.Debugf("Could not get PVC %v: %v", newName, getErr)
-			return getErr
+			return fmt.Errorf("Failed to get %v PVC: %v", claim.Name, err)
 		}
+
+		if !reflect.DeepEqual(current.ObjectMeta.Labels, claim.ObjectMeta.Labels) {
+			current.ObjectMeta.Labels = claim.ObjectMeta.Labels
+
+			if err := client.Update(context.TODO(), current); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if retryErr != nil {
+		return retryErr
 	}
 
 	return nil
 }
 
-func createPersistentVolumeClaim(pvcName, namespace string, volSpec v1.PersistentVolumeClaimSpec) *v1.PersistentVolumeClaim {
-	pvc := persistentVolumeClaim(pvcName, namespace)
+func createPersistentVolumeClaim(pvcName, namespace, clusterName string, volSpec v1.PersistentVolumeClaimSpec) *v1.PersistentVolumeClaim {
+	pvc := persistentVolumeClaim(pvcName, namespace, clusterName)
 	pvc.Spec = volSpec
 	return pvc
 }
 
-func persistentVolumeClaim(pvcName, namespace string) *v1.PersistentVolumeClaim {
+func persistentVolumeClaim(pvcName, namespace, clusterName string) *v1.PersistentVolumeClaim {
+
+	pvcLabels := map[string]string{
+		"logging-cluster": clusterName,
+	}
+
 	return &v1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PersistentVolumeClaim",
@@ -53,6 +96,7 @@ func persistentVolumeClaim(pvcName, namespace string) *v1.PersistentVolumeClaim 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pvcName,
 			Namespace: namespace,
+			Labels:    pvcLabels,
 		},
 	}
 }

--- a/pkg/k8shandler/recovery.go
+++ b/pkg/k8shandler/recovery.go
@@ -1,0 +1,345 @@
+package k8shandler
+
+import (
+	"strings"
+
+	"github.com/openshift/elasticsearch-operator/pkg/utils"
+	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	loggingv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+)
+
+// recoverOrphanedCluster is used to look for an existing cluster
+// that matches the ElasticsearchRequest name but the UUID may be different
+// NOTE: we only try to recover if our nodes do not have a UUID defined
+func (er *ElasticsearchRequest) recoverOrphanedCluster() error {
+
+	nodesToMatch := make(map[int]loggingv1.ElasticsearchNode)
+	for nodeIndex, node := range er.cluster.Spec.Nodes {
+		if node.GenUUID == nil {
+			// keep track of the index it was at so we can correctly update it later
+			nodesToMatch[nodeIndex] = node
+		}
+	}
+
+	if len(nodesToMatch) > 0 {
+		// first get a list of known UUIDs
+		knownUUIDs := []string{}
+		for _, node := range er.cluster.Spec.Nodes {
+			if node.GenUUID != nil {
+				knownUUIDs = append(knownUUIDs, *node.GenUUID)
+			}
+		}
+
+		// collect uuid counts
+		selector := map[string]string{}
+		pvcList, err := GetPVCList(er.cluster.Namespace, selector, er.client)
+		if err != nil {
+			logrus.Errorf("Unable to retrieve PVC list while recovering cluster %q in namespace %q: %v", er.cluster.Name, er.cluster.Namespace, err)
+			return err
+		}
+
+		if len(pvcList.Items) > 0 {
+			return er.recoverFromPVCs(knownUUIDs, nodesToMatch)
+		} else {
+			return er.recoverFromDeployments(knownUUIDs, nodesToMatch)
+		}
+	}
+
+	return nil
+}
+
+func (er *ElasticsearchRequest) deploymentSpecMatchNode(node loggingv1.ElasticsearchNode, deployment appsv1.DeploymentSpec, count int32) bool {
+
+	// we know roles will match, first check node count
+	if node.NodeCount != count {
+		return false
+	}
+
+	return er.podSpecMatchNode(node, deployment.Template.Spec)
+}
+
+func (er *ElasticsearchRequest) statefulSetSpecMatchNode(node loggingv1.ElasticsearchNode, statefulset appsv1.StatefulSetSpec) bool {
+
+	// we know roles will match, first check node count
+	if node.NodeCount != *statefulset.Replicas {
+		return false
+	}
+
+	return er.podSpecMatchNode(node, statefulset.Template.Spec)
+}
+
+func (er *ElasticsearchRequest) podSpecMatchNode(node loggingv1.ElasticsearchNode, podSpec corev1.PodSpec) bool {
+
+	selectors := mergeSelectors(node.NodeSelector, er.cluster.Spec.Spec.NodeSelector)
+	selectors = utils.EnsureLinuxNodeSelector(selectors)
+
+	if !areSelectorsSame(selectors, podSpec.NodeSelector) {
+		return false
+	}
+
+	tolerations := appendTolerations(node.Tolerations, er.cluster.Spec.Spec.Tolerations)
+
+	if !containsSameTolerations(podSpec.Tolerations, tolerations) {
+		return false
+	}
+
+	nodeResources := newResourceRequirements(node.Resources, er.cluster.Spec.Spec.Resources)
+
+	var deploymentNodeResources corev1.ResourceRequirements
+
+	for _, container := range podSpec.Containers {
+		if container.Name == "elasticsearch" {
+			deploymentNodeResources = container.Resources
+		}
+	}
+
+	// make sure resources are same
+	if different, _ := utils.CompareResources(nodeResources, deploymentNodeResources); different {
+		return false
+	}
+
+	return true
+}
+
+func parseNodeName(name string) (clusterName, roles, uuid string) {
+
+	splitName := strings.Split(name, "-")
+
+	// deployment/statefulset names
+	if len(splitName) == 4 {
+		clusterName = splitName[0]
+		roles = splitName[1]
+		uuid = splitName[2]
+
+		return
+	}
+
+	// the case of the old PVC name
+	if len(splitName) == 5 {
+		clusterName = splitName[1]
+		roles = splitName[2]
+		uuid = splitName[3]
+
+		return
+	}
+
+	return
+}
+
+func (er *ElasticsearchRequest) recoverFromDeployments(knownUUIDs []string, nodesToMatch map[int]loggingv1.ElasticsearchNode) error {
+
+	uuidCounts := make(map[string]int32)
+	if len(nodesToMatch) > 0 {
+		// collect uuid counts
+		selector := map[string]string{
+			"cluster-name": er.cluster.Name,
+		}
+
+		deploymentList, err := GetDeploymentList(er.cluster.Namespace, selector, er.client)
+		if err != nil {
+			logrus.Errorf("Unable to retrieve Deployment list while recovering cluster %q in namespace %q: %v", er.cluster.Name, er.cluster.Namespace, err)
+			return err
+		}
+
+		for _, deployment := range deploymentList.Items {
+			clusterName, _, uuid := parseNodeName(deployment.Name)
+
+			if clusterName != er.cluster.Name {
+				continue
+			}
+
+			if value, ok := uuidCounts[uuid]; ok {
+				uuidCounts[uuid] = value + 1
+			} else {
+				uuidCounts[uuid] = 1
+			}
+		}
+	}
+
+	// slight misnomer -- the key is the index which refers back to its index for er.cluster.Spec.Nodes
+	for nodeIndex, node := range nodesToMatch {
+
+		selector := map[string]string{
+			"cluster-name":   er.cluster.Name,
+			"es-node-client": "false",
+			"es-node-data":   "false",
+			"es-node-master": "false",
+		}
+
+		for _, role := range node.Roles {
+			switch role {
+			case loggingv1.ElasticsearchRoleClient:
+				selector["es-node-client"] = "true"
+				break
+			case loggingv1.ElasticsearchRoleData:
+				selector["es-node-data"] = "true"
+				break
+			case loggingv1.ElasticsearchRoleMaster:
+				selector["es-node-master"] = "true"
+			}
+		}
+
+		if isDataNode(node) {
+			var deploymentList *appsv1.DeploymentList
+			deploymentList, err := GetDeploymentList(er.cluster.Namespace, selector, er.client)
+			if err != nil {
+				logrus.Errorf("Unable to retrieve Deployment list while recovering cluster %q in namespace %q: %v", er.cluster.Name, er.cluster.Namespace, err)
+				return err
+			}
+
+			for _, deployment := range deploymentList.Items {
+				clusterName, _, uuid := parseNodeName(deployment.Name)
+
+				if clusterName != er.cluster.Name {
+					continue
+				}
+
+				if sliceContainsString(knownUUIDs, uuid) {
+					logrus.Infof("already found %q in %v while adopting", uuid, knownUUIDs)
+					continue
+				}
+
+				if er.cluster.Spec.Nodes[nodeIndex].GenUUID == nil {
+					if er.deploymentSpecMatchNode(node, deployment.Spec, uuidCounts[uuid]) {
+						er.cluster.Spec.Nodes[nodeIndex].GenUUID = &uuid
+						knownUUIDs = append(knownUUIDs, uuid)
+
+						er.setUUID(nodeIndex, uuid)
+						break
+					}
+				}
+			}
+		} else {
+			var statefulsetList *appsv1.StatefulSetList
+			statefulsetList, err := GetStatefulSetList(er.cluster.Namespace, selector, er.client)
+			if err != nil {
+				logrus.Errorf("Unable to retrieve Statefulset list while recovering cluster %q in namespace %q: %v", er.cluster.Name, er.cluster.Namespace, err)
+				return err
+			}
+
+			for _, statefulSet := range statefulsetList.Items {
+				clusterName, _, uuid := parseNodeName(statefulSet.Name)
+
+				if clusterName != er.cluster.Name {
+					continue
+				}
+
+				if sliceContainsString(knownUUIDs, uuid) {
+					logrus.Infof("already found %q in %v while adopting", uuid, knownUUIDs)
+					continue
+				}
+
+				if er.cluster.Spec.Nodes[nodeIndex].GenUUID == nil {
+					if er.statefulSetSpecMatchNode(node, statefulSet.Spec) {
+						er.cluster.Spec.Nodes[nodeIndex].GenUUID = &uuid
+						knownUUIDs = append(knownUUIDs, uuid)
+
+						er.setUUID(nodeIndex, uuid)
+						break
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// for PVCs we only need to match on roles and replicas for the sake of naming
+func (er *ElasticsearchRequest) recoverFromPVCs(knownUUIDs []string, nodesToMatch map[int]loggingv1.ElasticsearchNode) error {
+
+	selector := map[string]string{
+		"logging-cluster": er.cluster.Name,
+	}
+
+	pvcList, err := GetPVCList(er.cluster.Namespace, selector, er.client)
+
+	if err != nil {
+		logrus.Errorf("Unable to retrieve PVC list while recovering cluster %q in namespace %q: %v", er.cluster.Name, er.cluster.Namespace, err)
+		return err
+	}
+
+	uuidCounts := make(map[string]int32)
+	for _, pvc := range pvcList.Items {
+
+		clusterName, _, uuid := parseNodeName(pvc.Name)
+
+		if clusterName != er.cluster.Name {
+			continue
+		}
+
+		if value, ok := uuidCounts[uuid]; ok {
+			uuidCounts[uuid] = value + 1
+		} else {
+			uuidCounts[uuid] = 1
+		}
+	}
+
+	// go through the nodesToMatch and match it based on the roles for the pvc
+	for nodeIndex, node := range nodesToMatch {
+
+		// if the node doesn't have storage defined, skip it
+		if node.Storage.StorageClassName == nil {
+			continue
+		}
+
+		isClientNode := false
+		isDataNode := false
+		isMasterNode := false
+
+		for _, role := range node.Roles {
+			switch role {
+			case loggingv1.ElasticsearchRoleClient:
+				isClientNode = true
+				break
+			case loggingv1.ElasticsearchRoleData:
+				isDataNode = true
+				break
+			case loggingv1.ElasticsearchRoleMaster:
+				isMasterNode = true
+			}
+		}
+
+		for _, pvc := range pvcList.Items {
+
+			clusterName, role, uuid := parseNodeName(pvc.Name)
+
+			if clusterName != er.cluster.Name {
+				continue
+			}
+
+			if sliceContainsString(knownUUIDs, uuid) {
+				logrus.Infof("already found %q in %v while adopting", uuid, knownUUIDs)
+				continue
+			}
+
+			// check that roles are same, if not then continue
+			if isClientNode != strings.Contains(role, "c") {
+				continue
+			}
+
+			if isDataNode != strings.Contains(role, "d") {
+				continue
+			}
+
+			if isMasterNode != strings.Contains(role, "m") {
+				continue
+			}
+
+			if node.NodeCount != uuidCounts[uuid] {
+				continue
+			}
+
+			// roles and node count match, reuse the UUID
+			er.cluster.Spec.Nodes[nodeIndex].GenUUID = &uuid
+			knownUUIDs = append(knownUUIDs, uuid)
+
+			er.setUUID(nodeIndex, uuid)
+		}
+	}
+
+	return nil
+}

--- a/pkg/k8shandler/util.go
+++ b/pkg/k8shandler/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -358,6 +359,48 @@ func DeletePod(podName, namespace string, client client.Client) error {
 
 func GetPodList(namespace string, selector map[string]string, sdkClient client.Client) (*v1.PodList, error) {
 	list := &v1.PodList{}
+
+	labelSelector := labels.SelectorFromSet(selector)
+
+	err := sdkClient.List(
+		context.TODO(),
+		&client.ListOptions{Namespace: namespace, LabelSelector: labelSelector},
+		list,
+	)
+
+	return list, err
+}
+
+func GetDeploymentList(namespace string, selector map[string]string, sdkClient client.Client) (*appsv1.DeploymentList, error) {
+	list := &appsv1.DeploymentList{}
+
+	labelSelector := labels.SelectorFromSet(selector)
+
+	err := sdkClient.List(
+		context.TODO(),
+		&client.ListOptions{Namespace: namespace, LabelSelector: labelSelector},
+		list,
+	)
+
+	return list, err
+}
+
+func GetStatefulSetList(namespace string, selector map[string]string, sdkClient client.Client) (*appsv1.StatefulSetList, error) {
+	list := &appsv1.StatefulSetList{}
+
+	labelSelector := labels.SelectorFromSet(selector)
+
+	err := sdkClient.List(
+		context.TODO(),
+		&client.ListOptions{Namespace: namespace, LabelSelector: labelSelector},
+		list,
+	)
+
+	return list, err
+}
+
+func GetPVCList(namespace string, selector map[string]string, sdkClient client.Client) (*v1.PersistentVolumeClaimList, error) {
+	list := &v1.PersistentVolumeClaimList{}
 
 	labelSelector := labels.SelectorFromSet(selector)
 


### PR DESCRIPTION
To address https://bugzilla.redhat.com/show_bug.cgi?id=1881957
Manual cherry-pick of https://github.com/openshift/elasticsearch-operator/pull/471

This addresses cases where there is or was an existing cluster created (deployments, pods, pvcs, etc) who's cluster name is the same as the CR name, however the new elasticsearch CR is missing UUIDs.

As part of the recovery/adoption process, it will be required that the PVCs to be picked back up have the label logging-cluster: <name-of-the-cr>. It will also be validated against the name of the cluster that the PVC name is based on.

Recovery/adoption will be triggered upon the processing of a CR that is missing UUIDs. It will only try to recover UUIDs for nodes that do not already have UUIDs defined.

Further documentation will need to be developed and publish as part of how to recover data that from another PVC. This PR does not seek to resolve that but rather address cases where an elasticsearch CR may have been removed on accident and then recreated (without UUIDs).

Please note: as part of this change EO will be creating PVCs with the required labels now, so to ensure keeping previously used PVCs they should be labeled per above.