### PR TITLE
Bug 1907758: Fix update replica count for logging indices only

### DIFF
--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -186,6 +186,7 @@ func sendEsRequest(cluster, namespace string, payload *EsRequest, client k8sclie
 		// TODO: eventually remove after all ES images have been updated to use SA token auth for EO?
 		if resp.StatusCode == http.StatusForbidden ||
 			resp.StatusCode == http.StatusUnauthorized {
+			log.Info("failed sending payload using bearer token", "method", payload.Method, "url", payload.URI)
 			// if we get a 401 that means that we couldn't read from the token and provided
 			// no header.
 			// if we get a 403 that means the ES cluster doesn't allow us to use
@@ -257,6 +258,10 @@ func sendRequestWithMTlsClient(clusterName, namespace string, payload *EsRequest
 	resp, err := httpClient.Do(request)
 
 	if resp != nil {
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
+			log.Info("failed sending payload using mTLS PKI", "method", payload.Method, "url", payload.URI)
+		}
+
 		payload.StatusCode = resp.StatusCode
 		if payload.RawResponseBody, err = getRawBody(resp.Body); err != nil {
 			log.Error(err, "failed to get raw response body")

--- a/internal/elasticsearch/replicas.go
+++ b/internal/elasticsearch/replicas.go
@@ -50,7 +50,7 @@ func (ec *esClient) updateAllIndexReplicas(replicaCount int32) (bool, error) {
 func (ec *esClient) GetIndexReplicaCounts() (map[string]interface{}, error) {
 	payload := &EsRequest{
 		Method: http.MethodGet,
-		URI:    "*/_settings/index.number_of_replicas",
+		URI:    "app-*,infra-*,audit-*/_settings/index.number_of_replicas",
 	}
 
 	ec.fnSendEsRequest(ec.cluster, ec.namespace, payload, ec.k8sClient)


### PR DESCRIPTION
### Description
This PR addresses a false negative error log in ES nodes logs. The culprit is the elasticsearch-operator trying to update `.security/_settings/index.number_of_replicas` setting. Such calls are currently only allowed using the admin cert/key PR directly to elasticsearch (e.g. like in `es_seed_acl`). This fix is not a downgrade in operating multiple replicas of the `.security` index. The ES init procedure for the `.security` index takes care to set the replicas to `1` if the ES cluster has more than one node.

Needs backports for: **release-4.6** and **release-4.5**

/cc @huikang 
/assign @jcantrill 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1907758
