### PR TITLE
Bug 1923791: Updating IndexManagement to only create initial index template

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -14,6 +14,9 @@ const (
 	ElasticsearchDefaultImage   = "quay.io/openshift/origin-logging-elasticsearch6"
 	ProxyDefaultImage           = "quay.io/openshift/origin-elasticsearch-proxy:latest"
 	TheoreticalShardMaxSizeInMB = 40960
+
+	// OcpTemplatePrefix is the prefix all operator generated templates
+	OcpTemplatePrefix = "ocp-gen"
 )
 
 var (

--- a/pkg/elasticsearch/templates.go
+++ b/pkg/elasticsearch/templates.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/openshift/elasticsearch-operator/pkg/constants"
 	"github.com/openshift/elasticsearch-operator/pkg/log"
 	estypes "github.com/openshift/elasticsearch-operator/pkg/types/elasticsearch"
 	"github.com/openshift/elasticsearch-operator/pkg/utils"
@@ -72,7 +73,7 @@ func (ec *esClient) ListTemplates() (sets.String, error) {
 func (ec *esClient) GetIndexTemplates() (map[string]estypes.GetIndexTemplate, error) {
 	payload := &EsRequest{
 		Method: http.MethodGet,
-		URI:    "_template/common.*",
+		URI:    fmt.Sprintf("_template/common.*,%s-*", constants.OcpTemplatePrefix),
 	}
 
 	ec.fnSendEsRequest(ec.cluster, ec.namespace, payload, ec.k8sClient)

--- a/pkg/k8shandler/index_management_test.go
+++ b/pkg/k8shandler/index_management_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	elasticsearch "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+	"github.com/openshift/elasticsearch-operator/pkg/constants"
 	"github.com/openshift/elasticsearch-operator/test/helpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -97,8 +98,18 @@ var _ = Describe("Index Management", func() {
 	})
 	Describe("#createOrUpdateIndexTemplate", func() {
 		BeforeEach(func() {
+
+			templateURI := fmt.Sprintf("_template/common.*,%s-*", constants.OcpTemplatePrefix)
+
 			chatter = helpers.NewFakeElasticsearchChatter(
 				map[string]helpers.FakeElasticsearchResponses{
+					templateURI: {
+						{
+							Error:      nil,
+							StatusCode: 200,
+							Body:       `{}`,
+						},
+					},
 					"_template/ocp-gen-node.infra": {
 						{
 							Error:      nil,
@@ -108,7 +119,7 @@ var _ = Describe("Index Management", func() {
 					},
 				},
 			)
-			request.esClient = helpers.NewFakeElasticsearchClient("elastichsearch", "openshift-logging", request.client, chatter)
+			request.esClient = helpers.NewFakeElasticsearchClient("elasticsearch", "openshift-logging", request.client, chatter)
 		})
 		It("should create an elasticsearch index template to support the index", func() {
 			Expect(request.createOrUpdateIndexTemplate(mapping)).To(BeNil())

--- a/pkg/k8shandler/migrations/pvc_naming.go
+++ b/pkg/k8shandler/migrations/pvc_naming.go
@@ -1,0 +1,9 @@
+package migrations
+
+func (mr *migrationRequest) createRenamedPVC() error {
+	return nil
+}
+
+func (mr *migrationRequest) rebindPV() error {
+	return nil
+}


### PR DESCRIPTION
### Description
Manual cherry-pick of #632 

Before:
the IndexManagement logic would create and reseed the generated index templates and we also were updating existing index templates in another location.

With this PR:
EO only creates the initial index template if it does not yet exist on the cluster. All index template (idempotent) update logic co-located and only occurring when a cluster restart is not in progress.

/cc @huikang 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1923791