### PR TITLE
[release-4.5] Bug 1883357: Bump es max_header_size to address errors seen in Kibana

### DIFF
--- a/pkg/k8shandler/configuration_tmpl.go
+++ b/pkg/k8shandler/configuration_tmpl.go
@@ -35,6 +35,9 @@ path:
 prometheus:
   indices: false
 
+# increase the max header size above 8kb default
+http.max_header_size: 128kb
+
 opendistro_security:
   authcz.admin_dn:
   - CN=system.admin,OU=OpenShift,O=Logging

--- a/pkg/k8shandler/confimaps_test.go
+++ b/pkg/k8shandler/confimaps_test.go
@@ -51,6 +51,9 @@ path:
 prometheus:
   indices: false
 
+# increase the max header size above 8kb default
+http.max_header_size: 128kb
+
 opendistro_security:
   authcz.admin_dn:
   - CN=system.admin,OU=OpenShift,O=Logging


### PR DESCRIPTION
Manual cherrypick of:
* https://github.com/openshift/elasticsearch-operator/pull/502
* https://github.com/openshift/elasticsearch-operator/pull/508

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1883357

By default, ES has a max header size of 8kb which is too low for the case where it is behind a reverse proxy (in the case of our stack). This results in a 504 if trying to navigate to the Kibana exploration page, or a 400 if trying to access the Kibana status page.