### PR TITLE
Bug 1891019: Adding logic to recover from crashloopbackoff for ES pods

### DIFF
--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -257,7 +257,8 @@ func progressUnshedulableNodes(cluster *api.Elasticsearch) {
 
 	for _, nodeStatus := range cluster.Status.Nodes {
 		if isPodUnschedulableConditionTrue(nodeStatus.Conditions) ||
-			isPodImagePullBackOff(nodeStatus.Conditions) {
+			isPodImagePullBackOff(nodeStatus.Conditions) ||
+			isPodCrashLoopBackOff(nodeStatus.Conditions) {
 
 			for _, node := range clusterNodes {
 				if nodeStatus.DeploymentName == node.name() || nodeStatus.StatefulSetName == node.name() {

--- a/pkg/k8shandler/status.go
+++ b/pkg/k8shandler/status.go
@@ -626,6 +626,11 @@ func isPodImagePullBackOff(conditions []api.ClusterCondition) bool {
 	return condition != nil && condition.Status == v1.ConditionTrue
 }
 
+func isPodCrashLoopBackOff(conditions []api.ClusterCondition) bool {
+	condition := getESNodeConditionWithReason(conditions, api.ESContainerWaiting, "CrashLoopBackOff")
+	return condition != nil && condition.Status == v1.ConditionTrue
+}
+
 func getESNodeCondition(conditions []api.ClusterCondition, conditionType api.ClusterConditionType) (int, *api.ClusterCondition) {
 	if conditions == nil {
 		return -1, nil


### PR DESCRIPTION
### Description
Adding crashloopbackoff to list of conditions for unschedulable nodes.
Cherry-picking logic that originally was introduced in https://github.com/openshift/elasticsearch-operator/pull/400

/cc @blockloop @periklis 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1891019
