### PR TITLE
Bug 1880926: Fix owner references for elasticsearch CR

### DIFF
--- a/pkg/indexmanagement/reconcile.go
+++ b/pkg/indexmanagement/reconcile.go
@@ -109,6 +109,7 @@ func ReconcileCurationConfigmap(apiclient client.Client, cluster *apis.Elasticse
 	data := scriptMap
 	desired := k8s.NewConfigMap(indexManagementConfigmap, cluster.Namespace, imLabels, data)
 	cluster.AddOwnerRefTo(desired)
+
 	err := apiclient.Create(context.TODO(), desired)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {

--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -45,14 +45,6 @@ var (
 	}
 )
 
-// addOwnerRefToObject appends the desired OwnerReference to the object
-// deprecated in favor of Elasticsearch#AddOwnerRefTo
-func addOwnerRefToObject(o metav1.Object, r metav1.OwnerReference) {
-	if (metav1.OwnerReference{}) != r {
-		o.SetOwnerReferences(append(o.GetOwnerReferences(), r))
-	}
-}
-
 func getESImage() string {
 	return utils.LookupEnvWithDefault("ELASTICSEARCH_IMAGE", constants.ElasticsearchDefaultImage)
 }

--- a/pkg/k8shandler/configmaps.go
+++ b/pkg/k8shandler/configmaps.go
@@ -120,7 +120,7 @@ func (er *ElasticsearchRequest) CreateOrUpdateConfigMaps() (err error) {
 		logConfig,
 	)
 
-	addOwnerRefToObject(configmap, getOwnerRef(dpl))
+	dpl.AddOwnerRefTo(configmap)
 
 	err = er.client.Create(context.TODO(), configmap)
 	if err != nil {

--- a/pkg/k8shandler/dashboards.go
+++ b/pkg/k8shandler/dashboards.go
@@ -29,5 +29,8 @@ func (er *ElasticsearchRequest) CreateOrUpdateDashboards() error {
 			"openshift-elasticsearch.json": string(utils.GetFileContents(fp)),
 		},
 	}
+
+	er.cluster.AddOwnerRefTo(cm)
+
 	return er.CreateOrUpdateConfigMap(cm)
 }

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -71,7 +71,7 @@ func (node *deploymentNode) populateReference(nodeName string, n api.Elasticsear
 		Template:                newPodTemplateSpec(nodeName, cluster.Name, cluster.Namespace, n, cluster.Spec.Spec, labels, roleMap, client, logConfig),
 	}
 
-	addOwnerRefToObject(&deployment, getOwnerRef(cluster))
+	cluster.AddOwnerRefTo(&deployment)
 
 	node.self = deployment
 	node.clusterName = cluster.Name

--- a/pkg/k8shandler/prometheus_rule.go
+++ b/pkg/k8shandler/prometheus_rule.go
@@ -27,14 +27,13 @@ func (er *ElasticsearchRequest) CreateOrUpdatePrometheusRules() error {
 	dpl := er.cluster
 
 	name := fmt.Sprintf("%s-%s", dpl.Name, "prometheus-rules")
-	owner := getOwnerRef(dpl)
 
 	rule, err := buildPrometheusRule(name, dpl.Namespace, dpl.Labels)
 	if err != nil {
 		return fmt.Errorf("failed to build prometheus rule: %w", err)
 	}
 
-	addOwnerRefToObject(rule, owner)
+	dpl.AddOwnerRefTo(rule)
 
 	err = er.client.Create(ctx, rule)
 	if err == nil {

--- a/pkg/k8shandler/service.go
+++ b/pkg/k8shandler/service.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/util/retry"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,10 +18,9 @@ func (er *ElasticsearchRequest) CreateOrUpdateServices() error {
 
 	dpl := er.cluster
 
-	ownerRef := getOwnerRef(dpl)
 	annotations := make(map[string]string)
 
-	err := createOrUpdateService(
+	err := er.createOrUpdateService(
 		fmt.Sprintf("%s-%s", dpl.Name, "cluster"),
 		dpl.Namespace,
 		dpl.Name,
@@ -31,15 +29,13 @@ func (er *ElasticsearchRequest) CreateOrUpdateServices() error {
 		selectorForES("es-node-master", dpl.Name),
 		annotations,
 		true,
-		ownerRef,
 		map[string]string{},
-		er.client,
 	)
 	if err != nil {
 		return fmt.Errorf("Failure creating service %v", err)
 	}
 
-	err = createOrUpdateService(
+	err = er.createOrUpdateService(
 		dpl.Name,
 		dpl.Namespace,
 		dpl.Name,
@@ -48,9 +44,7 @@ func (er *ElasticsearchRequest) CreateOrUpdateServices() error {
 		selectorForES("es-node-client", dpl.Name),
 		annotations,
 		false,
-		ownerRef,
 		map[string]string{},
-		er.client,
 	)
 	if err != nil {
 		return fmt.Errorf("Failure creating service %v", err)
@@ -58,7 +52,7 @@ func (er *ElasticsearchRequest) CreateOrUpdateServices() error {
 
 	//legacy metrics service that likely can be rolled into the single service that goes through the proxy
 	annotations["service.alpha.openshift.io/serving-cert-secret-name"] = fmt.Sprintf("%s-%s", dpl.Name, "metrics")
-	err = createOrUpdateService(
+	err = er.createOrUpdateService(
 		fmt.Sprintf("%s-%s", dpl.Name, "metrics"),
 		dpl.Namespace,
 		dpl.Name,
@@ -67,11 +61,9 @@ func (er *ElasticsearchRequest) CreateOrUpdateServices() error {
 		selectorForES("es-node-client", dpl.Name),
 		annotations,
 		false,
-		ownerRef,
 		map[string]string{
 			"scrape-metrics": "enabled",
 		},
-		er.client,
 	)
 	if err != nil {
 		return fmt.Errorf("Failure creating service %v", err)
@@ -79,7 +71,10 @@ func (er *ElasticsearchRequest) CreateOrUpdateServices() error {
 	return nil
 }
 
-func createOrUpdateService(serviceName, namespace, clusterName, targetPortName string, port int32, selector, annotations map[string]string, publishNotReady bool, owner metav1.OwnerReference, labels map[string]string, client client.Client) error {
+func (er *ElasticsearchRequest) createOrUpdateService(serviceName, namespace, clusterName, targetPortName string, port int32, selector, annotations map[string]string, publishNotReady bool, labels map[string]string) error {
+
+	client := er.client
+	cluster := er.cluster
 
 	labels = appendDefaultLabel(clusterName, labels)
 
@@ -94,7 +89,8 @@ func createOrUpdateService(serviceName, namespace, clusterName, targetPortName s
 		labels,
 		publishNotReady,
 	)
-	addOwnerRefToObject(service, owner)
+
+	cluster.AddOwnerRefTo(service)
 
 	err := client.Create(context.TODO(), service)
 	if err != nil {

--- a/pkg/k8shandler/service_monitor.go
+++ b/pkg/k8shandler/service_monitor.go
@@ -19,13 +19,13 @@ func (er *ElasticsearchRequest) CreateOrUpdateServiceMonitors() error {
 
 	dpl := er.cluster
 	serviceMonitorName := fmt.Sprintf("monitor-%s-%s", dpl.Name, "cluster")
-	owner := getOwnerRef(dpl)
 
 	labelsWithDefault := appendDefaultLabel(dpl.Name, dpl.Labels)
 	labelsWithDefault["scrape-metrics"] = "enabled"
 
 	elasticsearchScMonitor := createServiceMonitor(serviceMonitorName, dpl.Name, dpl.Namespace, labelsWithDefault)
-	addOwnerRefToObject(elasticsearchScMonitor, owner)
+	dpl.AddOwnerRefTo(elasticsearchScMonitor)
+
 	err := er.client.Create(context.TODO(), elasticsearchScMonitor)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("Failure constructing Elasticsearch ServiceMonitor: %v", err)

--- a/pkg/k8shandler/serviceaccount.go
+++ b/pkg/k8shandler/serviceaccount.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	loggingv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,10 +14,9 @@ import (
 
 // CreateOrUpdateServiceAccount ensures the existence of the serviceaccount for Elasticsearch cluster
 func (er *ElasticsearchRequest) CreateOrUpdateServiceAccount() (err error) {
-
 	dpl := er.cluster
 
-	err = createOrUpdateServiceAccount(dpl.Name, dpl.Namespace, getOwnerRef(dpl), er.client)
+	err = createOrUpdateServiceAccount(dpl.Name, dpl.Namespace, er.cluster, er.client)
 	if err != nil {
 		return fmt.Errorf("Failure creating ServiceAccount %v", err)
 	}
@@ -24,9 +24,9 @@ func (er *ElasticsearchRequest) CreateOrUpdateServiceAccount() (err error) {
 	return nil
 }
 
-func createOrUpdateServiceAccount(serviceAccountName, namespace string, ownerRef metav1.OwnerReference, client client.Client) error {
+func createOrUpdateServiceAccount(serviceAccountName, namespace string, cluster *loggingv1.Elasticsearch, client client.Client) error {
 	serviceAccount := newServiceAccount(serviceAccountName, namespace)
-	addOwnerRefToObject(serviceAccount, ownerRef)
+	cluster.AddOwnerRefTo(serviceAccount)
 
 	err := client.Create(context.TODO(), serviceAccount)
 	if err != nil {

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -84,7 +84,7 @@ func (n *statefulSetNode) populateReference(nodeName string, node api.Elasticsea
 	}
 	statefulSet.Spec.Template.Spec.Containers[0].ReadinessProbe = nil
 
-	addOwnerRefToObject(&statefulSet, getOwnerRef(cluster))
+	cluster.AddOwnerRefTo(&statefulSet)
 
 	n.self = statefulSet
 	n.clusterName = cluster.Name


### PR DESCRIPTION
### Description
This PR addresses a mismatch in using `ownerReferences` for Elasticsearch CR dependents. Based on the following list the operator reconciler cluster-scoped dependents that poison the kubernetes gargbage collector cache. In turn the Elasticsearch CR and its namespace dependents get deleted as discussed in this upstream [PR](https://github.com/kubernetes/kubernetes/issues/65200) as well as noted on the [docs](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents).

Furthermore, this PR addresses missing `ownerReferences` for dashboard configmaps. It also cleanups duplicate usage of `addOwnerRefToObject` from `common.go` in favor of `AddOwnerRefTo` from `elasticsearch_types.go`.

```
"Service/elasticsearch"
"Service/elasticsearch-cluster"
"Service/elasticsearch-metrics"
"Deployment/elasticsearch-cdm-d2i89wrd-1"
"Deployment/elasticsearch-cdm-d2i89wrd-2"
"Deployment/elasticsearch-cdm-d2i89wrd-3"
"CronJob/elasticsearch-delete-app"
"CronJob/elasticsearch-delete-audit"
"CronJob/elasticsearch-delete-infra"
"CronJob/elasticsearch-rollover-app"
"CronJob/elasticsearch-rollover-audit"
"CronJob/elasticsearch-rollover-infra"
"ConfigMap/elasticsearch"
"ConfigMap/indexmanagement-scripts"
"ServiceAccount/elasticsearch"

"ClusterRole/elasticsearch-metrics"
"ClusterRole/elasticsearch-proxy"
"ClusterRoleBinding/elasticsearch-metrics"
"ClusterRoleBinding/elasticsearch-proxy"

"Role/elasticsearch-index-management"
"RoleBinding/elasticsearch-index-management"
"ServiceMonitor/monitor-elasticsearch-cluster"
"PrometheusRule/elasticsearch-prometheus-rules"
````
 
/cc @blockloop 
/assign @ewolinetz 
 
/cherry-pick release-4.5
 
#### Links

- Affecting PR(s):  #493, #481
- Bugzilla:  https://bugzilla.redhat.com/show_bug.cgi?id=1880926 (in dependency: https://bugzilla.redhat.com/show_bug.cgi?id=1882450)
