### PR TITLE
Bug 1883719: Bulk statistics are recorded under write threadpool

### DIFF
--- a/files/prometheus_alerts.yml
+++ b/files/prometheus_alerts.yml
@@ -22,12 +22,12 @@
     "labels":
       "severity": "warning"
 
-  - "alert": "ElasticsearchIndexingRequestsRejectionJumps"
+  - "alert": "ElasticsearchWriteRequestsRejectionJumps"
     "annotations":
-      "message": "High Indexing Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster }} cluster. This node may not be keeping up with the indexing speed."
-      "summary": "High Indexing Rejection Ratio - {{ $value }}%"
+      "message": "High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster }} cluster. This node may not be keeping up with the indexing speed."
+      "summary": "High Write Rejection Ratio - {{ $value }}%"
     "expr": |
-      round( indexing:reject_ratio:rate2m * 100, 0.001 ) > 5
+      round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
     "for": "10m"
     "labels":
       "severity": "warning"

--- a/files/prometheus_rules.yml
+++ b/files/prometheus_rules.yml
@@ -3,11 +3,11 @@
 - "name": "logging_elasticsearch.rules"
   "rules":
   - "expr": |
-      rate(es_threadpool_threads_count{name="index", type="rejected"}[2m])
-    "record": "indexing:rejected_requests:rate2m"
+      rate(es_threadpool_threads_count{name="write", type="rejected"}[2m])
+    "record": "writing:rejected_requests:rate2m"
   - "expr": |
-      rate(es_threadpool_threads_count{name="index", type="completed"}[2m])
-    "record": "indexing:completed_requests:rate2m"
+      rate(es_threadpool_threads_count{name="write", type="completed"}[2m])
+    "record": "writing:completed_requests:rate2m"
   - "expr": |
-      sum by (cluster, instance, node) (indexing:rejected_requests:rate2m) / on (cluster, instance, node) (indexing:completed_requests:rate2m)
-    "record": "indexing:reject_ratio:rate2m"
+      sum by (cluster, instance, node) (writing:rejected_requests:rate2m) / on (cluster, instance, node) (writing:completed_requests:rate2m)
+    "record": "writing:reject_ratio:rate2m"


### PR DESCRIPTION
Bulk threadpool was renamed to write. See elastic/elasticsearch#29593

https://bugzilla.redhat.com/show_bug.cgi?id=1883719

Fix of https://github.com/openshift/elasticsearch-operator/pull/511

/cc @blockloop