### PR TITLE
Bug 1884477: Update bundle manifests to reflect latest CRD state

### DIFF
--- a/bundle/manifests/logging.openshift.io_kibanas_crd.yaml
+++ b/bundle/manifests/logging.openshift.io_kibanas_crd.yaml
@@ -209,4 +209,5 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}


### PR DESCRIPTION
### Description
This PR addresses the sync between our latest CRD state into our bundle manifest directory. This is mandatory to provide an up2date 4.6.0 bundle image.
 
/cc @blockloop 
/assign @ewolinetz 

### Links
- Bugzilla:  https://bugzilla.redhat.com/show_bug.cgi?id=1884477
