### PR TITLE
Reduce the footprint of the elasticsearch-operator-registry image

### DIFF
--- a/olm_deploy/operatorregistry/Dockerfile
+++ b/olm_deploy/operatorregistry/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/operator-framework/upstream-registry-builder AS registry-builder
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 WORKDIR /
 COPY manifests/ /manifests


### PR DESCRIPTION
### Description

This PR reduces the size of the elasticsearch-operator-registry image from 1.1 GB to 333 MB:

#### Before
```
$ podman image tree 127.0.0.1:5000/openshift/elasticsearch-operator-registry
Image ID: ed583fbe15c6
Tags:     [127.0.0.1:5000/openshift/elasticsearch-operator-registry:latest]
Size:     1.119GB
Image Layers
├──  ID: 613be09ab3c0 Size: 211.1MB
├──  ID: eb6dbe2d0eaa Size:   841MB Top Layer of: [registry.svc.ci.openshift.org/openshift/release:golang-1.12]
├──  ID: 48dd41eb413f Size: 70.66kB
├──  ID: ccb1fb4e4382 Size:  7.68kB
├──  ID: a272bb660edd Size: 4.096kB
├──  ID: 7454f954ce69 Size: 27.92MB
├──  ID: 321bfd15172e Size: 28.65MB
└──  ID: 363c3d1548ad Size:  9.93MB Top Layer of: [127.0.0.1:5000/openshift/elasticsearch-operator-registry:latest]
```

#### After

```
$ podman image tree 127.0.0.1:5000/openshift/elasticsearch-operator-registry
Image ID: ad4d83f63cb2
Tags:     [127.0.0.1:5000/openshift/elasticsearch-operator-registry:latest]
Size:     332.5MB
Image Layers
├──  ID: 226bfaae015f Size: 210.9MB
├──  ID: 1da86dd5dbd9 Size: 20.48kB
├──  ID: 186cc8c306d7 Size: 17.81MB
├──  ID: 91485e999e6c Size: 1.701MB
├──  ID: 87c57e253743 Size: 35.48MB Top Layer of: [registry.svc.ci.openshift.org/ocp/4.7:base]
├──  ID: dbc5c5f302c3 Size: 70.66kB
├──  ID: 71e067048eb1 Size: 6.656kB
├──  ID: 6f18b5fc604f Size: 4.096kB
├──  ID: 214d1833ac3c Size: 27.92MB
├──  ID: e1ceccf7d801 Size: 28.65MB
└──  ID: b1cb501be8db Size:  9.93MB Top Layer of: [127.0.0.1:5000/openshift/elasticsearch-operator-registry:latest]
```

/cc vimalk78
/assign ewolinetz