### PR TITLE
Bug 1878305: Bump es max_header_size to address errors seen in Kibana

### DIFF
--- a/pkg/k8shandler/configmaps_test.go
+++ b/pkg/k8shandler/configmaps_test.go
@@ -149,6 +149,9 @@ path:
 prometheus:
   indices: false
 
+# increase the max header size above 8kb default
+http.max_header_size: 16kb
+
 opendistro_security:
   authcz.admin_dn:
   - CN=system.admin,OU=OpenShift,O=Logging

--- a/pkg/k8shandler/configuration_tmpl.go
+++ b/pkg/k8shandler/configuration_tmpl.go
@@ -35,6 +35,9 @@ path:
 prometheus:
   indices: false
 
+# increase the max header size above 8kb default
+http.max_header_size: 16kb
+
 opendistro_security:
   authcz.admin_dn:
   - CN=system.admin,OU=OpenShift,O=Logging


### PR DESCRIPTION
To address: https://bugzilla.redhat.com/show_bug.cgi?id=1878305

By default, ES has a max header size of `8kb` which is too low for the case where it is behind a reverse proxy (in the case of our stack). This results in a `504` if trying to navigate to the Kibana exploration page, or a `400` if trying to access the Kibana status page.

Also fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1845293