### PR TITLE
Bug 1886856: Increase es proxy default memory resources to 256Mi

### DIFF
--- a/pkg/k8shandler/common_test.go
+++ b/pkg/k8shandler/common_test.go
@@ -366,7 +366,7 @@ func TestResourcesCommonResourceAndNodeLimitDefined(t *testing.T) {
 func TestProxyContainerResourcesDefined(t *testing.T) {
 
 	expectedCPU := resource.MustParse("100m")
-	expectedMemory := resource.MustParse("64Mi")
+	expectedMemory := resource.MustParse("256Mi")
 
 	empty := v1.ResourceRequirements{}
 	proxyResources := newESProxyResourceRequirements(empty, empty)

--- a/pkg/k8shandler/defaults.go
+++ b/pkg/k8shandler/defaults.go
@@ -17,8 +17,8 @@ const (
 	defaultESMemoryRequest = "1Gi"
 	// ESProxy
 	defaultESProxyCpuRequest    = "100m"
-	defaultESProxyMemoryLimit   = "64Mi"
-	defaultESProxyMemoryRequest = "64Mi"
+	defaultESProxyMemoryLimit   = "256Mi"
+	defaultESProxyMemoryRequest = "256Mi"
 
 	maxMasterCount       = 3
 	maxPrimaryShardCount = 5


### PR DESCRIPTION
### Description
The current default memory requests and limits for elasticsearch-proxy are set to 64Mi. This is a too tight budget according to metrics (see below):

![image](https://user-images.githubusercontent.com/152312/95596072-38678500-0a4d-11eb-96b7-3fcf02959260.png)

In turn this results into container restarts that have impact on serving elasticsearch requests reliably. This PR addresses this issue by bumping the elasticsearch-proxy request/limits from `64Mi` to `256Mi`
 
/cc @blockloop 
/assign @ewolinetz 
 
/cherry-pick release-4.6
 
### Links
- Bugzilla:  https://bugzilla.redhat.com/show_bug.cgi?id=1886856
