### PR TITLE
LOG-959: Adding degraded condition for when we are missing the required secret/fields for ES

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -22,6 +22,14 @@ const (
 var (
 	ReconcileForGlobalProxyList = []string{KibanaTrustedCAName}
 	packagedElasticsearchImage  = utils.LookupEnvWithDefault("ELASTICSEARCH_IMAGE", ElasticsearchDefaultImage)
+	ExpectedSecretKeys          = []string{
+		"admin-ca",
+		"admin-cert",
+		"admin-key",
+		"elasticsearch.crt",
+		"elasticsearch.key",
+		"logging-es.crt",
+		"logging-es.key"}
 )
 
 func PackagedElasticsearchImage() string {

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -33,6 +33,17 @@ func (er *ElasticsearchRequest) L() logr.Logger {
 func SecretReconcile(requestCluster *elasticsearchv1.Elasticsearch, requestClient client.Client) error {
 	var secretChanged bool
 
+	elasticsearchRequest := ElasticsearchRequest{
+		client:  requestClient,
+		cluster: requestCluster,
+		ll:      log.WithValues("cluster", requestCluster.Name, "namespace", requestCluster.Namespace),
+	}
+
+	// evaluate if we are missing the required secret/certs
+	if ok, missing := elasticsearchRequest.hasRequiredSecrets(); !ok {
+		elasticsearchRequest.UpdateDegradedCondition(true, "Missing Required Secrets", missing)
+	}
+
 	newSecretHash := getSecretDataHash(requestCluster.Name, requestCluster.Namespace, requestClient)
 
 	nretries := -1
@@ -84,6 +95,8 @@ func Reconcile(requestCluster *elasticsearchv1.Elasticsearch, requestClient clie
 		ll:       log.WithValues("cluster", requestCluster.Name, "namespace", requestCluster.Namespace),
 	}
 
+	degradedCondition := false
+
 	// Ensure existence of servicesaccount
 	if err := elasticsearchRequest.CreateOrUpdateServiceAccount(); err != nil {
 		return kverrors.Wrap(err, "Failed to reconcile ServiceAccount for Elasticsearch cluster")
@@ -117,19 +130,35 @@ func Reconcile(requestCluster *elasticsearchv1.Elasticsearch, requestClient clie
 		return kverrors.Wrap(err, "Failed to reconcile Service Monitors for Elasticsearch cluster")
 	}
 
+	/* Priority for evaluating degraded state
+	   To properly denote priority of degraded states, we check them in the reverse
+	   order of what this list shows (so that the higher priority message can replace
+	   lower priorty ones).
+
+	1. missing certs
+	2. missing prom rules/alerts
+	*/
+
 	// Ensure existence of prometheus rules
 	if err := elasticsearchRequest.CreateOrUpdatePrometheusRules(); err != nil {
 		// no need to error out here, we can just mark ourselves as degraded and report why
 		elasticsearchRequest.UpdateDegradedCondition(true, "Missing Prometheus Rules", err.Error())
-	} else {
-		// TODO: when we eventually add additional cases to be degraded we will need to adjust this
-		// so we don't inadvertently remove other degraded status messages
-		elasticsearchRequest.UpdateDegradedCondition(false, "", "")
+		degradedCondition = true
+	}
+
+	// evaluate if we are missing the required secret/certs
+	if ok, missing := elasticsearchRequest.hasRequiredSecrets(); !ok {
+		elasticsearchRequest.UpdateDegradedCondition(true, "Missing Required Secrets", missing)
+		degradedCondition = true
 	}
 
 	// Ensure index management is in place
 	if err := elasticsearchRequest.CreateOrUpdateIndexManagement(); err != nil {
 		return kverrors.Wrap(err, "Failed to reconcile IndexMangement for Elasticsearch cluster")
+	}
+
+	if !degradedCondition {
+		elasticsearchRequest.UpdateDegradedCondition(false, "", "")
 	}
 
 	return nil

--- a/internal/k8shandler/secret.go
+++ b/internal/k8shandler/secret.go
@@ -4,27 +4,30 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"strings"
 
+	"github.com/openshift/elasticsearch-operator/internal/constants"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func getSecret(secretName, namespace string, client client.Client) *v1.Secret {
+func getSecret(secretName, namespace string, client client.Client) (*v1.Secret, error) {
 	secret := v1.Secret{}
 
 	err := client.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: namespace}, &secret)
-	if err != nil {
-		// check if doesn't exist
-	}
 
-	return &secret
+	return &secret, err
 }
 
 func getSecretDataHash(secretName, namespace string, client client.Client) string {
 	hash := ""
 
-	secret := getSecret(secretName, namespace, client)
+	secret, err := getSecret(secretName, namespace, client)
+	if err != nil {
+		return hash
+	}
 
 	dataHashes := make(map[string][32]byte)
 
@@ -39,4 +42,47 @@ func getSecretDataHash(secretName, namespace string, client client.Client) strin
 	}
 
 	return hash
+}
+
+// hasRequiredSecrets will check that all secrets that we expect for EO to be able to communicate
+// with the ES cluster it manages exist.
+// It will return true if all required secrets/keys exist.
+// Otherwise, it will return false and the message will be populated with what is missing.
+func (er ElasticsearchRequest) hasRequiredSecrets() (bool, string) {
+
+	message := ""
+	hasRequired := true
+
+	secret, err := getSecret(er.cluster.Name, er.cluster.Namespace, er.client)
+
+	// check that the secret is there
+	if apierrors.IsNotFound(err) {
+		return false, fmt.Sprintf("Expected secret %q in namespace %q is missing", er.cluster.Name, er.cluster.Namespace)
+	}
+
+	var missingCerts []string
+	var secretKeys []string
+
+	for key, data := range secret.Data {
+		// check that the fields aren't blank
+		if string(data) == "" {
+			missingCerts = append(missingCerts, key)
+		}
+
+		secretKeys = append(secretKeys, key)
+	}
+
+	// check the fields are there
+	for _, key := range constants.ExpectedSecretKeys {
+		if !sliceContainsString(secretKeys, key) {
+			missingCerts = append(missingCerts, key)
+		}
+	}
+
+	if len(missingCerts) > 0 {
+		message = fmt.Sprintf("Secret %q fields are either missing or empty: [%s]", er.cluster.Name, strings.Join(missingCerts, ", "))
+		hasRequired = false
+	}
+
+	return hasRequired, message
 }


### PR DESCRIPTION
### Description
Adding `Degraded` condition for when we are missing required secret/fields for communicating with Elasticsearch.
This degraded condition will take priority over the current missing prometheus alerts since EO not being able to communicate with ES means the operator cannot perform any operations on the cluster.

Missing field(s):
```
  conditions:
  - lastTransitionTime: "2021-02-09T22:36:37Z"
    message: 'Secret "elasticsearch" fields are either missing or empty: [admin-ca,
      admin-cert, admin-key]'
    reason: Missing Required Secrets
    status: "True"
    type: Degraded

```

Missing secret:
```
  conditions:
  - lastTransitionTime: "2021-02-09T22:03:42Z"
    message: Expected secret "elasticsearch" in namespace "openshift-logging" is missing
    reason: Missing Required Secrets
    status: "True"
    type: Degraded
```

/cc @blockloop @periklis 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-959
