### PR TITLE
Use default storageclass for elasticsearch pvc if none defined in CR

### DIFF
--- a/pkg/apis/logging/v1/elasticsearch_types.go
+++ b/pkg/apis/logging/v1/elasticsearch_types.go
@@ -144,7 +144,7 @@ type ElasticsearchNode struct {
 	// The type of backing storage that should be used for the node
 	//
 	// +optional
-	Storage ElasticsearchStorageSpec `json:"storage"`
+	Storage ElasticsearchStorageSpec `json:"storage,omitempty"`
 
 	// GenUUID will be populated by the operator if not provided
 	//
@@ -185,6 +185,7 @@ type ElasticsearchNodeSpec struct {
 type ElasticsearchStorageSpec struct {
 	// The name of the storage class to use with creating the node's PVC.
 	// More info: https://kubernetes.io/docs/concepts/storage/storage-classes/
+	// +optional
 	StorageClassName *string `json:"storageClassName,omitempty"`
 
 	// The max storage capacity for the node to provision.

--- a/test/e2e-olm/elasticsearch_test.go
+++ b/test/e2e-olm/elasticsearch_test.go
@@ -206,7 +206,6 @@ func multipleNodesWithNonDataNodeTest(t *testing.T) {
 	nonDataUUID := utils.GenerateUUID()
 	t.Logf("Using GenUUID for non data nodes: %v", nonDataUUID)
 
-	storageClassName := "gp2"
 	storageClassSize := resource.MustParse("2G")
 
 	esNonDataNode := loggingv1.ElasticsearchNode{
@@ -216,8 +215,7 @@ func multipleNodesWithNonDataNodeTest(t *testing.T) {
 		},
 		NodeCount: int32(1),
 		Storage: loggingv1.ElasticsearchStorageSpec{
-			StorageClassName: &storageClassName,
-			Size:             &storageClassSize,
+			Size: &storageClassSize,
 		},
 		GenUUID: &nonDataUUID,
 	}

--- a/test/e2e-olm/utils.go
+++ b/test/e2e-olm/utils.go
@@ -66,7 +66,6 @@ func createElasticsearchCR(t *testing.T, f *test.Framework, ctx *test.Context, e
 	cpuValue := resource.MustParse("256m")
 	memValue := resource.MustParse("1Gi")
 
-	storageClassName := "gp2"
 	storageClassSize := resource.MustParse("2Gi")
 
 	esDataNode := loggingv1.ElasticsearchNode{
@@ -75,12 +74,11 @@ func createElasticsearchCR(t *testing.T, f *test.Framework, ctx *test.Context, e
 			loggingv1.ElasticsearchRoleData,
 			loggingv1.ElasticsearchRoleMaster,
 		},
-		NodeCount: int32(replicas),
 		Storage: loggingv1.ElasticsearchStorageSpec{
-			StorageClassName: &storageClassName,
-			Size:             &storageClassSize,
+			Size: &storageClassSize,
 		},
-		GenUUID: &dataUUID,
+		NodeCount: int32(replicas),
+		GenUUID:   &dataUUID,
 	}
 
 	// create elasticsearch custom resource
@@ -173,7 +171,6 @@ func createElasticsearchSecret(t *testing.T, f *test.Framework, ctx *test.Contex
 	namespace, err := ctx.GetWatchNamespace()
 	if err != nil {
 		return fmt.Errorf("Could not get namespace: %v", err)
-
 	}
 
 	if err := generateCertificates(t, namespace, uuid); err != nil {
@@ -304,7 +301,6 @@ func createKibanaProxySecret(f *test.Framework, ctx *test.Context, esUUID string
 	namespace, err := ctx.GetWatchNamespace()
 	if err != nil {
 		return fmt.Errorf("Could not get namespace: %v", err)
-
 	}
 
 	kibanaProxySecret := utils.Secret(


### PR DESCRIPTION
### Description
This PR addresses a long-standing request to use the default cluster-wide storage class when the appropriate Elasticsearch CR field is undefined. The implementation is addressing this by making mandatory to set the field to an empty string if the user needs ephemeral storage. The following modes are now support for Elasticsearch CR users:

#### Persistent Storage using default cluster-wide StorageClass
```
apiVersion: "logging.openshift.io/v1"
kind: "ClusterLogging"
metadata:
  name: "instance"
  namespace: "openshift-logging"
spec:
  managementState: "Managed"
  logStore:
    type: "elasticsearch"
    elasticsearch:
      nodeCount: 1
      storage:                  # <---- No storage class name provided here
        size: 80Gi
      redundancyPolicy: "ZeroRedundancy"
```

#### Persistent Storage using custom StorageClass
```
apiVersion: "logging.openshift.io/v1"
kind: "ClusterLogging"
metadata:
  name: "instance"
  namespace: "openshift-logging"
spec:
  managementState: "Managed"
  logStore:
    type: "elasticsearch"
    elasticsearch:
      nodeCount: 1
      storage:
        storageClassName: "gp2" # <---- Custom storage class name provided here
        size: 80Gi
      redundancyPolicy: "ZeroRedundancy"
```

#### Ephemeral storage without storage definition
```
apiVersion: "logging.openshift.io/v1"
kind: "ClusterLogging"
metadata:
  name: "instance"
  namespace: "openshift-logging"
spec:
  managementState: "Managed"
  logStore:
    type: "elasticsearch"
    elasticsearch: # <---- Ephemeral storage without storage definition
      nodeCount: 1
      redundancyPolicy: "ZeroRedundancy"
```

/cc @blockloop 
/assign @ewolinetz 
 
### Links
- JIRA:  https://issues.redhat.com/browse/LOG-918
