### PR TITLE
Bug 1878305: further increasing http max_header_size

### DIFF
--- a/pkg/k8shandler/configmaps_test.go
+++ b/pkg/k8shandler/configmaps_test.go
@@ -150,7 +150,7 @@ prometheus:
   indices: false
 
 # increase the max header size above 8kb default
-http.max_header_size: 16kb
+http.max_header_size: 128kb
 
 opendistro_security:
   authcz.admin_dn:

--- a/pkg/k8shandler/configuration_tmpl.go
+++ b/pkg/k8shandler/configuration_tmpl.go
@@ -36,7 +36,7 @@ prometheus:
   indices: false
 
 # increase the max header size above 8kb default
-http.max_header_size: 16kb
+http.max_header_size: 128kb
 
 opendistro_security:
   authcz.admin_dn:


### PR DESCRIPTION
Addresses comment https://bugzilla.redhat.com/show_bug.cgi?id=1883357#c2 (which is the 4.5 backport of bug referenced in PR title)

Further increasing the http.max_header_size above 16kb to 128kb