### PR TITLE
Enable coverage html for prow CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ image:
 test-unit: $(GO_JUNIT_REPORT) coveragedir junitreportdir test-unit-prom
 	@go test -v -race -coverprofile=$(COVERAGE_DIR)/test-unit.cov ./pkg/... ./cmd/... 2>&1 | $(GO_JUNIT_REPORT) > $(JUNIT_REPORT_OUTPUT_DIR)/junit.xml
 	@grep -v 'zz_generated\.' $(COVERAGE_DIR)/test-unit.cov > $(COVERAGE_DIR)/nogen.cov
-	@go tool cover -html=$(COVERAGE_DIR)/nogen.cov -o $(COVERAGE_DIR)/test-unit-coverage.html
+	@go tool cover -html=$(COVERAGE_DIR)/nogen.cov -o $(COVERAGE_DIR)/coverage.html
 	@go tool cover -func=$(COVERAGE_DIR)/nogen.cov | tail -n 1
 
 test-unit-prom: $(PROMTOOL)


### PR DESCRIPTION
### Description
This PR enables the converage information to show up in Prow CI. It is a followup of openshift/release#13420

/cc @blockloop 
/assign @ewolinetz 
