### PR TITLE
Bug 1913469: fix link to the alert page

### DIFF
--- a/files/prometheus_alerts.yml
+++ b/files/prometheus_alerts.yml
@@ -4,7 +4,7 @@
   "rules":
   - "alert": "ElasticsearchClusterNotHealthy"
     "annotations":
-      "message": "Cluster {{ $labels.cluster }} health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Cluster-Health-is-Red"
+      "message": "Cluster {{ $labels.cluster }} health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Health-is-Red"
       "summary": "Cluster health status is RED"
     "expr": |
       sum by (cluster) (es_cluster_status == 2)
@@ -14,7 +14,7 @@
 
   - "alert": "ElasticsearchClusterNotHealthy"
     "annotations":
-      "message": "Cluster {{ $labels.cluster }} health status has been YELLOW for at least 20m. Some shard replicas are not allocated. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Cluster-Healthy-is-Yellow"
+      "message": "Cluster {{ $labels.cluster }} health status has been YELLOW for at least 20m. Some shard replicas are not allocated. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Healthy-is-Yellow"
       "summary": "Cluster health status is YELLOW"
     "expr": |
       sum by (cluster) (es_cluster_status == 1)
@@ -24,7 +24,7 @@
 
   - "alert": "ElasticsearchWriteRequestsRejectionJumps"
     "annotations":
-      "message": "High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster }} cluster. This node may not be keeping up with the indexing speed. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Write-Requests-Rejection-Jumps"
+      "message": "High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster }} cluster. This node may not be keeping up with the indexing speed. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Write-Requests-Rejection-Jumps"
       "summary": "High Write Rejection Ratio - {{ $value }}%"
     "expr": |
       round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
@@ -34,7 +34,7 @@
 
   - "alert": "ElasticsearchNodeDiskWatermarkReached"
     "annotations":
-      "message": "Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+      "message": "Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached"
       "summary": "Disk Low Watermark Reached - disk saturation is {{ $value }}%"
     "expr": |
       sum by (instance, pod) (
@@ -51,7 +51,7 @@
 
   - "alert": "ElasticsearchNodeDiskWatermarkReached"
     "annotations":
-      "message": "Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Node-Disk-High-Watermark-Reached"
+      "message": "Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-High-Watermark-Reached"
       "summary": "Disk High Watermark Reached - disk saturation is {{ $value }}%"
     "expr": |
       sum by (instance, pod) (
@@ -68,7 +68,7 @@
 
   - "alert": "ElasticsearchNodeDiskWatermarkReached"
     "annotations":
-      "message": "Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
+      "message": "Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
       "summary": "Disk Flood Stage Watermark Reached - disk saturation is {{ $value }}%"
     "expr": |
       sum by (instance, pod) (
@@ -85,7 +85,7 @@
 
   - "alert": "ElasticsearchJVMHeapUseHigh"
     "annotations":
-      "message": "JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-JVM-Heap-Use-is-High"
+      "message": "JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-JVM-Heap-Use-is-High"
       "summary": "JVM Heap usage on the node is high"
     "expr": |
       sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
@@ -95,7 +95,7 @@
 
   - "alert": "AggregatedLoggingSystemCPUHigh"
     "annotations":
-      "message": "System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Aggregated-Logging-System-CPU-is-High"
+      "message": "System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Aggregated-Logging-System-CPU-is-High"
       "summary": "System CPU usage is high"
     "expr": |
       sum by (cluster, instance, node) (es_os_cpu_percent) > 90
@@ -105,7 +105,7 @@
 
   - "alert": "ElasticsearchProcessCPUHigh"
     "annotations":
-      "message": "ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Process-CPU-is-High"
+      "message": "ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Process-CPU-is-High"
       "summary": "ES process CPU usage is high"
     "expr": |
       sum by (cluster, instance, node) (es_process_cpu_percent) > 90
@@ -116,7 +116,7 @@
   - alert: ElasticsearchDiskSpaceRunningLow
     annotations:
       message: |-
-        Cluster {{ $labels.cluster }} is predicted to be out of disk space within the next 6h For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Disk-Space-is-Running-Low
+        Cluster {{ $labels.cluster }} is predicted to be out of disk space within the next 6h For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Disk-Space-is-Running-Low
       summary: Cluster low on disk space
     expr: |
       sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
@@ -127,7 +127,7 @@
   - alert: ElasticsearchHighFileDescriptorUsage
     annotations:
       message: |-
-        Cluster {{ $labels.cluster }} is predicted to be out of file descriptors within the next hour. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-FileDescriptor-Usage-is-high
+        Cluster {{ $labels.cluster }} is predicted to be out of file descriptors within the next hour. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-FileDescriptor-Usage-is-high
       summary: Cluster low on file descriptors
     expr: |
       predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0

--- a/test/files/prometheus-unit-tests/test.yml
+++ b/test/files/prometheus-unit-tests/test.yml
@@ -60,7 +60,7 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Cluster health status is YELLOW"
-              message: "Cluster elasticsearch health status has been YELLOW for at least 20m. Some shard replicas are not allocated. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Cluster-Healthy-is-Yellow"
+              message: "Cluster elasticsearch health status has been YELLOW for at least 20m. Some shard replicas are not allocated. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Healthy-is-Yellow"
 
       # --------- ElasticsearchClusterNotHealthy (red) ---------
       - eval_time: 38m
@@ -71,7 +71,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Cluster health status is RED"
-              message: "Cluster elasticsearch health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Cluster-Health-is-Red"
+              message: "Cluster elasticsearch health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Health-is-Red"
 
       # --------- ElasticsearchWriteRequestsRejectionJumps ---------
       # Within the first 10m the percent of rejected requests is = 5% (the alert require > 5%)
@@ -89,7 +89,7 @@ tests:
               severity: warning
             exp_annotations:
               summary: "High Write Rejection Ratio - 10%"
-              message: "High Write Rejection Ratio at elasticsearch-cdm-1 node in elasticsearch cluster. This node may not be keeping up with the indexing speed. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Write-Requests-Rejection-Jumps"
+              message: "High Write Rejection Ratio at elasticsearch-cdm-1 node in elasticsearch cluster. This node may not be keeping up with the indexing speed. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Write-Requests-Rejection-Jumps"
 
       # --------- ElasticsearchNodeDiskWatermarkReached ---------
       # By the end of 10th minute we do not expect the low watermark has been active for more than 5 minutes.
@@ -107,7 +107,7 @@ tests:
               severity: info
             exp_annotations:
               summary: "Disk Low Watermark Reached - disk saturation is 90%"
-              message: "Disk Low Watermark Reached at pod-1 pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+              message: "Disk Low Watermark Reached at pod-1 pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached"
 
       # --------- AggregatedLoggingSystemCPUHigh ---------
       - eval_time: 15m
@@ -120,7 +120,7 @@ tests:
               severity: alert
             exp_annotations:
               summary: "System CPU usage is high"
-              message: "System CPU usage on the node elasticsearch-cdm-1 in elasticsearch cluster is 95%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Aggregated-Logging-System-CPU-is-High"
+              message: "System CPU usage on the node elasticsearch-cdm-1 in elasticsearch cluster is 95%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Aggregated-Logging-System-CPU-is-High"
 
       # Critical value not reached - no alert is fired
       - eval_time: 5m
@@ -138,7 +138,7 @@ tests:
               severity: alert
             exp_annotations:
               summary: "ES process CPU usage is high"
-              message: "ES process CPU usage on the node elasticsearch-cdm-1 in elasticsearch cluster is 95%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Process-CPU-is-High"
+              message: "ES process CPU usage on the node elasticsearch-cdm-1 in elasticsearch cluster is 95%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Process-CPU-is-High"
 
       # Critical value not reached - no alert is fired
       - eval_time: 5m


### PR DESCRIPTION
### Description
Fix the url link to the alert page: "md.md" should be ".md"

/cc @ewolinetz 
/assign @ewolinetz @blockloop 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1913469
