### PR TITLE
Examples: Allow deployment of es example in a different namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ RUN_LOG?=elasticsearch-operator.log
 RUN_PID?=elasticsearch-operator.pid
 LOGGING_IMAGE_STREAM?=stable
 OPERATOR_NAMESPACE=openshift-operators-redhat
-DEPLOYMENT_NAMESPACE=openshift-logging
+DEPLOYMENT_NAMESPACE?=openshift-logging
 REPLICAS?=0
 OS_NAME=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 

--- a/bundle/manifests/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
@@ -50,7 +50,7 @@ metadata:
                       }
                     }
                   },
-                  "redundancyPolicy": "SingleRedundancy",
+                  "redundancyPolicy": "ZeroRedundancy",
                   "nodes": [
                     {
                         "nodeCount": 1,

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -91,7 +91,9 @@ Deploy the resources for the operator, build the operator image, push the image 
 Deploy the pre-requirements for the operator to function (i.e. CRD, RBAC, sample secret)
 
 ### deploy-example
-Deploy an example custom resource for a single node Elasticsearch cluster
+Install the operator and deploy an example custom resource for a single node
+Elasticsearch cluster in the default namespace `openshift-logging`. To deploy
+in a different namespace: `DEPLOYMENT_NAMESPACE=newproject make deploy-example`.
 
 ### elasticsearch-cleanup
 Remove all deployed resources


### PR DESCRIPTION
- the openshif-logging space may be unavailable