### PR TITLE
Bug 1906895: Remove replace directive in 5.0 CSV manifest

### DIFF
--- a/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
@@ -475,5 +475,4 @@ spec:
   minKubeVersion: 1.18.3
   provider:
     name: Red Hat
-  replaces: elasticsearch-operator.v4.7.0
   version: 5.0.0

--- a/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
@@ -295,5 +295,4 @@ spec:
   minKubeVersion: 1.18.3
   provider:
     name: Red Hat
-  replaces: elasticsearch-operator.v4.7.0
   version: 0.0.0

--- a/manifests/5.0/elasticsearch-operator.v5.0.0.clusterserviceversion.yaml
+++ b/manifests/5.0/elasticsearch-operator.v5.0.0.clusterserviceversion.yaml
@@ -475,5 +475,4 @@ spec:
   minKubeVersion: 1.18.3
   provider:
     name: Red Hat
-  replaces: elasticsearch-operator.v4.7.0
   version: 5.0.0


### PR DESCRIPTION
### Description
This PR addresses a small glitch in generation CSV manifests for upcoming version 5.0. In detail it omits using the `replace` directive in the CSV spec to enable QE importing unreleased operators using the `opm` CLI tool.

/cc @huikang 
/assign @jcantrill  

### Links

- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1906895
