### PR TITLE
Bug 1893992: Improve elasticsearch indexmanagement rollover script

### DIFF
--- a/internal/indexmanagement/scripts.go
+++ b/internal/indexmanagement/scripts.go
@@ -1,9 +1,93 @@
 package indexmanagement
 
+const checkRollover = `
+#!/bin/python
+
+import json,sys
+
+try:
+  fileToRead = sys.argv[1]
+  currentIndex = sys.argv[2]
+except IndexError:
+    raise SystemExit(f"Usage: {sys.argv[0]} <file_to_read> <current_index>")
+
+try:
+  with open(fileToRead) as f:
+    data = json.load(f)
+except ValueError:
+  raise SystemExit(f"Invalid JSON: {f}")
+
+try:
+  if not data['acknowledged']:
+    if not data['rolled_over']:
+      for condition in data['conditions']:
+        if data['conditions'][condition]:
+          print(f"Index was not rolled over despite meeting conditions to do so: {data['conditions']}")
+          sys.exit(1)
+      
+      print(data['old_index'])
+      sys.exit(0)
+    
+  if data['old_index'] != currentIndex:
+    print(f"old index {data['old_index']} does not match expected index {currentIndex}")
+    sys.exit(1)
+      
+  print(data['new_index'])
+except KeyError as e:
+  raise SystemExit(f"Unable to check rollover for {data}: missing key {e}")
+`
+
+const getWriteIndex = `
+#!/bin/python
+
+import json,sys
+
+try:
+  alias = sys.argv[1]
+  indices = sys.argv[2]
+except IndexError:
+  raise SystemExit(f"Usage: {sys.argv[0]} <write_alias> <write_indices>")
+
+try:
+  data = json.loads(indices)
+except ValueError:
+  raise SystemExit(f"Invalid JSON: {indices}")
+
+try:
+  writeIndex = [index for index in data if data[index]['aliases'][alias].get('is_write_index')]
+  if len(writeIndex) > 0:
+    print(writeIndex[0])
+except:
+  e = sys.exc_info()[0]
+  raise SystemExit(f"Error trying to determine the 'write' index from {data}: {e}")
+`
+
 const rolloverScript = `
 set -euo pipefail
 CONNECT_TIMEOUT=${CONNECT_TIMEOUT:-30}
 decoded=$(echo $PAYLOAD | base64 -d)
+
+# get current write index
+# find out the current write index for ${POLICY_MAPPING}-write and check if there is the next generation of it
+writeIndices=$(curl -s $ES_SERVICE/${POLICY_MAPPING}-*/_alias/${POLICY_MAPPING}-write \
+  --cacert /etc/indexmanagement/keys/admin-ca \
+  --connect-timeout ${CONNECT_TIMEOUT} \
+  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  -HContent-Type:application/json)
+
+if echo "$writeIndices" | grep "\"error\"" ; then
+  echo "Error while attemping to determine the active write alias: $writeIndices"
+  exit 1
+fi
+
+if ! writeIndex="$(python /tmp/scripts/getWriteIndex.py "${POLICY_MAPPING}-write" "$writeIndices")" ; then
+  echo $writeIndex
+  exit 1
+fi
+
+echo "Current write index for ${POLICY_MAPPING}-write: $writeIndex"
+
+# try to rollover
 code=$(curl -s "$ES_SERVICE/${POLICY_MAPPING}-write/_rollover?pretty" \
   -w "%{response_code}" \
   --connect-timeout ${CONNECT_TIMEOUT} \
@@ -13,8 +97,84 @@ code=$(curl -s "$ES_SERVICE/${POLICY_MAPPING}-write/_rollover?pretty" \
   -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
   -o /tmp/response.txt \
   -d $decoded)
-if [ "$code" == "200" ] ; then
-  exit 0 
+
+echo "Checking results from _rollover call"
+
+if [ "$code" != "200" ] ; then
+  # already in bad state
+  echo "Calculating next write index based on current write index..."
+
+  indexGeneration="$(echo $writeIndex | cut -d'-' -f2)"
+  writeBase="$(echo $writeIndex | cut -d'-' -f1)"
+
+  # if we don't strip off the leading 0s it does math wrong...
+  generation=$(echo $indexGeneration | sed 's/^0*//')
+  # pad the index name again with 0s
+  nextGeneration="$(printf '%06g' $(($generation + 1)))"
+  nextIndex="$writeBase-$nextGeneration"
+else
+  # check response to see if it did roll over (field in response)
+  if ! nextIndex="$(python /tmp/scripts/checkRollover.py "/tmp/response.txt" "$writeIndex")" ; then
+    echo $nextIndex
+    exit 1
+  fi
+fi
+
+echo "Next write index for ${POLICY_MAPPING}-write: $nextIndex"
+echo "Checking if $nextIndex exists"
+
+# if true, ensure next index was created
+code=$(curl -s "$ES_SERVICE/$nextIndex/" \
+  -w "%{response_code}" \
+  --connect-timeout ${CONNECT_TIMEOUT} \
+  --cacert /etc/indexmanagement/keys/admin-ca \
+  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  -o /dev/null)
+if [ "$code" == "404" ] ; then
+  cat /tmp/response.txt
+  exit 1
+fi
+
+echo "Checking if $nextIndex is the write index for ${POLICY_MAPPING}-write"
+
+# if true, ensure write-alias points to next index
+writeIndices=$(curl -s $ES_SERVICE/${POLICY_MAPPING}-*/_alias/${POLICY_MAPPING}-write \
+  --cacert /etc/indexmanagement/keys/admin-ca \
+  --connect-timeout ${CONNECT_TIMEOUT} \
+  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  -HContent-Type:application/json)
+
+if echo "$writeIndices" | grep "\"error\"" ; then
+  echo "Error while attemping to determine the active write alias: $writeIndices"
+  exit 1
+fi
+
+if ! writeIndex="$(python /tmp/scripts/getWriteIndex.py "${POLICY_MAPPING}-write" "$writeIndices")" ; then
+  echo $writeIndex
+  exit 1
+fi
+
+if [ "$nextIndex" == "$writeIndex" ] ; then
+  echo "Done!"
+  exit 0
+fi
+
+echo "Updating alias for ${POLICY_MAPPING}-write"
+
+# else - try to update alias to be correct
+code=$(curl -s "$ES_SERVICE/_aliases" \
+  -w "%{response_code}" \
+  --connect-timeout ${CONNECT_TIMEOUT} \
+  --cacert /etc/indexmanagement/keys/admin-ca \
+  -HContent-Type:application/json \
+  -XPOST \
+  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  -o /tmp/response.txt \
+  -d '{"actions":[{"add":{"index": "'$writeIndex'", "alias": "'${POLICY_MAPPING}-write'", "is_write_index": false}},{"add":{"index": "'$nextIndex'", "alias": "'${POLICY_MAPPING}-write'", "is_write_index": true}}]}')
+
+if [ "$code" == 200 ] ; then
+  echo "Done!"
+  exit 0
 fi
 cat /tmp/response.txt
 exit 1
@@ -143,6 +303,8 @@ done
 `
 
 var scriptMap = map[string]string{
-	"delete":   deleteScript,
-	"rollover": rolloverScript,
+	"delete":           deleteScript,
+	"rollover":         rolloverScript,
+	"getWriteIndex.py": getWriteIndex,
+	"checkRollover.py": checkRollover,
 }


### PR DESCRIPTION
### Description
Hardening the rollover script called by the indexmanagement rollover cronjob.
This will now check if the rollover was successful based on the current write index.

If it was not, determine what the next index would be

For both success and failure we check:
1) Was the next index created
2) Does the write alias point to this index

If it does not point to it, we update the write alias.

/cc @lukas-vlcek @blockloop 

/cherry-pick release-4.6

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1893992
