### PR TITLE
LOG-967: Add service monitor endpoint for es-proxy prometheus metrics

### DIFF
--- a/pkg/k8shandler/service_monitor.go
+++ b/pkg/k8shandler/service_monitor.go
@@ -46,7 +46,14 @@ func createServiceMonitor(serviceMonitorName, clusterName, namespace string, lab
 		ServerName: fmt.Sprintf("%s-%s.%s.svc", clusterName, "metrics", namespace),
 		// ServerName can be e.g. elasticsearch-metrics.openshift-logging.svc
 	}
-	endpoint := monitoringv1.Endpoint{
+	proxy := monitoringv1.Endpoint{
+		Port:            clusterName,
+		Path:            "/metrics",
+		Scheme:          "https",
+		BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+		TLSConfig:       &tlsConfig,
+	}
+	elasticsearch := monitoringv1.Endpoint{
 		Port:            clusterName,
 		Path:            "/_prometheus/metrics",
 		Scheme:          "https",
@@ -55,7 +62,7 @@ func createServiceMonitor(serviceMonitorName, clusterName, namespace string, lab
 	}
 	svcMonitor.Spec = monitoringv1.ServiceMonitorSpec{
 		JobLabel:  "monitor-elasticsearch",
-		Endpoints: []monitoringv1.Endpoint{endpoint},
+		Endpoints: []monitoringv1.Endpoint{proxy, elasticsearch},
 		Selector:  labelSelector,
 		NamespaceSelector: monitoringv1.NamespaceSelector{
 			MatchNames: []string{namespace},


### PR DESCRIPTION
### Description
This PR exposes the new es-proxy prometheus metrics endpoint to allow collection of these metrics by cluster-monitoring.
 
/cc @blockloop   
/assign @ewolinetz 
 
### Links
- Depending on PR(s):  openshift/elasticsearch-proxy#56
