### PR TITLE
Bug 1885723: Allow kibana server to access OD tenantinfo

### DIFF
--- a/internal/k8shandler/configmaps_test.go
+++ b/internal/k8shandler/configmaps_test.go
@@ -154,6 +154,8 @@ opendistro_security:
   authcz.admin_dn:
   - CN=system.admin,OU=OpenShift,O=Logging
   config_index_name: ".security"
+  restapi:
+    roles_enabled: ["kibana_server"]
   ssl:
     transport:
       enabled: true

--- a/internal/k8shandler/configuration_tmpl.go
+++ b/internal/k8shandler/configuration_tmpl.go
@@ -42,6 +42,8 @@ opendistro_security:
   authcz.admin_dn:
   - CN=system.admin,OU=OpenShift,O=Logging
   config_index_name: ".security"
+  restapi:
+    roles_enabled: ["kibana_server"]
   ssl:
     transport:
       enabled: true


### PR DESCRIPTION
### Description
This PR addresses missing access rights for the `kibana_server` opendisto security role to allow kibana access the `_opendistro/_security/tenantinfo` API path. I.e.:

The Kibana opendistro security plugin includes a migration step for user tenants which requires access to the internal opendistro security API. The approach used follows the steps:
1. OpenDistro Security Plugin initializes a ES client to access `_opendistro/_security`.
2. This client is using the `elasticsearch.username: "CN=system.logging.kibana,OU=OpenShift,O=Logging"` from `kibana.yml` as its internal user to access Elasticsearch.
3. The subject `CN=system.logging.kibana,OU=OpenShift,O=Logging` maps to the role `kibana_server`
4. This role is not enabled in `opendistro_security.restapi.roles_enabled:` and kibana fails to access the `tenantinfo`.

More info for OD API access control: 
https://github.com/opendistro-for-elasticsearch/security/blob/v0.10.0.4/securityconfig/elasticsearch.yml.example#L33

Needs backport: **release-4.6** and **release-4.5**

/cc @jcantrill 
/assign @jcantrill 
### Links

- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1885723

