### PR TITLE
Bug 1918920: [LOGEXP 1009] Watch secret update for elasticsearch cluster

### DIFF
--- a/controllers/logging/secret_controller.go
+++ b/controllers/logging/secret_controller.go
@@ -1,0 +1,78 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	loggingv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
+	"github.com/openshift/elasticsearch-operator/internal/k8shandler"
+)
+
+// SecretReconciler reconciles a Secret object
+type SecretReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+func (r *SecretReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	_ = context.Background()
+
+	cluster := &loggingv1.Elasticsearch{}
+	esName := types.NamespacedName{
+		Namespace: req.Namespace,
+		Name:      req.Name,
+	}
+
+	err := r.Get(context.TODO(), esName, cluster)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	err = k8shandler.SecretReconcile(cluster, r.Client)
+	return ctrl.Result{}, err
+}
+
+func esSecretUpdatePredicate(r client.Client) predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			cluster := &loggingv1.Elasticsearch{}
+			esName := types.NamespacedName{
+				Namespace: e.MetaNew.GetNamespace(),
+				Name:      e.MetaNew.GetName(),
+			}
+			err := r.Get(context.TODO(), esName, cluster)
+			if err != nil {
+				return false
+			}
+			return true
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}).
+		WithEventFilter(esSecretUpdatePredicate(r.Client)).
+		Complete(r)
+}

--- a/internal/k8shandler/deployment.go
+++ b/internal/k8shandler/deployment.go
@@ -93,6 +93,10 @@ func (node *deploymentNode) name() string {
 	return node.self.Name
 }
 
+func (node *deploymentNode) getSecretHash() string {
+	return node.secretHash
+}
+
 func (node *deploymentNode) state() api.ElasticsearchNodeStatus {
 	// var rolloutForReload v1.ConditionStatus
 	var rolloutForUpdate v1.ConditionStatus

--- a/internal/k8shandler/nodetypefactory.go
+++ b/internal/k8shandler/nodetypefactory.go
@@ -19,6 +19,7 @@ type NodeTypeInterface interface {
 	isMissing() bool
 	name() string
 	delete() error
+	getSecretHash() string
 
 	refreshHashes()
 	scaleDown() error

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -1,11 +1,16 @@
 package k8shandler
 
 import (
+	"context"
+
 	"github.com/ViaQ/logerr/kverrors"
 	"github.com/ViaQ/logerr/log"
 	"github.com/go-logr/logr"
 	elasticsearchv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
 	"github.com/openshift/elasticsearch-operator/internal/elasticsearch"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -23,6 +28,50 @@ func (er *ElasticsearchRequest) L() logr.Logger {
 		er.ll = log.WithValues("cluster", er.cluster.Name, "namespace", er.cluster.Namespace)
 	}
 	return er.ll
+}
+
+func SecretReconcile(requestCluster *elasticsearchv1.Elasticsearch, requestClient client.Client) error {
+	var secretChanged bool
+
+	newSecretHash := getSecretDataHash(requestCluster.Name, requestCluster.Namespace, requestClient)
+
+	nretries := -1
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		nretries++
+
+		cluster := &elasticsearchv1.Elasticsearch{}
+		if err := requestClient.Get(context.TODO(), types.NamespacedName{Name: requestCluster.Name, Namespace: requestCluster.Namespace}, cluster); err != nil {
+			return err
+		}
+
+		// compare the new secret with current one in the nodes
+		for _, node := range nodes[nodeMapKey(requestCluster.Name, requestCluster.Namespace)] {
+			if node.getSecretHash() != "" && newSecretHash != node.getSecretHash() {
+
+				// Cluster's secret has been updated, update the cluster status to be redeployed
+				_, nodeStatus := getNodeStatus(node.name(), &cluster.Status)
+				if nodeStatus.UpgradeStatus.ScheduledForCertRedeploy != corev1.ConditionTrue {
+					secretChanged = true
+					nodeStatus.UpgradeStatus.ScheduledForCertRedeploy = corev1.ConditionTrue
+				}
+			}
+		}
+
+		if secretChanged {
+			if err := requestClient.Status().Update(context.TODO(), cluster); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	if retryErr != nil {
+		return kverrors.Wrap(retryErr, "failed to update status for cert redeploys",
+			"cluster", requestCluster.Name,
+			"retries", nretries)
+	}
+
+	return nil
 }
 
 func Reconcile(requestCluster *elasticsearchv1.Elasticsearch, requestClient client.Client) error {

--- a/internal/k8shandler/statefulset.go
+++ b/internal/k8shandler/statefulset.go
@@ -104,6 +104,10 @@ func (n *statefulSetNode) scaleUp() error {
 	return n.setReplicaCount(n.replicas)
 }
 
+func (node *statefulSetNode) getSecretHash() string {
+	return node.secretHash
+}
+
 func (n *statefulSetNode) state() api.ElasticsearchNodeStatus {
 	var rolloutForUpdate v1.ConditionStatus
 	var rolloutForCertReload v1.ConditionStatus

--- a/main.go
+++ b/main.go
@@ -120,6 +120,14 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Kibana")
 		os.Exit(1)
 	}
+	if err = (&controllers.SecretReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("Secret"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Secret")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	// Add the Metrics Service


### PR DESCRIPTION
### Description
Add a controller to watch changes to ES's secret
   - Predicate returns true if the updated secret name matches any cluster's name/namespace
   - compare the hash content of the secret. if changed, mark the node status to "restart"

/cc @ewolinetz @jcantrill 
/assign @ewolinetz 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1009
