### PR TITLE
Bug 1920215: LOG-1018: Updating IndexManagement to only create initial index template

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -14,6 +14,9 @@ const (
 	ElasticsearchDefaultImage   = "quay.io/openshift/origin-logging-elasticsearch6"
 	ProxyDefaultImage           = "quay.io/openshift/origin-elasticsearch-proxy:latest"
 	TheoreticalShardMaxSizeInMB = 40960
+
+	// OcpTemplatePrefix is the prefix all operator generated templates
+	OcpTemplatePrefix = "ocp-gen"
 )
 
 var (

--- a/internal/elasticsearch/templates.go
+++ b/internal/elasticsearch/templates.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/ViaQ/logerr/log"
+	"github.com/openshift/elasticsearch-operator/internal/constants"
 	estypes "github.com/openshift/elasticsearch-operator/internal/types/elasticsearch"
 	"github.com/openshift/elasticsearch-operator/internal/utils"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -76,7 +77,7 @@ func (ec *esClient) ListTemplates() (sets.String, error) {
 func (ec *esClient) GetIndexTemplates() (map[string]estypes.GetIndexTemplate, error) {
 	payload := &EsRequest{
 		Method: http.MethodGet,
-		URI:    "_template/common.*",
+		URI:    fmt.Sprintf("_template/common.*,%s-*", constants.OcpTemplatePrefix),
 	}
 
 	ec.fnSendEsRequest(ec.cluster, ec.namespace, payload, ec.k8sClient)

--- a/internal/k8shandler/index_management.go
+++ b/internal/k8shandler/index_management.go
@@ -8,13 +8,9 @@ import (
 
 	"github.com/ViaQ/logerr/log"
 	logging "github.com/openshift/elasticsearch-operator/apis/logging/v1"
+	"github.com/openshift/elasticsearch-operator/internal/constants"
 	"github.com/openshift/elasticsearch-operator/internal/indexmanagement"
 	esapi "github.com/openshift/elasticsearch-operator/internal/types/elasticsearch"
-)
-
-const (
-	// ocpTemplatePrefix is the prefix all operator generated templates
-	ocpTemplatePrefix = "ocp-gen"
 )
 
 func (er *ElasticsearchRequest) CreateOrUpdateIndexManagement() error {
@@ -79,7 +75,7 @@ func (er *ElasticsearchRequest) cullIndexManagement(mappings []logging.IndexMana
 	difference := existing.Difference(mappingNames)
 
 	for _, template := range difference.List() {
-		if strings.HasPrefix(template, ocpTemplatePrefix) {
+		if strings.HasPrefix(template, constants.OcpTemplatePrefix) {
 			if err := esClient.DeleteIndexTemplate(template); err != nil {
 				log.Error(err, "Unable to delete stale template in order to reconcile", "template", template)
 			}
@@ -112,7 +108,7 @@ func (er *ElasticsearchRequest) initializeIndexIfNeeded(mapping logging.IndexMan
 }
 
 func formatTemplateName(name string) string {
-	return fmt.Sprintf("%s-%s", ocpTemplatePrefix, name)
+	return fmt.Sprintf("%s-%s", constants.OcpTemplatePrefix, name)
 }
 
 func formatWriteAlias(mapping logging.IndexManagementPolicyMappingSpec) string {
@@ -129,6 +125,18 @@ func (er *ElasticsearchRequest) createOrUpdateIndexTemplate(mapping logging.Inde
 	replicas := int32(calculateReplicaCount(cluster))
 	aliases := append(mapping.Aliases, mapping.Name)
 	template := esapi.NewIndexTemplate(pattern, aliases, primaryShards, replicas)
+
+	// check to compare the current index templates vs what we just generated
+	templates, err := esClient.GetIndexTemplates()
+	if err != nil {
+		return err
+	}
+
+	for templateName := range templates {
+		if templateName == name {
+			return nil
+		}
+	}
 
 	return esClient.CreateIndexTemplate(name, template)
 }

--- a/internal/k8shandler/index_management_test.go
+++ b/internal/k8shandler/index_management_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	elasticsearch "github.com/openshift/elasticsearch-operator/apis/logging/v1"
+	"github.com/openshift/elasticsearch-operator/internal/constants"
 	"github.com/openshift/elasticsearch-operator/test/helpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -95,8 +96,18 @@ var _ = Describe("Index Management", func() {
 	})
 	Describe("#createOrUpdateIndexTemplate", func() {
 		BeforeEach(func() {
+
+			templateURI := fmt.Sprintf("_template/common.*,%s-*", constants.OcpTemplatePrefix)
+
 			chatter = helpers.NewFakeElasticsearchChatter(
 				map[string]helpers.FakeElasticsearchResponses{
+					templateURI: {
+						{
+							Error:      nil,
+							StatusCode: 200,
+							Body:       `{}`,
+						},
+					},
 					"_template/ocp-gen-node.infra": {
 						{
 							Error:      nil,
@@ -106,7 +117,7 @@ var _ = Describe("Index Management", func() {
 					},
 				},
 			)
-			request.esClient = helpers.NewFakeElasticsearchClient("elastichsearch", "openshift-logging", request.client, chatter)
+			request.esClient = helpers.NewFakeElasticsearchClient("elasticsearch", "openshift-logging", request.client, chatter)
 		})
 		It("should create an elasticsearch index template to support the index", func() {
 			Expect(request.createOrUpdateIndexTemplate(mapping)).To(BeNil())


### PR DESCRIPTION
### Description
Before:
the IndexManagement logic would create and reseed the generated index templates and we also were updating existing index templates in another location.

With this PR:
EO only creates the initial index template if it does not yet exist on the cluster. All index template (idempotent) update logic co-located and only occurring when a cluster restart is not in progress.

/cc @lukas-vlcek @blockloop 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1018
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1920215
