### PR TITLE
Bug 1898572: Restricting console links to clusterlogging operator use case

### DIFF
--- a/test/e2e-olm/kibana_test.go
+++ b/test/e2e-olm/kibana_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/elasticsearch-operator/pkg/k8shandler/kibana"
 	"github.com/openshift/elasticsearch-operator/test/utils"
@@ -83,13 +82,6 @@ func KibanaDeployment(t *testing.T) {
 		t.Errorf("timed out waiting for Deployment kibana: %v", err)
 	}
 
-	consoleLink := &consolev1.ConsoleLink{}
-	key := types.NamespacedName{Name: kibana.KibanaConsoleLinkName}
-	err = waitForObject(t, f.Client, key, consoleLink, retryInterval, timeout)
-	if err != nil {
-		t.Errorf("Kibana console link missing: %v", err)
-	}
-
 	// Test recovering route after deletion
 	name := "kibana"
 	routeInst := kibana.NewRoute(name, namespace, name)
@@ -99,7 +91,7 @@ func KibanaDeployment(t *testing.T) {
 	}
 
 	route := &routev1.Route{}
-	key = types.NamespacedName{Name: name, Namespace: namespace}
+	key := types.NamespacedName{Name: name, Namespace: namespace}
 	err = waitForObject(t, f.Client, key, route, retryInterval, timeout)
 	if err != nil {
 		t.Errorf("Kibana route not recovered: %v", err)


### PR DESCRIPTION
### Description
Currently it is possible for a `kibana` resource that is created by a developer in a non `openshift-logging` namespace to cause the console links to be recreated based on this new CR. Likewise, when this `kibana` resource is removed we lose the `openshift-logging` console links.

This PR seeks to restrict the creation of these to just the ClusterLogging use case (since that use case is what provides fluentd and log aggregation for the cluster).

/cc @blockloop @periklis @lukas-vlcek 

/cherry-pick release-4.6

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1898572