### PR TITLE
Bug 1883777: Fix owner references for elasticsearch CR

### DIFF
--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -22,14 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// addOwnerRefToObject appends the desired OwnerReference to the object
-// deprecated in favor of Elasticsearch#AddOwnerRefTo
-func addOwnerRefToObject(o metav1.Object, r metav1.OwnerReference) {
-	if (metav1.OwnerReference{}) != r {
-		o.SetOwnerReferences(append(o.GetOwnerReferences(), r))
-	}
-}
-
 func getImage() string {
 	return utils.LookupEnvWithDefault("ELASTICSEARCH_IMAGE", constants.ElasticsearchDefaultImage)
 }

--- a/pkg/k8shandler/configmaps.go
+++ b/pkg/k8shandler/configmaps.go
@@ -74,7 +74,7 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateConfigMaps() (er
 		logConfig,
 	)
 
-	addOwnerRefToObject(configmap, getOwnerRef(dpl))
+	dpl.AddOwnerRefTo(configmap)
 
 	err = elasticsearchRequest.client.Create(context.TODO(), configmap)
 	if err != nil {

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -74,7 +74,7 @@ func (deploymentNode *deploymentNode) populateReference(nodeName string, node ap
 		Template:                newPodTemplateSpec(nodeName, cluster.Name, cluster.Namespace, node, cluster.Spec.Spec, labels, roleMap, client, logConfig),
 	}
 
-	addOwnerRefToObject(&deployment, getOwnerRef(cluster))
+	cluster.AddOwnerRefTo(&deployment)
 
 	deploymentNode.self = deployment
 	deploymentNode.clusterName = cluster.Name

--- a/pkg/k8shandler/prometheus_rule.go
+++ b/pkg/k8shandler/prometheus_rule.go
@@ -25,14 +25,13 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdatePrometheusRules(
 	dpl := elasticsearchRequest.cluster
 
 	ruleName := fmt.Sprintf("%s-%s", dpl.Name, "prometheus-rules")
-	owner := getOwnerRef(dpl)
 
 	promRule, err := buildPrometheusRule(ruleName, dpl.Namespace, dpl.Labels)
 	if err != nil {
 		return err
 	}
 
-	addOwnerRefToObject(promRule, owner)
+	dpl.AddOwnerRefTo(promRule)
 
 	err = elasticsearchRequest.client.Create(context.TODO(), promRule)
 	if err != nil && !errors.IsAlreadyExists(err) {

--- a/pkg/k8shandler/service.go
+++ b/pkg/k8shandler/service.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/util/retry"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -18,11 +17,9 @@ import (
 func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateServices() error {
 
 	dpl := elasticsearchRequest.cluster
-
-	ownerRef := getOwnerRef(dpl)
 	annotations := make(map[string]string)
 
-	err := createOrUpdateService(
+	err := elasticsearchRequest.createOrUpdateService(
 		fmt.Sprintf("%s-%s", dpl.Name, "cluster"),
 		dpl.Namespace,
 		dpl.Name,
@@ -31,15 +28,13 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateServices() error
 		selectorForES("es-node-master", dpl.Name),
 		annotations,
 		true,
-		ownerRef,
 		map[string]string{},
-		elasticsearchRequest.client,
 	)
 	if err != nil {
 		return fmt.Errorf("Failure creating service %v", err)
 	}
 
-	err = createOrUpdateService(
+	err = elasticsearchRequest.createOrUpdateService(
 		dpl.Name,
 		dpl.Namespace,
 		dpl.Name,
@@ -48,9 +43,7 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateServices() error
 		selectorForES("es-node-client", dpl.Name),
 		annotations,
 		false,
-		ownerRef,
 		map[string]string{},
-		elasticsearchRequest.client,
 	)
 	if err != nil {
 		return fmt.Errorf("Failure creating service %v", err)
@@ -58,7 +51,7 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateServices() error
 
 	//legacy metrics service that likely can be rolled into the single service that goes through the proxy
 	annotations["service.alpha.openshift.io/serving-cert-secret-name"] = fmt.Sprintf("%s-%s", dpl.Name, "metrics")
-	err = createOrUpdateService(
+	err = elasticsearchRequest.createOrUpdateService(
 		fmt.Sprintf("%s-%s", dpl.Name, "metrics"),
 		dpl.Namespace,
 		dpl.Name,
@@ -67,11 +60,9 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateServices() error
 		selectorForES("es-node-client", dpl.Name),
 		annotations,
 		false,
-		ownerRef,
 		map[string]string{
 			"scrape-metrics": "enabled",
 		},
-		elasticsearchRequest.client,
 	)
 	if err != nil {
 		return fmt.Errorf("Failure creating service %v", err)
@@ -79,7 +70,10 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateServices() error
 	return nil
 }
 
-func createOrUpdateService(serviceName, namespace, clusterName, targetPortName string, port int32, selector, annotations map[string]string, publishNotReady bool, owner metav1.OwnerReference, labels map[string]string, client client.Client) error {
+func (er *ElasticsearchRequest) createOrUpdateService(serviceName, namespace, clusterName, targetPortName string, port int32, selector, annotations map[string]string, publishNotReady bool, labels map[string]string) error {
+
+	client := er.client
+	cluster := er.cluster
 
 	labels = appendDefaultLabel(clusterName, labels)
 
@@ -94,7 +88,8 @@ func createOrUpdateService(serviceName, namespace, clusterName, targetPortName s
 		labels,
 		publishNotReady,
 	)
-	addOwnerRefToObject(service, owner)
+
+	cluster.AddOwnerRefTo(service)
 
 	err := client.Create(context.TODO(), service)
 	if err != nil {

--- a/pkg/k8shandler/service_monitor.go
+++ b/pkg/k8shandler/service_monitor.go
@@ -19,13 +19,14 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateServiceMonitors(
 
 	dpl := elasticsearchRequest.cluster
 	serviceMonitorName := fmt.Sprintf("monitor-%s-%s", dpl.Name, "cluster")
-	owner := getOwnerRef(dpl)
 
 	labelsWithDefault := appendDefaultLabel(dpl.Name, dpl.Labels)
 	labelsWithDefault["scrape-metrics"] = "enabled"
 
 	elasticsearchScMonitor := createServiceMonitor(serviceMonitorName, dpl.Name, dpl.Namespace, labelsWithDefault)
-	addOwnerRefToObject(elasticsearchScMonitor, owner)
+
+	dpl.AddOwnerRefTo(elasticsearchScMonitor)
+
 	err := elasticsearchRequest.client.Create(context.TODO(), elasticsearchScMonitor)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("Failure constructing Elasticsearch ServiceMonitor: %v", err)

--- a/pkg/k8shandler/serviceaccount.go
+++ b/pkg/k8shandler/serviceaccount.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	loggingv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,7 +17,7 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateServiceAccount()
 
 	dpl := elasticsearchRequest.cluster
 
-	err = createOrUpdateServiceAccount(dpl.Name, dpl.Namespace, getOwnerRef(dpl), elasticsearchRequest.client)
+	err = createOrUpdateServiceAccount(dpl.Name, dpl.Namespace, dpl, elasticsearchRequest.client)
 	if err != nil {
 		return fmt.Errorf("Failure creating ServiceAccount %v", err)
 	}
@@ -24,9 +25,10 @@ func (elasticsearchRequest *ElasticsearchRequest) CreateOrUpdateServiceAccount()
 	return nil
 }
 
-func createOrUpdateServiceAccount(serviceAccountName, namespace string, ownerRef metav1.OwnerReference, client client.Client) error {
+func createOrUpdateServiceAccount(serviceAccountName, namespace string, cluster *loggingv1.Elasticsearch, client client.Client) error {
 	serviceAccount := newServiceAccount(serviceAccountName, namespace)
-	addOwnerRefToObject(serviceAccount, ownerRef)
+
+	cluster.AddOwnerRefTo(serviceAccount)
 
 	err := client.Create(context.TODO(), serviceAccount)
 	if err != nil {

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -73,7 +73,7 @@ func (statefulSetNode *statefulSetNode) populateReference(nodeName string, node 
 	}
 	statefulSet.Spec.Template.Spec.Containers[0].ReadinessProbe = nil
 
-	addOwnerRefToObject(&statefulSet, getOwnerRef(cluster))
+	cluster.AddOwnerRefTo(&statefulSet)
 
 	statefulSetNode.self = statefulSet
 	statefulSetNode.clusterName = cluster.Name


### PR DESCRIPTION
### Description
This PR is a manual backport of #498. It removes all namespace-scoped owners from cluster-scoped resources' `ownerReferences` field. In turn this resolves random GC collection of Elasticsearch CR owned resources, e.g. deployments.
 
/cc @blockloop 
/assign @ewolinetz 
 
/cherry-pick release-4.4

### Links
- Depending on PR(s):  #498
- Bugzilla:  https://bugzilla.redhat.com/show_bug.cgi?id=1883777
