### PR TITLE
Bug 1898572: Fix kibana unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,10 @@ image:
 	fi
 
 test-unit: $(GO_JUNIT_REPORT) coveragedir junitreportdir test-unit-prom
-	@go test -v -race -coverprofile=$(COVERAGE_DIR)/test-unit.cov ./pkg/... ./cmd/... 2>&1 | tee /dev/stderr | $(GO_JUNIT_REPORT) > $(JUNIT_REPORT_OUTPUT_DIR)/junit.xml
+	@set -o pipefail && \
+		go test -v -race -coverprofile=$(COVERAGE_DIR)/test-unit.cov ./pkg/... ./cmd/... 2>&1 | \
+		tee /dev/stderr | \
+		$(GO_JUNIT_REPORT) > $(JUNIT_REPORT_OUTPUT_DIR)/junit.xml
 	@grep -v 'zz_generated\.' $(COVERAGE_DIR)/test-unit.cov > $(COVERAGE_DIR)/nogen.cov
 	@go tool cover -html=$(COVERAGE_DIR)/nogen.cov -o $(COVERAGE_DIR)/test-unit-coverage.html
 	@go tool cover -func=$(COVERAGE_DIR)/nogen.cov | tail -n 1

--- a/pkg/k8shandler/kibana/kibana_test.go
+++ b/pkg/k8shandler/kibana/kibana_test.go
@@ -35,6 +35,12 @@ var _ = Describe("Reconciling", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kibana",
 				Namespace: "test-namespace",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: expectedCLOKind,
+						Name: expectedCLOName,
+					},
+				},
 			},
 			Spec: loggingv1.KibanaSpec{
 				ManagementState: loggingv1.ManagementStateManaged,


### PR DESCRIPTION
### Description
This PR provides a small fix for the broken kibana/consolelink unit tests. The unit tests did not report failure because of the missing `pipefail` setting.

/cc @huikang 
/assign @ewolinetz 

### Links
- Bugzilla:
