### PR TITLE
Bug 1899589: Updating CRD to make storage size required if storage is provided

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,13 +82,14 @@ image:
 	fi
 
 test-unit: $(GO_JUNIT_REPORT) coveragedir junitreportdir test-unit-prom
-	@go test -v -race -coverprofile=$(COVERAGE_DIR)/test-unit.cov ./pkg/... ./cmd/... 2>&1 | $(GO_JUNIT_REPORT) > $(JUNIT_REPORT_OUTPUT_DIR)/junit.xml
+	@go test -v -race -coverprofile=$(COVERAGE_DIR)/test-unit.cov ./pkg/... ./cmd/... 2>&1 | tee /dev/stderr | $(GO_JUNIT_REPORT) > $(JUNIT_REPORT_OUTPUT_DIR)/junit.xml
 	@grep -v 'zz_generated\.' $(COVERAGE_DIR)/test-unit.cov > $(COVERAGE_DIR)/nogen.cov
 	@go tool cover -html=$(COVERAGE_DIR)/nogen.cov -o $(COVERAGE_DIR)/test-unit-coverage.html
 	@go tool cover -func=$(COVERAGE_DIR)/nogen.cov | tail -n 1
 
 test-unit-prom: $(PROMTOOL)
 	@$(PROMTOOL) test rules ./test/files/prometheus-unit-tests/test.yml
+
 
 deploy: deploy-image
 	LOCAL_IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY=127.0.0.1:5000/openshift/elasticsearch-operator-registry \

--- a/pkg/k8shandler/common.go
+++ b/pkg/k8shandler/common.go
@@ -584,6 +584,14 @@ func newVolumeSource(clusterName, nodeName, namespace string, node api.Elasticse
 		return volSource
 	}
 
+	// in the case where we do not have a size provided we need to
+	// fall back to using ephemeral storage since a pvc requires a size
+	if specVol.Size == nil {
+		log.Info("Storage size is required but was missing. Defaulting to EmptyDirVolume. Please adjust your CR accordingly.")
+		volSource.EmptyDir = &v1.EmptyDirVolumeSource{}
+		return volSource
+	}
+
 	// Persistent storage
 	claimName := fmt.Sprintf("%s-%s", clusterName, nodeName)
 	volSource.PersistentVolumeClaim = &v1.PersistentVolumeClaimVolumeSource{

--- a/pkg/k8shandler/common_test.go
+++ b/pkg/k8shandler/common_test.go
@@ -736,6 +736,17 @@ func TestNewVolumeSource(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "persistent storage without storage size",
+			node: api.ElasticsearchNode{
+				Storage: api.ElasticsearchStorageSpec{
+					StorageClassName: &gp2SCName,
+				},
+			},
+			vs: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{},
+			},
+		},
 	}
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
### Description
The size field for logging storage should have been marked as required, if we did not provide it we would receive a panic from a null pointer. This PR seeks to make it required at the CRD level, as well as have fall back in the event cr creation/update makes it past CRD validation.

/cc @blockloop @periklis

/cherry-pick release-4.6

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1899589