### PR TITLE
Add GH pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+### Description
+<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
+
+/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
+/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->
+
+/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->
+
+### Links
+<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
+- Depending on PR(s):
+- Bugzilla:
+- Github issue:
+- JIRA:
+- Enhancement proposal:


### PR DESCRIPTION
### Description
This PR addresses the missing PR template for this repository to ease compliance with this repo's code review guidelines.
 
/cc @blockloop  
/assign @ewolinetz  