### PR TITLE
force make image to be a real target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ tags
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 /.zz_generate_timestamp
 /tmp
+.output/

--- a/Dockerfile.centos.patch
+++ b/Dockerfile.centos.patch
@@ -11,4 +11,4 @@
 +FROM docker.io/centos:8 AS centos
  
  ENV ALERTS_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_alerts.yml"
- ENV RULES_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_rules.yml"
+ ENV RULES_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_recording_rules.yml"

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ Dockerfile.dev: Dockerfile Dockerfile.centos.patch
 	patch -o Dockerfile.dev Dockerfile Dockerfile.centos.patch
 
 image: Dockerfile.dev
-	echo podman build -f $^ -t $(IMAGE_TAG) .
+	podman build -f $^ -t $(IMAGE_TAG) .
 
 test-unit: $(GO_JUNIT_REPORT) coveragedir junitreportdir test-unit-prom
 	@set -o pipefail && \

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -133,13 +133,15 @@ You'll need `podman` in addition to `docker`.
 If you used the new `openshift-installer`, it creates a user named `kubeadmin`
 with the password in the file `installer/auth/kubeadmin_password`.
 
-If you already built the image with `make image`, use `SKIP_BUILD=true` to do a push
-only. You need `oc login` to the cluster before pushing the image to the register.
+If you already built the image with `make image`, then it will not be built
+again until a change is detected in a prerequisite file (defined in the
+Makefile) You need `oc login` to the cluster before pushing the image to the
+register.
 
 ```bash
 oc login --token=<token> --server=https://api.<cluster>:6443
 # Or oc login -u kubeadmin -p <password>, if using openshift installer
-SKIP_BUILD=true make deploy-image
+make deploy-image
 ```
 
 ## Upgrading operator-sdk


### PR DESCRIPTION
This is a baby step towards making the makefile use real targets that only execute
when something is changed. This creates a new pattern for targets that do not 
produce a file on the disk. For any target that does not create a filesystem target
add `@touch $@` to the end of the target and map the target to `.output/<target_name>`

For example:

```
image: .output/image
.output/image: <prereqs here | this part is very important>
    podman build -t <etc etc>
    @touch $@
```