### PR TITLE
Bug 1890838: Condense indexmanagement into single cronjob

### DIFF
--- a/internal/k8shandler/index_management.go
+++ b/internal/k8shandler/index_management.go
@@ -49,12 +49,8 @@ func (er *ElasticsearchRequest) CreateOrUpdateIndexManagement() error {
 	for _, mapping := range spec.Mappings {
 		policy := policies[mapping.PolicyRef]
 		ll := log.WithValues("mapping", mapping.Name, "policy", policy.Name)
-		if err := indexmanagement.ReconcileRolloverCronjob(er.client, er.cluster, policy, mapping, primaryShards); err != nil {
-			ll.Error(err, "could not reconcile rollover cronjob")
-			return err
-		}
-		if err := indexmanagement.ReconcileCurationCronjob(er.client, er.cluster, policy, mapping, primaryShards); err != nil {
-			ll.Error(err, "could not reconcile curation cronjob")
+		if err := indexmanagement.ReconcileIndexManagementCronjob(er.client, er.cluster, policy, mapping, primaryShards); err != nil {
+			ll.Error(err, "could not reconcile indexmanagement cronjob")
 			return err
 		}
 	}


### PR DESCRIPTION
### Description
This PR collapses the multiple policy cronjobs to a single job with multiple tasks it runs:
* delete
* rollover

The reasoning is there is a potential race condition between the previous jobs which both rely upon a `-write` alias that may lead to false information.  Additionally, ES does not have transactions or is ACID.  By converting these into tasks we execute for management we:
* potentially free disk for ES to do additional work
* give a better chance for the rollover to be successful
* May need to add a task to "unblock" the read-only index identified in the BZ

One risk in this proposed solution is failure of the first container will block any subsequent behaviors.  Placing the PR on hold pending agreement its a viable solution

/cc @lukas-vlcek @periklis 
/assign  @ewolinetz 
/assign @alanconway 
/cherrypick release-4.6

### Links
https://bugzilla.redhat.com/show_bug.cgi?id=1890838

/hold
