### PR TITLE
LOG-1030: Adding degraded state to ES cluster status for prometheus case

### DIFF
--- a/apis/logging/v1/elasticsearch_types.go
+++ b/apis/logging/v1/elasticsearch_types.go
@@ -335,4 +335,5 @@ const (
 	Unschedulable            ClusterConditionType = "Unschedulable"
 	NodeStorage              ClusterConditionType = "NodeStorage"
 	CustomImage              ClusterConditionType = "CustomImageIgnored"
+	DegradedState            ClusterConditionType = "Degraded"
 )

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -70,7 +70,12 @@ func Reconcile(requestCluster *elasticsearchv1.Elasticsearch, requestClient clie
 
 	// Ensure existence of prometheus rules
 	if err := elasticsearchRequest.CreateOrUpdatePrometheusRules(); err != nil {
-		return kverrors.Wrap(err, "Failed to reconcile PrometheusRules for Elasticsearch cluster")
+		// no need to error out here, we can just mark ourselves as degraded and report why
+		elasticsearchRequest.UpdateDegradedCondition(true, "Missing Prometheus Rules", err.Error())
+	} else {
+		// TODO: when we eventually add additional cases to be degraded we will need to adjust this
+		// so we don't inadvertently remove other degraded status messages
+		elasticsearchRequest.UpdateDegradedCondition(false, "", "")
 	}
 
 	// Ensure index management is in place

--- a/internal/k8shandler/status.go
+++ b/internal/k8shandler/status.go
@@ -853,6 +853,30 @@ func updateInvalidReplicationCondition(status *api.ElasticsearchStatus, value v1
 	})
 }
 
+func (er *ElasticsearchRequest) UpdateDegradedCondition(value bool, reason, message string) {
+	cluster := er.cluster
+
+	statusValue := v1.ConditionFalse
+
+	if value {
+		statusValue = v1.ConditionTrue
+	}
+
+	updateConditionWithRetry(
+		cluster,
+		statusValue,
+		func(status *api.ElasticsearchStatus, statusValue v1.ConditionStatus) bool {
+			return updateESNodeCondition(&cluster.Status, &api.ClusterCondition{
+				Type:    api.DegradedState,
+				Status:  statusValue,
+				Reason:  reason,
+				Message: message,
+			})
+		},
+		er.client,
+	)
+}
+
 func updateUpdatingSettingsCondition(status *api.ElasticsearchStatus, value v1.ConditionStatus) bool {
 	return updateESNodeCondition(status, &api.ClusterCondition{
 		Type:   api.UpdatingSettings,

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -168,7 +169,7 @@ func addMetrics(ctx context.Context, cfg *rest.Config) {
 
 	// The ServiceMonitor is created in the same namespace where the operator is deployed
 	_, err = metrics.CreateServiceMonitors(cfg, operatorNs, services)
-	if err != nil {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		log.Info("Could not create ServiceMonitor object", "error", err)
 		// If this operator is deployed to a cluster without the prometheus-operator running, it will return
 		// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.


### PR DESCRIPTION
### Description
No longer block rest of configuration if prom errors occur -- will be marked as Degraded

/cc @lukas-vlcek @blockloop 

example output:
```
status:
  cluster:
    activePrimaryShards: 8
    activeShards: 16
    initializingShards: 0
    numDataNodes: 3
    numNodes: 3
    pendingTasks: 0
    relocatingShards: 0
    status: green
    unassignedShards: 0
  conditions:
  - lastTransitionTime: "2021-01-21T21:25:06Z"
    message: 'failed to build prometheus rule: failed to open file: open /etc/elasticsearch-operator/files/prometheus_recording_rules_bad.yml:
      no such file or directory'
    reason: Missing Prometheus Rules
    status: "True"
    type: Degraded
  nodes:
  - deploymentName: elasticsearch-cdm-od99jfcc-1
    upgradeStatus: {}
  - deploymentName: elasticsearch-cdm-od99jfcc-2
    upgradeStatus: {}
  - deploymentName: elasticsearch-cdm-od99jfcc-3
    upgradeStatus: {}
```

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1030
