### PR TITLE
Bug 1882495: Block auto index creation for indices with "-write" suffix

### DIFF
--- a/pkg/k8shandler/configmaps_test.go
+++ b/pkg/k8shandler/configmaps_test.go
@@ -33,6 +33,8 @@ node:
   data: ${HAS_DATA}
   max_local_storage_nodes: 1
 
+action.auto_create_index: "-*-write,+*"
+
 network:
   publish_host: ${POD_IP}
   bind_host: ["${POD_IP}",_local_]

--- a/pkg/k8shandler/configuration_tmpl.go
+++ b/pkg/k8shandler/configuration_tmpl.go
@@ -17,6 +17,8 @@ node:
   data: ${HAS_DATA}
   max_local_storage_nodes: 1
 
+action.auto_create_index: "-*-write,+*"
+
 network:
   publish_host: ${POD_IP}
   bind_host: ["${POD_IP}",_local_]


### PR DESCRIPTION
This PR modifies ES configuration to disallow auto-creation of indices with a "-write" suffix.  This will assist in upgrade scenarios to 4.5 where the new data model relies on "-write" aliases.  It additionally will help with situations where customers mismatch CLO and EO.  The outcome is they should find logs are not being pushed to the storage and errors generating in the collector but it will protect the data store and keep from additional action needed to "fix" bad indices

ref https://bugzilla.redhat.com/show_bug.cgi?id=1882495

cc @ewolinetz @mffiedler 