### PR TITLE
LOG-951: Replace alpha svc annotation with beta

### DIFF
--- a/pkg/k8shandler/service.go
+++ b/pkg/k8shandler/service.go
@@ -57,7 +57,7 @@ func (er *ElasticsearchRequest) CreateOrUpdateServices() error {
 	}
 
 	// legacy metrics service that likely can be rolled into the single service that goes through the proxy
-	annotations["service.alpha.openshift.io/serving-cert-secret-name"] = fmt.Sprintf("%s-%s", dpl.Name, "metrics")
+	annotations["service.beta.openshift.io/serving-cert-secret-name"] = fmt.Sprintf("%s-%s", dpl.Name, "metrics")
 	err = er.createOrUpdateService(
 		fmt.Sprintf("%s-%s", dpl.Name, "metrics"),
 		dpl.Namespace,
@@ -122,6 +122,7 @@ func (er *ElasticsearchRequest) createOrUpdateService(serviceName, namespace, cl
 		current.Spec.Selector = service.Spec.Selector
 		current.Spec.PublishNotReadyAddresses = service.Spec.PublishNotReadyAddresses
 		current.Labels = service.Labels
+		current.Annotations = service.Annotations
 		if err = client.Update(context.TODO(), current); err != nil {
 			return err
 		}

--- a/pkg/k8shandler/service_test.go
+++ b/pkg/k8shandler/service_test.go
@@ -1,0 +1,383 @@
+package k8shandler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	loggingv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestCreateOrUpdateServices(t *testing.T) {
+	isControlled := true
+
+	tests := []struct {
+		desc    string
+		cluster *loggingv1.Elasticsearch
+		objs    []runtime.Object
+		wantSvc map[string]*corev1.Service
+		wantErr bool
+	}{
+		{
+			desc: "create services",
+			cluster: &loggingv1.Elasticsearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "elasticsearch",
+					Namespace: "openshift-logging",
+				},
+			},
+			wantSvc: map[string]*corev1.Service{
+				"elasticsearch-cluster": {
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "elasticsearch-cluster",
+						Namespace:       "openshift-logging",
+						ResourceVersion: "1",
+						Labels:          map[string]string{"cluster-name": "elasticsearch"},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "logging.openshift.io/v1",
+								Kind:       "Elasticsearch",
+								Name:       "elasticsearch",
+								Controller: &isControlled,
+							},
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "elasticsearch",
+								Protocol:   corev1.ProtocolTCP,
+								Port:       9300,
+								TargetPort: intstr.IntOrString{Type: 1, StrVal: "cluster"},
+							},
+						},
+						Selector: map[string]string{
+							"cluster-name":   "elasticsearch",
+							"es-node-master": "true",
+						},
+						PublishNotReadyAddresses: true,
+					},
+				},
+				"elasticsearch": {
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "elasticsearch",
+						Namespace:       "openshift-logging",
+						ResourceVersion: "1",
+						Labels:          map[string]string{"cluster-name": "elasticsearch"},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "logging.openshift.io/v1",
+								Kind:       "Elasticsearch",
+								Name:       "elasticsearch",
+								Controller: &isControlled,
+							},
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "elasticsearch",
+								Protocol:   corev1.ProtocolTCP,
+								Port:       9200,
+								TargetPort: intstr.IntOrString{Type: 1, StrVal: "restapi"},
+							},
+						},
+						Selector: map[string]string{
+							"cluster-name":   "elasticsearch",
+							"es-node-client": "true",
+						},
+					},
+				},
+				"elasticsearch-metrics": {
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "elasticsearch-metrics",
+						Namespace:       "openshift-logging",
+						ResourceVersion: "1",
+						Annotations: map[string]string{
+							"service.beta.openshift.io/serving-cert-secret-name": "elasticsearch-metrics",
+						},
+						Labels: map[string]string{
+							"cluster-name":   "elasticsearch",
+							"scrape-metrics": "enabled",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "logging.openshift.io/v1",
+								Kind:       "Elasticsearch",
+								Name:       "elasticsearch",
+								Controller: &isControlled,
+							},
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "elasticsearch",
+								Protocol:   corev1.ProtocolTCP,
+								Port:       60001,
+								TargetPort: intstr.IntOrString{Type: 1, StrVal: "metrics"},
+							},
+						},
+						Selector: map[string]string{
+							"cluster-name":   "elasticsearch",
+							"es-node-client": "true",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "update services",
+			cluster: &loggingv1.Elasticsearch{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "elasticsearch",
+					Namespace: "openshift-logging",
+				},
+			},
+			objs: []runtime.Object{
+				&corev1.Service{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "elasticsearch-metrics",
+						Namespace:       "openshift-logging",
+						ResourceVersion: "1",
+						Annotations: map[string]string{
+							"service.alpha.openshift.io/serving-cert-secret-name": "elasticsearch-metrics",
+						},
+						Labels: map[string]string{
+							"cluster-name":   "elasticsearch",
+							"scrape-metrics": "enabled",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "logging.openshift.io/v1",
+								Kind:       "Elasticsearch",
+								Name:       "elasticsearch",
+								Controller: &isControlled,
+							},
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "elasticsearch",
+								Protocol:   corev1.ProtocolTCP,
+								Port:       60001,
+								TargetPort: intstr.IntOrString{Type: 1, StrVal: "metrics"},
+							},
+						},
+						Selector: map[string]string{
+							"cluster-name":   "elasticsearch",
+							"es-node-client": "true",
+						},
+					},
+				},
+			},
+			wantSvc: map[string]*corev1.Service{
+				"elasticsearch-cluster": {
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "elasticsearch-cluster",
+						Namespace:       "openshift-logging",
+						ResourceVersion: "1",
+						Labels:          map[string]string{"cluster-name": "elasticsearch"},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "logging.openshift.io/v1",
+								Kind:       "Elasticsearch",
+								Name:       "elasticsearch",
+								Controller: &isControlled,
+							},
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "elasticsearch",
+								Protocol:   corev1.ProtocolTCP,
+								Port:       9300,
+								TargetPort: intstr.IntOrString{Type: 1, StrVal: "cluster"},
+							},
+						},
+						Selector: map[string]string{
+							"cluster-name":   "elasticsearch",
+							"es-node-master": "true",
+						},
+						PublishNotReadyAddresses: true,
+					},
+				},
+				"elasticsearch": {
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "elasticsearch",
+						Namespace:       "openshift-logging",
+						ResourceVersion: "1",
+						Labels:          map[string]string{"cluster-name": "elasticsearch"},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "logging.openshift.io/v1",
+								Kind:       "Elasticsearch",
+								Name:       "elasticsearch",
+								Controller: &isControlled,
+							},
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "elasticsearch",
+								Protocol:   corev1.ProtocolTCP,
+								Port:       9200,
+								TargetPort: intstr.IntOrString{Type: 1, StrVal: "restapi"},
+							},
+						},
+						Selector: map[string]string{
+							"cluster-name":   "elasticsearch",
+							"es-node-client": "true",
+						},
+					},
+				},
+				"elasticsearch-metrics": {
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "elasticsearch-metrics",
+						Namespace:       "openshift-logging",
+						ResourceVersion: "2",
+						Annotations: map[string]string{
+							"service.beta.openshift.io/serving-cert-secret-name": "elasticsearch-metrics",
+						},
+						Labels: map[string]string{
+							"cluster-name":   "elasticsearch",
+							"scrape-metrics": "enabled",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "logging.openshift.io/v1",
+								Kind:       "Elasticsearch",
+								Name:       "elasticsearch",
+								Controller: &isControlled,
+							},
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "elasticsearch",
+								Protocol:   corev1.ProtocolTCP,
+								Port:       60001,
+								TargetPort: intstr.IntOrString{Type: 1, StrVal: "metrics"},
+							},
+						},
+						Selector: map[string]string{
+							"cluster-name":   "elasticsearch",
+							"es-node-client": "true",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			client := fake.NewFakeClient(test.objs...)
+
+			req := &ElasticsearchRequest{
+				client:  client,
+				cluster: test.cluster,
+				ll:      log.Log.WithValues("cluster", "test-elasticsearch", "namespace", "test"),
+			}
+
+			err := req.CreateOrUpdateServices()
+			if test.wantErr && err == nil {
+				t.Error("missing error")
+			}
+
+			// Get elasticsearch-cluster SVC
+			key := types.NamespacedName{
+				Name:      "elasticsearch-cluster",
+				Namespace: test.cluster.GetNamespace(),
+			}
+			got := &corev1.Service{}
+
+			err = client.Get(context.TODO(), key, got)
+			if err != nil {
+				t.Errorf("failed with error: %s", err)
+			}
+
+			want := test.wantSvc["elasticsearch-cluster"]
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("diff: %s", diff)
+			}
+
+			// Get elasticsearch SVC
+			key = types.NamespacedName{
+				Name:      test.cluster.GetName(),
+				Namespace: test.cluster.GetNamespace(),
+			}
+			got = &corev1.Service{}
+
+			err = client.Get(context.TODO(), key, got)
+			if err != nil {
+				t.Errorf("failed with error: %s", err)
+			}
+
+			want = test.wantSvc["elasticsearch"]
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("diff: %s", diff)
+			}
+
+			// Get elasticsearch SVC
+			key = types.NamespacedName{
+				Name:      "elasticsearch-metrics",
+				Namespace: test.cluster.GetNamespace(),
+			}
+			got = &corev1.Service{}
+
+			err = client.Get(context.TODO(), key, got)
+			if err != nil {
+				t.Errorf("failed with error: %s", err)
+			}
+
+			want = test.wantSvc["elasticsearch-metrics"]
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("diff: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
This PR addresses a switch from the alpha to beta annotation of `service.beta.openshift.io/serving-cert-secret-name`. This annotation serves for injecting the prometheus CA certificate for the annotated service resource.

/cc @blockloop 
/assign @ewolinetz 

### Links

- JIRA: https://issues.redhat.com/browse/LOG-951
