### PR TITLE
[release-4.6] Bug 1885667: Updating index template logic to cap primary shards

### DIFF
--- a/pkg/k8shandler/index_management.go
+++ b/pkg/k8shandler/index_management.go
@@ -102,7 +102,7 @@ func (er *ElasticsearchRequest) initializeIndexIfNeeded(mapping logging.IndexMan
 	}
 	if len(indices) < 1 {
 		indexName := fmt.Sprintf("%s-000001", mapping.Name)
-		primaryShards := getDataCount(cluster)
+		primaryShards := int32(calculatePrimaryCount(cluster))
 		replicas := int32(calculateReplicaCount(cluster))
 		index := esapi.NewIndex(indexName, primaryShards, replicas)
 		index.AddAlias(mapping.Name, false)
@@ -129,7 +129,7 @@ func (er *ElasticsearchRequest) createOrUpdateIndexTemplate(mapping logging.Inde
 
 	name := formatTemplateName(mapping.Name)
 	pattern := fmt.Sprintf("%s*", mapping.Name)
-	primaryShards := getDataCount(cluster)
+	primaryShards := int32(calculatePrimaryCount(cluster))
 	replicas := int32(calculateReplicaCount(cluster))
 	aliases := append(mapping.Aliases, mapping.Name)
 	template := esapi.NewIndexTemplate(pattern, aliases, primaryShards, replicas)


### PR DESCRIPTION
### Description
Updating index template logic to correctly use function to calculate primary shards instead of just counting data nodes

Manual cherrypick of https://github.com/openshift/elasticsearch-operator/pull/574

/cc @blockloop 
/assign @jcantrill 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1885667