### PR TITLE
Remove fmt from make build because it breaks ART

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ regenerate: $(OPERATOR_SDK)
 	@rm -f $(GEN_TIMESTAMP)
 	@$(MAKE) generate
 
-build: fmt
+build:
 	@go build -o $(GOBIN)/elasticsearch-operator $(MAIN_PKG)
 
 clean:


### PR DESCRIPTION
Remove fmt from make build because it breaks ART

/cc @periklis 
/assign @jcantrill 
