### PR TITLE
LOG-912: Use must-gather for artifact gathering where appropriate

### DIFF
--- a/hack/testing-olm-upgrade/test-020-olm-upgrade-4.4-4.5.sh
+++ b/hack/testing-olm-upgrade/test-020-olm-upgrade-4.4-4.5.sh
@@ -31,16 +31,7 @@ cleanup(){
   log::info "Running cleanup"
   end_seconds=$(date +%s)
   runtime="$(($end_seconds - $start_seconds))s"
-  oc -n openshift-operators-redhat -o yaml get subscription elasticsearch-operator > $ARTIFACT_DIR/subscription-eo.yml 2>&1 ||:
-  oc -n openshift-operators-redhat -o yaml get deployment/elasticsearch-operator > $ARTIFACT_DIR/elasticsearch-operator-deployment.yml 2>&1 ||:
-  oc -n openshift-operators-redhat -o yaml get pods > $ARTIFACT_DIR/openshift-operators-redhat-pods.yml 2>&1 ||:
-  oc -n openshift-operators-redhat -o yaml get configmaps > $ARTIFACT_DIR/openshift-operators-redhat-configmaps.yml 2>&1 ||:
-  oc -n openshift-operators-redhat describe deployment/elasticsearch-operator > $ARTIFACT_DIR/elasticsearch-operator.describe 2>&1 ||:
-
-  oc logs -n "openshift-operators-redhat" deployment/elasticsearch-operator > $ARTIFACT_DIR/elasticsearch-operator.log 2>&1 ||:
-  oc  -n openshift-operator-lifecycle-manager logs --since=$runtime deployment/catalog-operator > $ARTIFACT_DIR/catalog-operator.logs 2>&1 ||:
-  oc  -n openshift-operator-lifecycle-manager logs --since=$runtime deployment/olm-operator > $ARTIFACT_DIR/olm-operator.logs 2>&1 ||:
-
+  oc adm must-gather --image=${IMAGE_CLUSTER_LOGGING_OPERATOR:-quay.io/openshift/origin-cluster-logging-operator:latest} --dest-dir=$ARTIFACT_DIR
   ${repo_dir}/olm_deploy/scripts/operator-uninstall.sh
   ${repo_dir}/olm_deploy/scripts/catalog-uninstall.sh
 


### PR DESCRIPTION
This PR replaces artifact gathering with the must gather scripts.  Note: this PR updates it one place only because the tests otherwise randomize the NS where tests are run unlike CLO where all artifacts are from known NS

ref: https://issues.redhat.com/browse/LOG-912

cc @periklis @ewolinetz 