### PR TITLE
 Bug 1916910: Condense indexmanagement into single cronjob

### DIFF
--- a/pkg/indexmanagement/reconcile.go
+++ b/pkg/indexmanagement/reconcile.go
@@ -3,13 +3,16 @@ package indexmanagement
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
 	batch "k8s.io/api/batch/v1beta1"
 	core "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -23,6 +26,7 @@ import (
 	apis "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
 	"github.com/openshift/elasticsearch-operator/pkg/constants"
 	"github.com/openshift/elasticsearch-operator/pkg/log"
+	kverrors "github.com/openshift/elasticsearch-operator/pkg/log"
 	k8s "github.com/openshift/elasticsearch-operator/pkg/types/k8s"
 	"github.com/openshift/elasticsearch-operator/pkg/utils"
 	"github.com/openshift/elasticsearch-operator/pkg/utils/comparators"
@@ -31,6 +35,7 @@ import (
 const (
 	indexManagementConfigmap = "indexmanagement-scripts"
 	defaultShardSize         = int32(40)
+	workingDir               = "/tmp/scripts"
 )
 
 var (
@@ -64,13 +69,7 @@ type rolloverConditions struct {
 func RemoveCronJobsForMappings(apiclient client.Client, cluster *apis.Elasticsearch, mappings []apis.IndexManagementPolicyMappingSpec, policies apis.PolicyMap) error {
 	expected := sets.NewString()
 	for _, mapping := range mappings {
-		policy := policies[mapping.PolicyRef]
-		if policy.Phases.Hot != nil {
-			expected.Insert(fmt.Sprintf("%s-rollover-%s", cluster.Name, mapping.Name))
-		}
-		if policy.Phases.Delete != nil {
-			expected.Insert(fmt.Sprintf("%s-delete-%s", cluster.Name, mapping.Name))
-		}
+		expected.Insert(fmt.Sprintf("%s-im-%s", cluster.Name, mapping.Name))
 	}
 
 	cronList := &batch.CronJobList{}
@@ -130,68 +129,68 @@ func ReconcileCurationConfigmap(apiclient client.Client, cluster *apis.Elasticse
 	}
 	return err
 }
-
-func ReconcileRolloverCronjob(apiclient client.Client, cluster *apis.Elasticsearch, policy apis.IndexManagementPolicySpec, mapping apis.IndexManagementPolicyMappingSpec, primaryShards int32) error {
-	if policy.Phases.Hot == nil {
-		log.Info("Skipping rollover cronjob for policymapping; hot phase not defined", "policymapping", mapping.Name)
+func ReconcileIndexManagementCronjob(apiclient client.Client, cluster *apis.Elasticsearch, policy apis.IndexManagementPolicySpec, mapping apis.IndexManagementPolicyMappingSpec, primaryShards int32) error {
+	if policy.Phases.Delete == nil && policy.Phases.Hot == nil {
+		log.V(1).Info("Skipping indexmanagement cronjob for policymapping; no phases are defined", "policymapping", mapping.Name)
 		return nil
+	}
+	envvars := []corev1.EnvVar{}
+	if policy.Phases.Delete != nil {
+		minAgeMillis, err := calculateMillisForTimeUnit(policy.Phases.Delete.MinAge)
+		if err != nil {
+			return err
+		}
+		envvars = append(envvars,
+			corev1.EnvVar{Name: "POLICY_MAPPING", Value: mapping.Name},
+			corev1.EnvVar{Name: "MIN_AGE", Value: strconv.FormatUint(minAgeMillis, 10)},
+		)
+	} else {
+		log.V(1).Info("Skipping curation management for policymapping; delete phase not defined", "policymapping", mapping.Name)
+	}
+
+	if policy.Phases.Hot != nil {
+		conditions := calculateConditions(policy, primaryShards)
+		payload, err := json.Marshal(map[string]rolloverConditions{"conditions": conditions})
+		if err != nil {
+			return kverrors.Wrap(err, "failed to serialize the rollover conditions to JSON")
+		}
+		envvars = append(envvars,
+			corev1.EnvVar{Name: "PAYLOAD", Value: base64.StdEncoding.EncodeToString(payload)},
+			corev1.EnvVar{Name: "POLICY_MAPPING", Value: mapping.Name},
+		)
+
+	} else {
+		log.V(1).Info("Skipping rollover management for policymapping; hot phase not defined", "policymapping", mapping.Name)
 	}
 	schedule, err := crontabScheduleFor(policy.PollInterval)
 	if err != nil {
 		return err
 	}
-	conditions := calculateConditions(policy, primaryShards)
-	name := fmt.Sprintf("%s-rollover-%s", cluster.Name, mapping.Name)
-	payload, err := utils.ToJson(map[string]rolloverConditions{"conditions": conditions})
-	if err != nil {
-		return fmt.Errorf("There was an error serializing the rollover conditions to JSON: %v", err)
-	}
-	envvars := []core.EnvVar{
-		{Name: "PAYLOAD", Value: base64.StdEncoding.EncodeToString([]byte(payload))},
-		{Name: "POLICY_MAPPING", Value: mapping.Name},
-	}
-	fnContainerHandler := func(container *core.Container) {
-		container.Command = []string{"bash"}
-		container.Args = []string{
-			"-c",
-			"/tmp/scripts/rollover",
-		}
-	}
-	desired := newCronJob(cluster.Name, constants.PackagedElasticsearchImage(), cluster.Namespace, name, schedule, cluster.Spec.Spec.NodeSelector, cluster.Spec.Spec.Tolerations, envvars, fnContainerHandler)
+	name := fmt.Sprintf("%s-im-%s", cluster.Name, mapping.Name)
+	script := formatCmd(policy)
+	desired := newCronJob(cluster.Name, cluster.Namespace, name, schedule, script, cluster.Spec.Spec.NodeSelector, cluster.Spec.Spec.Tolerations, envvars)
 
 	cluster.AddOwnerRefTo(desired)
 	return reconcileCronJob(apiclient, cluster, desired, areCronJobsSame)
 }
 
-func ReconcileCurationCronjob(apiclient client.Client, cluster *apis.Elasticsearch, policy apis.IndexManagementPolicySpec, mapping apis.IndexManagementPolicyMappingSpec, primaryShards int32) error {
-	if policy.Phases.Delete == nil {
-		log.Info("Skipping curation cronjob for policymapping; delete phase not defined", "policymapping", mapping.Name)
-		return nil
+func formatCmd(policy apis.IndexManagementPolicySpec) string {
+	cmd := []string{}
+	result := []string{}
+	if policy.Phases.Delete != nil {
+		cmd = append(cmd, "./delete", "delete_rc=$?")
+		result = append(result, "exit $delete_rc")
 	}
-	schedule, err := crontabScheduleFor(policy.PollInterval)
-	if err != nil {
-		return err
+	if policy.Phases.Hot != nil {
+		cmd = append(cmd, "./rollover", "rollover_rc=$?")
+		result = append(result, "exit $rollover_rc")
 	}
-	minAgeMillis, err := calculateMillisForTimeUnit(policy.Phases.Delete.MinAge)
-	if err != nil {
-		return err
+	if len(cmd) == 0 {
+		return ""
 	}
-	name := fmt.Sprintf("%s-delete-%s", cluster.Name, mapping.Name)
-	envvars := []core.EnvVar{
-		{Name: "POLICY_MAPPING", Value: mapping.Name},
-		{Name: "MIN_AGE", Value: strconv.FormatUint(minAgeMillis, 10)},
-	}
-	fnContainerHandler := func(container *core.Container) {
-		container.Command = []string{"bash"}
-		container.Args = []string{
-			"-c",
-			"/tmp/scripts/delete",
-		}
-	}
-	desired := newCronJob(cluster.Name, constants.PackagedElasticsearchImage(), cluster.Namespace, name, schedule, cluster.Spec.Spec.NodeSelector, cluster.Spec.Spec.Tolerations, envvars, fnContainerHandler)
-
-	cluster.AddOwnerRefTo(desired)
-	return reconcileCronJob(apiclient, cluster, desired, areCronJobsSame)
+	cmd = append(cmd, fmt.Sprintf("$(%s)", strings.Join(result, "&&")))
+	script := strings.Join(cmd, ";")
+	return script
 }
 
 func reconcileCronJob(apiclient client.Client, cluster *apis.Elasticsearch, desired *batch.CronJob, fnAreCronJobsSame func(lhs, rhs *batch.CronJob) bool) error {
@@ -234,38 +233,44 @@ func areCronJobsSame(lhs, rhs *batch.CronJob) bool {
 	if lhs.Spec.Suspend != nil && rhs.Spec.Suspend != nil && *lhs.Spec.Suspend != *rhs.Spec.Suspend {
 		return false
 	}
-
 	for i, container := range lhs.Spec.JobTemplate.Spec.Template.Spec.Containers {
 		other := rhs.Spec.JobTemplate.Spec.Template.Spec.Containers[i]
-		if container.Name != other.Name {
+		if !areContainersSame(container, other) {
 			return false
 		}
-		if container.Image != other.Image {
-			return false
-		}
-
-		if !reflect.DeepEqual(container.Command, other.Command) {
-			return false
-		}
-		if !reflect.DeepEqual(container.Args, other.Args) {
-			return false
-		}
-
-		if !comparators.AreResourceRequementsSame(container.Resources, other.Resources) {
-			return false
-		}
-
-		if !comparators.EnvValueEqual(container.Env, other.Env) {
-			return false
-		}
-
 	}
 	return true
 }
 
-func newCronJob(clusterName, image, namespace, name, schedule string, nodeSelector map[string]string, tolerations []core.Toleration, envvars []core.EnvVar, fnContainerHander func(*core.Container)) *batch.CronJob {
-	container := core.Container{
-		Name:            "indexmanagement",
+func areContainersSame(container, other corev1.Container) bool {
+	if container.Name != other.Name {
+		return false
+	}
+	if container.Image != other.Image {
+		return false
+	}
+
+	if !reflect.DeepEqual(container.Command, other.Command) {
+		return false
+	}
+	if !reflect.DeepEqual(container.Args, other.Args) {
+		return false
+	}
+
+	if !comparators.AreResourceRequementsSame(container.Resources, other.Resources) {
+		return false
+	}
+
+	if !comparators.EnvValueEqual(container.Env, other.Env) {
+		return false
+	}
+	return true
+}
+
+func newContainer(clusterName, name, image, scriptPath string, envvars []corev1.EnvVar) corev1.Container {
+	envvars = append(envvars, corev1.EnvVar{Name: "ES_SERVICE", Value: fmt.Sprintf("https://%s:9200", clusterName)})
+	container := corev1.Container{
+		Name:            name,
 		Image:           image,
 		ImagePullPolicy: core.PullIfNotPresent,
 		Resources: v1.ResourceRequirements{
@@ -274,30 +279,36 @@ func newCronJob(clusterName, image, namespace, name, schedule string, nodeSelect
 				v1.ResourceCPU:    defaultCPURequest,
 			},
 		},
-		Env: []core.EnvVar{
-			{Name: "ES_SERVICE", Value: fmt.Sprintf("https://%s:9200", clusterName)},
+		WorkingDir: workingDir,
+		Env:        envvars,
+		Command:    []string{"bash"},
+		Args: []string{
+			"-c",
+			scriptPath,
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "certs", ReadOnly: true, MountPath: "/etc/indexmanagement/keys"},
+			{Name: "scripts", ReadOnly: false, MountPath: workingDir},
 		},
 	}
-	container.Env = append(container.Env, envvars...)
-	fnContainerHander(&container)
 
-	container.VolumeMounts = []v1.VolumeMount{
-		{Name: "certs", ReadOnly: true, MountPath: "/etc/indexmanagement/keys"},
-		{Name: "scripts", ReadOnly: false, MountPath: "/tmp/scripts"},
-	}
-	podSpec := core.PodSpec{
+	return container
+}
+
+func newCronJob(clusterName, namespace, name, schedule, script string, nodeSelector map[string]string, tolerations []corev1.Toleration, envvars []corev1.EnvVar) *batch.CronJob {
+	containerName := "indexmanagement"
+	podSpec := corev1.PodSpec{
 		ServiceAccountName: clusterName,
-		Containers:         []v1.Container{container},
-		Volumes: []v1.Volume{
-			{Name: "certs", VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: clusterName}}},
-			{Name: "scripts", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: indexManagementConfigmap}, DefaultMode: fullExecMode}}},
+		Containers:         []corev1.Container{newContainer(clusterName, containerName, constants.PackagedElasticsearchImage(), script, envvars)},
+		Volumes: []corev1.Volume{
+			{Name: "certs", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: clusterName}}},
+			{Name: "scripts", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: indexManagementConfigmap}, DefaultMode: fullExecMode}}},
 		},
 		NodeSelector:                  utils.EnsureLinuxNodeSelector(nodeSelector),
 		Tolerations:                   tolerations,
 		RestartPolicy:                 v1.RestartPolicyNever,
 		TerminationGracePeriodSeconds: utils.GetInt64(300),
 	}
-
 	cronJob := &batch.CronJob{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "CronJob",
@@ -319,7 +330,7 @@ func newCronJob(clusterName, image, namespace, name, schedule string, nodeSelect
 					Parallelism:  utils.GetInt32(1),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      name,
+							Name:      containerName,
 							Namespace: namespace,
 							Labels:    imLabels,
 						},

--- a/pkg/indexmanagement/reconcile_test.go
+++ b/pkg/indexmanagement/reconcile_test.go
@@ -20,14 +20,13 @@ var _ = Describe("Index Management", func() {
 	defer GinkgoRecover()
 
 	var (
-		primaryShards      = int32(1)
-		apiclient          client.Client
-		testclient         *fakeruntime.FakeClient
-		cluster            *apis.Elasticsearch
-		policy             apis.IndexManagementPolicySpec
-		mapping            apis.IndexManagementPolicyMappingSpec
-		cronjob            *batch.CronJob
-		fnContainerHandler = func(container *core.Container) {}
+		primaryShards = int32(1)
+		apiclient     client.Client
+		testclient    *fakeruntime.FakeClient
+		cluster       *apis.Elasticsearch
+		policy        apis.IndexManagementPolicySpec
+		mapping       apis.IndexManagementPolicyMappingSpec
+		cronjob       *batch.CronJob
 	)
 	BeforeEach(func() {
 		apiclient = fake.NewFakeClient()
@@ -51,8 +50,39 @@ var _ = Describe("Index Management", func() {
 		}
 		selector := map[string]string{}
 		tolerations := []core.Toleration{}
-		name := fmt.Sprintf("%s-rollover-%s", cluster.Name, policy.Name)
-		cronjob = newCronJob(cluster.Name, "animage", cluster.Namespace, name, "*/5 * * * *", selector, tolerations, []core.EnvVar{}, fnContainerHandler)
+		name := fmt.Sprintf("%s-im-%s", cluster.Name, mapping.Name)
+		cronjob = newCronJob(cluster.Name, cluster.Namespace, name, "*/5 * * * *", "",selector, tolerations, []core.EnvVar{})
+	})
+	Describe("#formatCmd", func(){
+		Context("with no policies", func(){
+			It("should return an empty command", func(){
+				Expect(formatCmd(apis.IndexManagementPolicySpec{})).To(BeEmpty())
+			})
+
+		})
+		Context("with delete phase", func(){
+			It("should format the command for delete", func(){
+				policy.Phases.Delete = &apis.IndexManagementDeletePhaseSpec{}
+				Expect(formatCmd(policy)).To(Equal("./delete;delete_rc=$?;$(exit $delete_rc)"))
+			})
+
+		})
+		Context("with rollover phase", func(){
+			It("should format the command for rollover", func(){
+				policy.Phases.Hot = &apis.IndexManagementHotPhaseSpec{}
+				Expect(formatCmd(policy)).To(Equal("./rollover;rollover_rc=$?;$(exit $rollover_rc)"))
+
+			})
+
+		})
+		Context("with delete and rollover phases", func(){
+			It("should format the command for all phases", func(){
+				policy.Phases.Delete = &apis.IndexManagementDeletePhaseSpec{}
+				policy.Phases.Hot = &apis.IndexManagementHotPhaseSpec{}
+				Expect(formatCmd(policy)).To(Equal("./delete;delete_rc=$?;./rollover;rollover_rc=$?;$(exit $delete_rc&&exit $rollover_rc)"))
+			})
+
+		})
 	})
 	Describe("#reconcileCronJob", func() {
 		var fnCronsAreSame = func(lhs, rhs *batch.CronJob) bool {
@@ -101,68 +131,12 @@ var _ = Describe("Index Management", func() {
 			})
 		})
 	})
-	Describe("#ReconcileCurationCronjob", func() {
+	Describe("#ReconcileIndexManagementCronjob", func() {
 		BeforeEach(func() {
-			selector := map[string]string{}
-			tolerations := []core.Toleration{}
-			name := fmt.Sprintf("%s-delete-%s", cluster.Name, policy.Name)
-			cronjob = newCronJob(cluster.Name, "anImage", cluster.Namespace, name, "*/5 * * * *", selector, tolerations, []core.EnvVar{}, fnContainerHandler)
-			policy.Phases.Delete = &apis.IndexManagementDeletePhaseSpec{
-				MinAge: "7d",
-			}
-		})
-
-		Describe("for invalid poll interval", func() {
-			It("should not create the cronjob and return the error", func() {
-				policy.PollInterval = "notavalue"
-				Expect(ReconcileCurationCronjob(apiclient, cluster, policy, mapping, primaryShards)).To(Not(BeNil()))
-			})
-		})
-		Describe("when trying to create the cronjob", func() {
-			Context("and no delete phase exists", func() {
-				It("should return without error", func() {
-					policy.Phases.Delete = nil
-					apiclient = fake.NewFakeClient(cronjob)
-					err := ReconcileCurationCronjob(apiclient, cluster, policy, mapping, primaryShards)
-					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
-				})
-			})
-			Context("and does not error", func() {
-				It("should return without error", func() {
-					apiclient = fake.NewFakeClient(cronjob)
-					err := ReconcileCurationCronjob(apiclient, cluster, policy, mapping, primaryShards)
-					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
-				})
-			})
-			Context("and errors for reasons other then already existing", func() {
-				It("should return the error", func() {
-					err := ReconcileCurationCronjob(apiclient, cluster, policy, mapping, primaryShards)
-					Expect(err).To(BeNil())
-				})
-
-			})
-			Context("and errors because it already exists", func() {
-				Context("when the current is different from the desired", func() {
-					It("should update the cronjob", func() {
-						cronjob.Spec.Schedule = "*/5 10 * * * *"
-						apiclient = fake.NewFakeClient(cronjob)
-						testclient = fakeruntime.NewFakeClient(apiclient, fakeruntime.NewAlreadyExistsException())
-						apiclient = testclient
-						err := ReconcileCurationCronjob(apiclient, cluster, policy, mapping, primaryShards)
-						Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
-						Expect(testclient.WasUpdated(cronjob.Name)).To(BeTrue(), "Exp. to update the cronjob")
-					})
-				})
-
-			})
-		})
-	})
-	Describe("#ReconcileRolloverCronjob", func() {
-		BeforeEach(func() {
-			selector := map[string]string{}
+		 	selector := map[string]string{}
 			tolerations := []core.Toleration{}
 			name := fmt.Sprintf("%s-rollover-%s", cluster.Name, policy.Name)
-			cronjob = newCronJob(cluster.Name, "animage", cluster.Namespace, name, "*/5 * * * *", selector, tolerations, []core.EnvVar{}, fnContainerHandler)
+			cronjob = newCronJob(cluster.Name, cluster.Namespace, name, "*/5 * * * *", "",selector, tolerations,[]core.EnvVar{})
 			policy.Phases.Hot = &apis.IndexManagementHotPhaseSpec{
 				Actions: apis.IndexManagementActionsSpec{
 					Rollover: &apis.IndexManagementActionSpec{
@@ -170,25 +144,53 @@ var _ = Describe("Index Management", func() {
 					},
 				},
 			}
+			policy.Phases.Delete = &apis.IndexManagementDeletePhaseSpec{
+				MinAge: "7d",
+			}
 		})
-
 		Describe("for invalid poll interval", func() {
 			It("should not create the cronjob and return the error", func() {
 				policy.PollInterval = "notavalue"
-				Expect(ReconcileRolloverCronjob(apiclient, cluster, policy, mapping, primaryShards)).To(Not(BeNil()))
+				Expect(ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)).To(Not(Succeed()))
 			})
 		})
 		Describe("when trying to create the cronjob", func() {
+			Context("and no phases exist", func() {
+				It("should return without error", func() {
+					policy.Phases.Delete = nil
+					policy.Phases.Hot = nil
+					apiclient = fake.NewFakeClient(cronjob)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
+				})
+			})
+			Context("and no delete phase exists", func() {
+				It("should return without error", func() {
+					policy.Phases.Delete = nil
+					apiclient = fake.NewFakeClient(cronjob)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
+				})
+			})
+			Context("and no hot phase exists", func() {
+				It("should return without error", func() {
+					policy.Phases.Hot = nil
+					apiclient = fake.NewFakeClient(cronjob)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
+				})
+
+			})
 			Context("and does not error", func() {
 				It("should return without error", func() {
 					apiclient = fake.NewFakeClient(cronjob)
-					err := ReconcileRolloverCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
 					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 				})
 			})
 			Context("and errors for reasons other then already existing", func() {
 				It("should return the error", func() {
-					err := ReconcileRolloverCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
 					Expect(err).To(BeNil())
 				})
 
@@ -196,17 +198,17 @@ var _ = Describe("Index Management", func() {
 			Context("and errors because it already exists", func() {
 				Context("when the current is different from the desired", func() {
 					It("should update the cronjob", func() {
-						cronjob.Spec.Schedule = "*/5 10 * * * *"
+						newSchedule := "*/5 10 * * * *"
+						cronjob.Spec.Schedule = newSchedule
 						apiclient = fake.NewFakeClient(cronjob)
-						testclient = fakeruntime.NewFakeClient(apiclient, fakeruntime.NewAlreadyExistsException())
-						apiclient = testclient
-						err := ReconcileRolloverCronjob(apiclient, cluster, policy, mapping, primaryShards)
+						err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
 						Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
-						Expect(testclient.WasUpdated(cronjob.Name)).To(BeTrue(), "Exp. to update the cronjob")
+						Expect(cronjob.Spec.Schedule).To(Equal(newSchedule), "Exp. to update the cronjob")
 					})
 				})
 
 			})
 		})
 	})
+
 })

--- a/pkg/k8shandler/index_management.go
+++ b/pkg/k8shandler/index_management.go
@@ -50,12 +50,8 @@ func (er *ElasticsearchRequest) CreateOrUpdateIndexManagement() error {
 	for _, mapping := range spec.Mappings {
 		policy := policies[mapping.PolicyRef]
 		ll := log.WithValues("mapping", mapping.Name, "policy", policy.Name)
-		if err := indexmanagement.ReconcileRolloverCronjob(er.client, er.cluster, policy, mapping, primaryShards); err != nil {
-			ll.Error(err, "could not reconcile rollover cronjob")
-			return err
-		}
-		if err := indexmanagement.ReconcileCurationCronjob(er.client, er.cluster, policy, mapping, primaryShards); err != nil {
-			ll.Error(err, "could not reconcile curation cronjob")
+		if err := indexmanagement.ReconcileIndexManagementCronjob(er.client, er.cluster, policy, mapping, primaryShards); err != nil {
+			ll.Error(err, "could not reconcile indexmanagement cronjob")
 			return err
 		}
 	}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -54,9 +55,29 @@ func Init(component string, keyValuePairs ...interface{}) {
 	})
 }
 
+//proxyLogger is a minimal adapter to Logger to
+//facilitate backports to 4.6 due to the difference in
+//log libraries.  It does not provide equivalent log
+// capabilities
+type proxyLogger struct {
+	level int
+}
+
+func V(verbosity int) proxyLogger {
+	return proxyLogger{level: verbosity}
+}
+func (p proxyLogger) Info(msg string, keysAndValues ...interface{}) {
+	if p.level == 0 {
+		Info(msg, keysAndValues)
+	}
+}
+
 // Logger returns the singleton logger that was created via Init
 func Logger() logr.Logger {
 	return logger
+}
+func Wrap(err error, msg string) error {
+	return fmt.Errorf("%s: %v", msg, err)
 }
 
 // Info logs a non-error message with the given key/value pairs as context.


### PR DESCRIPTION
(cherry picked from commit c7079ed90bc0fbe76bad0871d7dbb1eab091af5f)

### Description
This PR collapses the multiple policy cronjobs to a single job with multiple tasks it runs:
* delete
* rollover
* adds simple adapter to log package to facilitate cherrypicks from post 4.6

The reasoning is there is a potential race condition between the previous jobs which both rely upon a `-write` alias that may lead to false information.  Additionally, ES does not have transactions or is ACID.  By converting these into tasks we execute for management we:
* potentially free disk for ES to do additional work
* give a better chance for the rollover to be successful
* May need to add a task to "unblock" the read-only index identified in the BZ

/cc @ewolinetz 

### Links
4.6 backport of https://github.com/openshift/elasticsearch-operator/pull/599
