### PR TITLE
[release-4.6] bug 1923788: fix ES node retart after secret update

### DIFF
--- a/pkg/controller/add_controllers.go
+++ b/pkg/controller/add_controllers.go
@@ -3,10 +3,12 @@ package controller
 import (
 	"github.com/openshift/elasticsearch-operator/pkg/controller/elasticsearch"
 	"github.com/openshift/elasticsearch-operator/pkg/controller/kibana"
+	"github.com/openshift/elasticsearch-operator/pkg/controller/secret"
 )
 
 func init() {
 	AddToManagerFuncs = append(AddToManagerFuncs,
 		kibana.Add,
-		elasticsearch.Add)
+		elasticsearch.Add,
+		secret.Add)
 }

--- a/pkg/controller/secret/controller.go
+++ b/pkg/controller/secret/controller.go
@@ -1,0 +1,103 @@
+// test
+
+package secret
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	// metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	loggingv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+	"github.com/openshift/elasticsearch-operator/pkg/k8shandler"
+)
+
+// Add creates a new Secret Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileSecret{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("secret-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for updates to the kibana secret
+	secretPred := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			cluster := &loggingv1.Elasticsearch{}
+			esName := types.NamespacedName{
+				Namespace: e.MetaNew.GetNamespace(),
+				Name:      e.MetaNew.GetName(),
+			}
+			err := mgr.GetClient().Get(context.TODO(), esName, cluster)
+			if err != nil {
+				return false
+			}
+			return true
+		},
+		CreateFunc:  func(e event.CreateEvent) bool { return false },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+
+	// Watch for changes to primary resource Secret
+	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{}, secretPred)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// blank assignment to verify that ReconcileSecret implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileSecret{}
+
+// ReconcileSecret reconciles a Secret object
+type ReconcileSecret struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+func (r *ReconcileSecret) Reconcile(req reconcile.Request) (reconcile.Result, error) {
+
+	cluster := &loggingv1.Elasticsearch{}
+	esName := types.NamespacedName{
+		Namespace: req.Namespace,
+		Name:      req.Name,
+	}
+
+	err := r.client.Get(context.TODO(), esName, cluster)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	err = k8shandler.SecretReconcile(cluster, r.client)
+
+	return reconcile.Result{}, err
+}

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -96,6 +96,10 @@ func (node *deploymentNode) name() string {
 	return node.self.Name
 }
 
+func (node *deploymentNode) getSecretHash() string {
+	return node.secretHash
+}
+
 func (node *deploymentNode) state() api.ElasticsearchNodeStatus {
 
 	//var rolloutForReload v1.ConditionStatus

--- a/pkg/k8shandler/nodetypefactory.go
+++ b/pkg/k8shandler/nodetypefactory.go
@@ -19,6 +19,7 @@ type NodeTypeInterface interface {
 	isMissing() bool
 	name() string
 	delete() error
+	getSecretHash() string
 
 	refreshHashes()
 	scaleDown() error

--- a/pkg/k8shandler/reconciler.go
+++ b/pkg/k8shandler/reconciler.go
@@ -1,12 +1,16 @@
 package k8shandler
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
 	elasticsearchv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
 	"github.com/openshift/elasticsearch-operator/pkg/elasticsearch"
 	"github.com/openshift/elasticsearch-operator/pkg/log"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -24,6 +28,49 @@ func (er *ElasticsearchRequest) L() logr.Logger {
 		er.ll = log.WithValues("cluster", er.cluster.Name, "namespace", er.cluster.Namespace)
 	}
 	return er.ll
+}
+
+func SecretReconcile(requestCluster *elasticsearchv1.Elasticsearch, requestClient client.Client) error {
+	var secretChanged bool
+
+	newSecretHash := getSecretDataHash(requestCluster.Name, requestCluster.Namespace, requestClient)
+
+	nretries := -1
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		nretries++
+
+		cluster := &elasticsearchv1.Elasticsearch{}
+		if err := requestClient.Get(context.TODO(), types.NamespacedName{Name: requestCluster.Name, Namespace: requestCluster.Namespace}, cluster); err != nil {
+			return err
+		}
+
+		// compare the new secret with current one in the nodes
+		for _, node := range nodes[nodeMapKey(requestCluster.Name, requestCluster.Namespace)] {
+			if node.getSecretHash() != "" && newSecretHash != node.getSecretHash() {
+
+				// Cluster's secret has been updated, update the cluster status to be redeployed
+				_, nodeStatus := getNodeStatus(node.name(), &cluster.Status)
+				if nodeStatus.UpgradeStatus.ScheduledForCertRedeploy != corev1.ConditionTrue {
+					secretChanged = true
+					nodeStatus.UpgradeStatus.ScheduledForCertRedeploy = corev1.ConditionTrue
+				}
+			}
+		}
+
+		if secretChanged {
+			if err := requestClient.Status().Update(context.TODO(), cluster); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	if retryErr != nil {
+		return fmt.Errorf("Error: failed to update status for cert redeploys %v after %v retries: %v",
+			requestCluster.Name, nretries, retryErr)
+	}
+
+	return nil
 }
 
 func Reconcile(requestCluster *elasticsearchv1.Elasticsearch, requestClient client.Client) error {

--- a/pkg/k8shandler/statefulset.go
+++ b/pkg/k8shandler/statefulset.go
@@ -105,6 +105,10 @@ func (n *statefulSetNode) scaleUp() error {
 	return n.setReplicaCount(n.replicas)
 }
 
+func (node *statefulSetNode) getSecretHash() string {
+	return node.secretHash
+}
+
 func (n *statefulSetNode) state() api.ElasticsearchNodeStatus {
 	//var rolloutForReload v1.ConditionStatus
 	var rolloutForUpdate v1.ConditionStatus


### PR DESCRIPTION
### Description

Manual cherry pick #628 

- add a secret controller to detect changes to ES secret and mark
  the ES ndoe to be scheduled for redeploy.

/cc @ewolinetz @jcantrill 
/assign @ewolinetz 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1923788
