### PR TITLE
Bug 1908958: Change ElasticsearchClusterNotHealthy to 7 minutes

### DIFF
--- a/files/prometheus_alerts.yml
+++ b/files/prometheus_alerts.yml
@@ -4,11 +4,11 @@
   "rules":
   - "alert": "ElasticsearchClusterNotHealthy"
     "annotations":
-      "message": "Cluster {{ $labels.cluster }} health status has been RED for at least 2m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Cluster-Health-is-Red"
+      "message": "Cluster {{ $labels.cluster }} health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Cluster-Health-is-Red"
       "summary": "Cluster health status is RED"
     "expr": |
       sum by (cluster) (es_cluster_status == 2)
-    "for": "2m"
+    "for": "7m"
     "labels":
       "severity": "critical"
 

--- a/test/files/prometheus-unit-tests/test.yml
+++ b/test/files/prometheus-unit-tests/test.yml
@@ -60,7 +60,7 @@ tests:
               message: "Cluster elasticsearch health status has been YELLOW for at least 20m. Some shard replicas are not allocated. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Cluster-Healthy-is-Yellow"
 
       # --------- ElasticsearchClusterNotHealthy (red) ---------
-      - eval_time: 33m
+      - eval_time: 38m
         alertname: ElasticsearchClusterNotHealthy
         exp_alerts:
           - exp_labels:
@@ -68,7 +68,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Cluster health status is RED"
-              message: "Cluster elasticsearch health status has been RED for at least 2m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Cluster-Health-is-Red"
+              message: "Cluster elasticsearch health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Cluster-Health-is-Red"
 
       # --------- ElasticsearchWriteRequestsRejectionJumps ---------
       # Within the first 10m the percent of rejected requests is = 5% (the alert require > 5%)


### PR DESCRIPTION
### Description
`ElasticsearchClusterNotHealthy` is one of the noisier alerts on OSD. After reviewing this alert we found that this alert "self resolves" most commonly after 5 minutes.
Setting this to 7 minutes should relieve this.

/cc @alanconway
/assign @ewolinetz

### Links
- JIRA: https://issues.redhat.com/browse/OSD-5889
- Bugzilla:
https://bugzilla.redhat.com/show_bug.cgi?id=1908958 4.7
https://bugzilla.redhat.com/show_bug.cgi?id=1908959 4.6