### PR TITLE
Bug 1910259: Fix missing grafana dashboard in OCP 4.7

### DIFF
--- a/controllers/logging/elasticsearch_controller.go
+++ b/controllers/logging/elasticsearch_controller.go
@@ -41,6 +41,7 @@ func (r *ElasticsearchReconciler) Reconcile(request ctrl.Request) (ctrl.Result, 
 		if apierrors.IsNotFound(err) {
 			log.Info("Flushing nodes", "objectKey", request.NamespacedName)
 			k8shandler.FlushNodes(request.NamespacedName.Name, request.NamespacedName.Namespace)
+			k8shandler.RemoveDashboardConfigMap(r.Client)
 			return ctrl.Result{}, nil
 		}
 


### PR DESCRIPTION
- Fix cross-namespace owner reference for the configmap
- Remove configmap after CR being deleted

### Description
OCP 4.7 (k8s v1.20) does not allow cross-namespace owner reference. So the configmap is garbage collected due to invalid reference. This PR fixes the issue.

/cc @blockloop 
/assign @ewolinetz 

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1910259
