### PR TITLE
Bug 1915454: Enable deployment on OCP v4.6

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v5.0"
+LABEL com.redhat.openshift.versions="v4.6-v4.7"
 
 LABEL \
     com.redhat.component="elasticsearch-operator" \


### PR DESCRIPTION
### Description
This PR enables deployment of 4.7 logging on OCP 4.6

/cc @vimalk78 @igor-karpukhin @ewolinetz 

### Links
https://bugzilla.redhat.com/show_bug.cgi?id=1915454

/cherrypick release-4.6