### PR TITLE
Bug 1890825: watch route deletion in kibana controller

### DIFF
--- a/pkg/controller/kibana/controller.go
+++ b/pkg/controller/kibana/controller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	loggingv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
 	"github.com/openshift/elasticsearch-operator/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
@@ -101,6 +102,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Watch for changes to the kibana pod
 	podPred := predicate.Funcs{
 		UpdateFunc:  func(e event.UpdateEvent) bool { return handlePod(e.MetaNew) },
 		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
@@ -108,6 +110,20 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
 	if err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &namespacedMapHandler, podPred); err != nil {
+		return err
+	}
+
+	// Watch for updates to the route
+	routePred := predicate.Funcs{
+		UpdateFunc:  func(e event.UpdateEvent) bool { return true },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
+		CreateFunc:  func(e event.CreateEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+	if err = c.Watch(&source.Kind{Type: &routev1.Route{}}, &handler.EnqueueRequestForOwner{
+		OwnerType:    &loggingv1.Kibana{},
+		IsController: true,
+	}, routePred); err != nil {
 		return err
 	}
 

--- a/test/e2e-olm/utils.go
+++ b/test/e2e-olm/utils.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ViaQ/logerr/kverrors"
 	consolev1 "github.com/openshift/api/console/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	loggingv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
 	"github.com/openshift/elasticsearch-operator/test/utils"
 
@@ -49,6 +50,12 @@ func registerSchemes(t *testing.T) {
 
 	consoleLinkList := &consolev1.ConsoleLinkList{}
 	err = test.AddToFrameworkScheme(consolev1.Install, consoleLinkList)
+	if err != nil {
+		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
+	}
+
+	routeList := &routev1.RouteList{}
+	err = test.AddToFrameworkScheme(routev1.Install, routeList)
 	if err != nil {
 		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
 	}


### PR DESCRIPTION
- fix unrecovered kibana route after being deleted
  by Adding watch event for route and enqueue for the owner

- add a test case to e2e test

### Description

- fix unrecovered kibana route after being deleted

/cc @jcantrill 
/assign @ewolinetz @blockloop 
/cherry-pick 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1890825