### PR TITLE
LOG-970: use centos as base image for docker

### DIFF
--- a/Dockerfile.centos.patch
+++ b/Dockerfile.centos.patch
@@ -1,0 +1,14 @@
+--- Dockerfile	2020-10-29 16:22:29.934746321 -0500
++++ Dockerfile.dev	2020-12-08 09:27:06.209552623 -0600
+@@ -1,9 +1,9 @@
+-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
++FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
+ WORKDIR /go/src/github.com/openshift/elasticsearch-operator
+ COPY . .
+ RUN make build
+ 
+-FROM registry.svc.ci.openshift.org/ocp/4.7:base
++FROM docker.io/centos:8 AS centos
+ 
+ ENV ALERTS_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_alerts.yml"
+ ENV RULES_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_rules.yml"

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,12 @@ lint-prom: $(PROMTOOL)
 	@$(PROMTOOL) check rules ./files/prometheus_rules.yml
 	@$(PROMTOOL) check rules ./files/prometheus_alerts.yml
 
-image:
-	@if [ $${SKIP_BUILD:-false} = false ] ; then \
-		podman build -t $(IMAGE_TAG) . ; \
-	fi
+.INTERMEDIATE: Dockerfile.dev
+Dockerfile.dev: Dockerfile Dockerfile.centos.patch
+	patch -o Dockerfile.dev Dockerfile Dockerfile.centos.patch
+
+image: Dockerfile.dev
+	echo podman build -f $^ -t $(IMAGE_TAG) .
 
 test-unit: $(GO_JUNIT_REPORT) coveragedir junitreportdir test-unit-prom
 	@set -o pipefail && \


### PR DESCRIPTION
### Description

`make image` now uses a CentOS base image. This shouldn't affect the upstream builds because the original Dockerfile is untouched. This _does_ however, change the default make target to use the new Dockerfile.dev which is based on CentOS. 

/cc @lukas-vlcek @vimalk78 
/assign @ewolinetz 

- JIRA: [LOG-970](https://issues.redhat.com/browse/LOG-970)
