### PR TITLE
Bug 1883444: capping primary shard count at 5 for performance reasons

### DIFF
--- a/pkg/elasticsearch/client.go
+++ b/pkg/elasticsearch/client.go
@@ -83,7 +83,8 @@ type Client interface {
 	CreateIndexTemplate(name string, template *estypes.IndexTemplate) error
 	DeleteIndexTemplate(name string) error
 	ListTemplates() (sets.String, error)
-	GetIndexTemplates() (map[string]interface{}, error)
+	GetIndexTemplates() (map[string]estypes.GetIndexTemplate, error)
+	UpdateTemplatePrimaryShards(shardCount int32) error
 
 	SetSendRequestFn(fn FnEsSendRequest)
 }

--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -155,6 +155,9 @@ func (er *ElasticsearchRequest) CreateOrUpdateElasticsearchCluster() error {
 		// ensure that MinMasters is (n / 2 + 1)
 		er.updateMinMasters()
 
+		// update our template primary shard counts in case they changed
+		er.updatePrimaryShards()
+
 		// ensure we always have shard allocation to All if we aren't doing an update...
 		er.tryEnsureAllShardAllocation()
 

--- a/pkg/k8shandler/configuration_tmpl.go
+++ b/pkg/k8shandler/configuration_tmpl.go
@@ -25,7 +25,7 @@ discovery.zen:
 
 gateway:
   recover_after_nodes: {{.NodeQuorum}}
-  expected_nodes: {{.RecoverExpectedShards}}
+  expected_nodes: {{.RecoverExpectedNodes}}
   recover_after_time: ${RECOVER_AFTER_TIME}
 
 path:

--- a/pkg/k8shandler/defaults_test.go
+++ b/pkg/k8shandler/defaults_test.go
@@ -1,0 +1,67 @@
+package k8shandler
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	api "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+)
+
+var (
+	dpl           *api.Elasticsearch
+	dataNodeCount int
+	dataNode      api.ElasticsearchNode
+)
+
+var _ = Describe("defaults", func() {
+	defer GinkgoRecover()
+
+	BeforeEach(func() {
+
+		dataNode = api.ElasticsearchNode{
+			Roles: []api.ElasticsearchNodeRole{
+				api.ElasticsearchRoleClient,
+				api.ElasticsearchRoleData,
+			},
+		}
+	})
+
+	Describe("#getPrimaryShardCount with excess data nodes", func() {
+
+		JustBeforeEach(func() {
+
+			dataNodeCount = 20
+			dataNode.NodeCount = int32(dataNodeCount)
+
+			dpl = &api.Elasticsearch{
+				Spec: api.ElasticsearchSpec{
+					Nodes: []api.ElasticsearchNode{
+						dataNode,
+					},
+				},
+			}
+		})
+		It("should return maxPrimaryShardCount", func() {
+			Expect(calculatePrimaryCount(dpl)).To(Equal(maxPrimaryShardCount))
+		})
+	})
+
+	Describe("#getPrimaryShardCount with 3 data nodes", func() {
+
+		JustBeforeEach(func() {
+
+			dataNodeCount = 3
+			dataNode.NodeCount = int32(dataNodeCount)
+
+			dpl = &api.Elasticsearch{
+				Spec: api.ElasticsearchSpec{
+					Nodes: []api.ElasticsearchNode{
+						dataNode,
+					},
+				},
+			}
+		})
+		It("should return data node count", func() {
+			Expect(calculatePrimaryCount(dpl)).To(Equal(dataNodeCount))
+		})
+	})
+})

--- a/pkg/k8shandler/elasticsearch.go
+++ b/pkg/k8shandler/elasticsearch.go
@@ -91,3 +91,12 @@ func (er *ElasticsearchRequest) updateReplicas() {
 		}
 	}
 }
+
+func (er *ElasticsearchRequest) updatePrimaryShards() {
+	if er.ClusterReady() {
+		primaryCount := int32(calculatePrimaryCount(er.cluster))
+		if err := er.esClient.UpdateTemplatePrimaryShards(primaryCount); err != nil {
+			er.L().Error(err, "Unable to update primary count")
+		}
+	}
+}

--- a/pkg/types/elasticsearch/types.go
+++ b/pkg/types/elasticsearch/types.go
@@ -50,6 +50,38 @@ type IndexTemplate struct {
 	Aliases  map[string]IndexAlias `json:"aliases,omitempty"`
 }
 
+type GetIndexTemplate struct {
+	Order         int32                           `json:"order,omitempty"`
+	IndexPatterns []string                        `json:"index_patterns,omitempty"`
+	Settings      GetIndexTemplateSettings        `json:"settings,omitempty"`
+	Aliases       map[string]IndexAlias           `json:"aliases,omitempty"`
+	Mappings      map[string]IndexMappingSettings `json:"mappings,omitempty"`
+}
+
+type GetIndexTemplateSettings struct {
+	Index IndexTemplateSettings `json:"index,omitempty"`
+}
+
+type IndexTemplateSettings struct {
+	Unassigned       UnassignedIndexSetting `json:"unassigned,omitempty"`
+	Translog         TranslogIndexSetting   `json:"translog,omitempty"`
+	RefreshInterval  string                 `json:"refresh_interval,omitempty"`
+	NumberOfShards   string                 `json:"number_of_shards,omitempty"`
+	NumberOfReplicas string                 `json:"number_of_replicas,omitempty"`
+}
+
+type UnassignedIndexSetting struct {
+	NodeLeft NodeLeftSetting `json:"node_left,omitempty"`
+}
+
+type NodeLeftSetting struct {
+	DelayedTimeout string `json:"delayed_timeout,omitempty"`
+}
+
+type TranslogIndexSetting struct {
+	FlushThresholdSize string `json:"flush_threshold_size,omitempty"`
+}
+
 type Aliases struct {
 }
 


### PR DESCRIPTION
Also updating reconcile loop to update the primary shard for index templates to ensure it accurately is reflected for new indices that are created.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1883444