### PR TITLE
Bug 1883777: Stop rescheduling non-existing nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-openapi/swag v0.19.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/google/btree v1.0.0 // indirect
+	github.com/google/martian v2.1.0+incompatible
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/gophercloud/gophercloud v0.0.0-20190405143950-35c7fd233bfd // indirect

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,7 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -329,9 +329,11 @@ func (node *deploymentNode) waitForNodeLeaveCluster() (error, bool) {
 }
 
 func (node *deploymentNode) isMissing() bool {
-	getNode := &apps.Deployment{}
-	if getErr := node.client.Get(context.TODO(), types.NamespacedName{Name: node.name(), Namespace: node.self.Namespace}, getNode); getErr != nil {
-		if errors.IsNotFound(getErr) {
+	obj := &apps.Deployment{}
+	key := types.NamespacedName{Name: node.name(), Namespace: node.self.Namespace}
+
+	if err := node.client.Get(context.TODO(), key, obj); err != nil {
+		if errors.IsNotFound(err) {
 			return true
 		}
 	}

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -238,9 +238,11 @@ func (node *statefulSetNode) replicaCount() (int32, error) {
 }
 
 func (node *statefulSetNode) isMissing() bool {
-	getNode := &apps.StatefulSet{}
-	if getErr := node.client.Get(context.TODO(), types.NamespacedName{Name: node.name(), Namespace: node.self.Namespace}, getNode); getErr != nil {
-		if errors.IsNotFound(getErr) {
+	obj := &apps.StatefulSet{}
+	key := types.NamespacedName{Name: node.name(), Namespace: node.self.Namespace}
+
+	if err := node.client.Get(context.TODO(), key, obj); err != nil {
+		if errors.IsNotFound(err) {
 			return true
 		}
 	}


### PR DESCRIPTION
### Description
This PR is a manual backport of #493. It addresses the case where deployments/statefulsets for Elasticsearch nodes are not existing although the last recorded status registered them as unschedulable. This event may happen during cluster upgrades where OCP cluster nodes become unavailable and in turn ES cluster nodes unschedulable for a period of time. The PR addresses this case by pruning the status fields in order to re-enable the deployment/statefulset recreation for the missing elasticsearch nodes.
 
/cc @blockloop 
/assign @ewolinetz 
 
/cherry-pick release-4.4
 
### Links
- Depending on PR(s):  #493
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1883777
