### PR TITLE
[release-4.6] Bug 1902768: Restricting console links to clusterlogging operator use case

### DIFF
--- a/pkg/k8shandler/kibana/kibana_test.go
+++ b/pkg/k8shandler/kibana/kibana_test.go
@@ -35,6 +35,12 @@ var _ = Describe("Reconciling", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kibana",
 				Namespace: "test-namespace",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: expectedCLOKind,
+						Name: expectedCLOName,
+					},
+				},
 			},
 			Spec: loggingv1.KibanaSpec{
 				ManagementState: loggingv1.ManagementStateManaged,

--- a/pkg/k8shandler/kibana/reconciler.go
+++ b/pkg/k8shandler/kibana/reconciler.go
@@ -30,6 +30,10 @@ const (
 	kibanaOAuthRedirectReference = "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"kibana\"}}"
 	kibana5Index                 = ".kibana"
 	kibana6Index                 = ".kibana-6"
+	expectedCLOKind              = "ClusterLogging"
+	expectedCLOName              = "instance"
+	expectedCLOKibana            = "kibana"
+	expectedCLONamespace         = "openshift-logging"
 )
 
 var (
@@ -68,12 +72,17 @@ func Reconcile(requestCluster *kibana.Kibana, requestClient client.Client, esCli
 		return err
 	}
 
-	if err := clusterKibanaRequest.createOrUpdateKibanaConsoleExternalLogLink(); err != nil {
-		return err
-	}
+	// we only want to create these if the use case is the CLO one
+	// make sure our namespace is "openshift-logging" and our cr name is "kibana"
+	// or do we just check that our owner ref is from a cluster logging object?
+	if clusterKibanaRequest.isCLOUseCase() {
+		if err := clusterKibanaRequest.createOrUpdateKibanaConsoleExternalLogLink(); err != nil {
+			return err
+		}
 
-	if err := clusterKibanaRequest.createOrUpdateKibanaConsoleLink(); err != nil {
-		return err
+		if err := clusterKibanaRequest.createOrUpdateKibanaConsoleLink(); err != nil {
+			return err
+		}
 	}
 
 	if err := clusterKibanaRequest.deleteKibana5Deployment(); err != nil {
@@ -181,6 +190,27 @@ func (clusterRequest *KibanaRequest) deleteKibana5Deployment() error {
 		return fmt.Errorf("failed to delete kibana 5 deployment: %s", err)
 	}
 	return nil
+}
+
+func (clusterRequest *KibanaRequest) isCLOUseCase() bool {
+
+	kibanaCR := clusterRequest.cluster
+
+	if kibanaCR.OwnerReferences != nil {
+		// also check for the owner ref being clusterlogging/instance
+		for _, ref := range kibanaCR.OwnerReferences {
+			if ref.Kind == expectedCLOKind && ref.Name == expectedCLOName {
+				return true
+			}
+		}
+	}
+
+	// this is a secondary check to allow for stand-alone EO testing to work
+	if kibanaCR.Name == expectedCLOKibana && kibanaCR.Namespace == expectedCLONamespace {
+		return true
+	}
+
+	return false
 }
 
 func (clusterRequest *KibanaRequest) createOrUpdateKibanaDeployment(proxyConfig *configv1.Proxy, clusterName string) (err error) {

--- a/test/e2e-olm/kibana_test.go
+++ b/test/e2e-olm/kibana_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	consolev1 "github.com/openshift/api/console/v1"
-	"github.com/openshift/elasticsearch-operator/pkg/k8shandler/kibana"
 	"github.com/openshift/elasticsearch-operator/test/utils"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
@@ -80,13 +78,6 @@ func KibanaDeployment(t *testing.T) {
 	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, kibanaCRName, 1, retryInterval, timeout)
 	if err != nil {
 		t.Errorf("timed out waiting for Deployment kibana: %v", err)
-	}
-
-	consoleLink := &consolev1.ConsoleLink{}
-	key := types.NamespacedName{Name: kibana.KibanaConsoleLinkName}
-	err = waitForObject(t, f.Client, key, consoleLink, retryInterval, timeout)
-	if err != nil {
-		t.Errorf("Kibana console link missing: %v", err)
 	}
 
 	ctx.Cleanup()


### PR DESCRIPTION
### Description
Manual cherry-pick of
* https://github.com/openshift/elasticsearch-operator/pull/581
* https://github.com/openshift/elasticsearch-operator/pull/587

/cc @blockloop @periklis 

/cherry-pick release-4.5

### Links
- Depending on PR(s): 
  https://github.com/openshift/elasticsearch-operator/pull/581
  https://github.com/openshift/elasticsearch-operator/pull/587
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1902768