### PR TITLE
Bug 1919075: Condense indexmanagement into single cronjob

### DIFF
--- a/pkg/indexmanagement/reconcile_test.go
+++ b/pkg/indexmanagement/reconcile_test.go
@@ -20,14 +20,13 @@ var _ = Describe("Index Management", func() {
 	defer GinkgoRecover()
 
 	var (
-		primaryShards      = int32(1)
-		apiclient          client.Client
-		testclient         *fakeruntime.FakeClient
-		cluster            *apis.Elasticsearch
-		policy             apis.IndexManagementPolicySpec
-		mapping            apis.IndexManagementPolicyMappingSpec
-		cronjob            *batch.CronJob
-		fnContainerHandler = func(container *core.Container) {}
+		primaryShards = int32(1)
+		apiclient     client.Client
+		testclient    *fakeruntime.FakeClient
+		cluster       *apis.Elasticsearch
+		policy        apis.IndexManagementPolicySpec
+		mapping       apis.IndexManagementPolicyMappingSpec
+		cronjob       *batch.CronJob
 	)
 	BeforeEach(func() {
 		apiclient = fake.NewFakeClient()
@@ -51,8 +50,39 @@ var _ = Describe("Index Management", func() {
 		}
 		selector := map[string]string{}
 		tolerations := []core.Toleration{}
-		name := fmt.Sprintf("%s-rollover-%s", cluster.Name, policy.Name)
-		cronjob = newCronJob(cluster.Name, "animage", cluster.Namespace, name, "*/5 * * * *", selector, tolerations, []core.EnvVar{}, fnContainerHandler)
+		name := fmt.Sprintf("%s-im-%s", cluster.Name, mapping.Name)
+		cronjob = newCronJob(cluster.Name, cluster.Namespace, name, "*/5 * * * *", "", selector, tolerations, []core.EnvVar{})
+	})
+	Describe("#formatCmd", func() {
+		Context("with no policies", func() {
+			It("should return an empty command", func() {
+				Expect(formatCmd(apis.IndexManagementPolicySpec{})).To(BeEmpty())
+			})
+
+		})
+		Context("with delete phase", func() {
+			It("should format the command for delete", func() {
+				policy.Phases.Delete = &apis.IndexManagementDeletePhaseSpec{}
+				Expect(formatCmd(policy)).To(Equal("./delete;delete_rc=$?;$(exit $delete_rc)"))
+			})
+
+		})
+		Context("with rollover phase", func() {
+			It("should format the command for rollover", func() {
+				policy.Phases.Hot = &apis.IndexManagementHotPhaseSpec{}
+				Expect(formatCmd(policy)).To(Equal("./rollover;rollover_rc=$?;$(exit $rollover_rc)"))
+
+			})
+
+		})
+		Context("with delete and rollover phases", func() {
+			It("should format the command for all phases", func() {
+				policy.Phases.Delete = &apis.IndexManagementDeletePhaseSpec{}
+				policy.Phases.Hot = &apis.IndexManagementHotPhaseSpec{}
+				Expect(formatCmd(policy)).To(Equal("./delete;delete_rc=$?;./rollover;rollover_rc=$?;$(exit $delete_rc&&exit $rollover_rc)"))
+			})
+
+		})
 	})
 	Describe("#reconcileCronJob", func() {
 		var fnCronsAreSame = func(lhs, rhs *batch.CronJob) bool {
@@ -101,68 +131,12 @@ var _ = Describe("Index Management", func() {
 			})
 		})
 	})
-	Describe("#ReconcileCurationCronjob", func() {
-		BeforeEach(func() {
-			selector := map[string]string{}
-			tolerations := []core.Toleration{}
-			name := fmt.Sprintf("%s-delete-%s", cluster.Name, policy.Name)
-			cronjob = newCronJob(cluster.Name, "anImage", cluster.Namespace, name, "*/5 * * * *", selector, tolerations, []core.EnvVar{}, fnContainerHandler)
-			policy.Phases.Delete = &apis.IndexManagementDeletePhaseSpec{
-				MinAge: "7d",
-			}
-		})
-
-		Describe("for invalid poll interval", func() {
-			It("should not create the cronjob and return the error", func() {
-				policy.PollInterval = "notavalue"
-				Expect(ReconcileCurationCronjob(apiclient, cluster, policy, mapping, primaryShards)).To(Not(BeNil()))
-			})
-		})
-		Describe("when trying to create the cronjob", func() {
-			Context("and no delete phase exists", func() {
-				It("should return without error", func() {
-					policy.Phases.Delete = nil
-					apiclient = fake.NewFakeClient(cronjob)
-					err := ReconcileCurationCronjob(apiclient, cluster, policy, mapping, primaryShards)
-					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
-				})
-			})
-			Context("and does not error", func() {
-				It("should return without error", func() {
-					apiclient = fake.NewFakeClient(cronjob)
-					err := ReconcileCurationCronjob(apiclient, cluster, policy, mapping, primaryShards)
-					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
-				})
-			})
-			Context("and errors for reasons other then already existing", func() {
-				It("should return the error", func() {
-					err := ReconcileCurationCronjob(apiclient, cluster, policy, mapping, primaryShards)
-					Expect(err).To(BeNil())
-				})
-
-			})
-			Context("and errors because it already exists", func() {
-				Context("when the current is different from the desired", func() {
-					It("should update the cronjob", func() {
-						cronjob.Spec.Schedule = "*/5 10 * * * *"
-						apiclient = fake.NewFakeClient(cronjob)
-						testclient = fakeruntime.NewFakeClient(apiclient, fakeruntime.NewAlreadyExistsException())
-						apiclient = testclient
-						err := ReconcileCurationCronjob(apiclient, cluster, policy, mapping, primaryShards)
-						Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
-						Expect(testclient.WasUpdated(cronjob.Name)).To(BeTrue(), "Exp. to update the cronjob")
-					})
-				})
-
-			})
-		})
-	})
-	Describe("#ReconcileRolloverCronjob", func() {
+	Describe("#ReconcileIndexManagementCronjob", func() {
 		BeforeEach(func() {
 			selector := map[string]string{}
 			tolerations := []core.Toleration{}
 			name := fmt.Sprintf("%s-rollover-%s", cluster.Name, policy.Name)
-			cronjob = newCronJob(cluster.Name, "animage", cluster.Namespace, name, "*/5 * * * *", selector, tolerations, []core.EnvVar{}, fnContainerHandler)
+			cronjob = newCronJob(cluster.Name, cluster.Namespace, name, "*/5 * * * *", "", selector, tolerations, []core.EnvVar{})
 			policy.Phases.Hot = &apis.IndexManagementHotPhaseSpec{
 				Actions: apis.IndexManagementActionsSpec{
 					Rollover: &apis.IndexManagementActionSpec{
@@ -170,25 +144,53 @@ var _ = Describe("Index Management", func() {
 					},
 				},
 			}
+			policy.Phases.Delete = &apis.IndexManagementDeletePhaseSpec{
+				MinAge: "7d",
+			}
 		})
-
 		Describe("for invalid poll interval", func() {
 			It("should not create the cronjob and return the error", func() {
 				policy.PollInterval = "notavalue"
-				Expect(ReconcileRolloverCronjob(apiclient, cluster, policy, mapping, primaryShards)).To(Not(BeNil()))
+				Expect(ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)).To(Not(Succeed()))
 			})
 		})
 		Describe("when trying to create the cronjob", func() {
+			Context("and no phases exist", func() {
+				It("should return without error", func() {
+					policy.Phases.Delete = nil
+					policy.Phases.Hot = nil
+					apiclient = fake.NewFakeClient(cronjob)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
+				})
+			})
+			Context("and no delete phase exists", func() {
+				It("should return without error", func() {
+					policy.Phases.Delete = nil
+					apiclient = fake.NewFakeClient(cronjob)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
+				})
+			})
+			Context("and no hot phase exists", func() {
+				It("should return without error", func() {
+					policy.Phases.Hot = nil
+					apiclient = fake.NewFakeClient(cronjob)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
+				})
+
+			})
 			Context("and does not error", func() {
 				It("should return without error", func() {
 					apiclient = fake.NewFakeClient(cronjob)
-					err := ReconcileRolloverCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
 					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 				})
 			})
 			Context("and errors for reasons other then already existing", func() {
 				It("should return the error", func() {
-					err := ReconcileRolloverCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
 					Expect(err).To(BeNil())
 				})
 
@@ -196,17 +198,17 @@ var _ = Describe("Index Management", func() {
 			Context("and errors because it already exists", func() {
 				Context("when the current is different from the desired", func() {
 					It("should update the cronjob", func() {
-						cronjob.Spec.Schedule = "*/5 10 * * * *"
+						newSchedule := "*/5 10 * * * *"
+						cronjob.Spec.Schedule = newSchedule
 						apiclient = fake.NewFakeClient(cronjob)
-						testclient = fakeruntime.NewFakeClient(apiclient, fakeruntime.NewAlreadyExistsException())
-						apiclient = testclient
-						err := ReconcileRolloverCronjob(apiclient, cluster, policy, mapping, primaryShards)
+						err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
 						Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
-						Expect(testclient.WasUpdated(cronjob.Name)).To(BeTrue(), "Exp. to update the cronjob")
+						Expect(cronjob.Spec.Schedule).To(Equal(newSchedule), "Exp. to update the cronjob")
 					})
 				})
 
 			})
 		})
 	})
+
 })

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,126 @@
+package log
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var (
+	once sync.Once
+
+	// empty logger to prevent nil pointer panics before Init is called
+	logger = zapr.NewLogger(zap.NewNop())
+
+	cfg = zap.Config{
+		Level:       zap.NewAtomicLevelAt(zap.InfoLevel),
+		Development: false,
+		Sampling: &zap.SamplingConfig{
+			Initial:    100,
+			Thereafter: 100,
+		},
+		Encoding:         "json",
+		EncoderConfig:    zap.NewProductionEncoderConfig(),
+		OutputPaths:      []string{"stdout"},
+		ErrorOutputPaths: []string{"stderr"},
+	}
+
+	// options
+	// disableStacktrace disables all stacktraces by setting the allowed level to 100, which is a number higher than the highest level of logging
+	disableStacktrace = zap.AddStacktrace(zap.NewAtomicLevelAt(zapcore.DPanicLevel))
+)
+
+// Init initializes the logger. This is required to use logging correctly
+// component is the name of the component being used to log messages. Typically this is your application name
+// keyValuePairs are default key/value pairs to be used with all logs in the future
+func Init(component string, keyValuePairs ...interface{}) {
+	once.Do(func() {
+		zap.AddCallerSkip(5)
+		zl, err := cfg.Build(disableStacktrace, zap.AddCallerSkip(2))
+		if err != nil {
+			// panic because this is a hard coding problem within the config itself that cannot be handled
+			// except by fixing the config struct itself.
+			panic(err)
+		}
+
+		logger = zapr.NewLogger(zl).
+			WithName(component)
+		if len(keyValuePairs) > 0 {
+			logger = logger.WithValues(keyValuePairs)
+		}
+	})
+}
+
+//proxyLogger is a minimal adapter to Logger to
+//facilitate backports to 4.6 due to the difference in
+//log libraries.  It does not provide equivalent log
+// capabilities
+type proxyLogger struct {
+	level int
+}
+
+func V(verbosity int) proxyLogger {
+	return proxyLogger{level: verbosity}
+}
+func (p proxyLogger) Info(msg string, keysAndValues ...interface{}) {
+	if p.level == 0 {
+		Info(msg, keysAndValues)
+	}
+}
+
+// Logger returns the singleton logger that was created via Init
+func Logger() logr.Logger {
+	return logger
+}
+func Wrap(err error, msg string) error {
+	return fmt.Errorf("%s: %v", msg, err)
+}
+
+// Info logs a non-error message with the given key/value pairs as context.
+//
+// The msg argument should be used to add some constant description to
+// the log line.  The key/value pairs can then be used to add additional
+// variable information.  The key/value pairs should alternate string
+// keys and arbitrary values.
+//
+// This is a package level function that is a shortcut for log.Logger().Info(...)
+func Info(msg string, keysAndValues ...interface{}) {
+	logger.Info(msg, keysAndValues...)
+}
+
+// Error logs an error, with the given message and key/value pairs as context.
+// It functions similarly to calling Info with the "error" named value, but may
+// have unique behavior, and should be preferred for logging errors (see the
+// package documentations for more information).
+//
+// The msg field should be used to add context to any underlying error,
+// while the err field should be used to attach the actual error that
+// triggered this log line, if present.
+//
+// This is a package level function that is a shortcut for log.Logger().Error(...)
+func Error(err error, msg string, keysAndValues ...interface{}) {
+	logger.Error(err, msg, keysAndValues...)
+}
+
+// WithValues adds some key-value pairs of context to a logger.
+// See Info for documentation on how key/value pairs work.
+//
+// This is a package level function that is a shortcut for log.Logger().WithValues(...)
+func WithValues(keysAndValues ...interface{}) logr.Logger {
+	return logger.WithValues(keysAndValues...)
+}
+
+// WithName adds a new element to the logger's name.
+// Successive calls with WithName continue to append
+// suffixes to the logger's name.  It's strongly recommended
+// that name segments contain only letters, digits, and hyphens
+// (see the package documentation for more information).
+//
+// This is a package level function that is a shortcut for log.Logger().WithName(...)
+func WithName(name string) logr.Logger {
+	return logger.WithName(name)
+}


### PR DESCRIPTION
### Description
This PR collapses the multiple policy cronjobs to a single job with multiple tasks it runs:

* delete
* rollover
* adds simple adapter to log package to facilitate cherrypicks from post 4.6

The reasoning is there is a potential race condition between the previous jobs which both rely upon a -write alias that may lead to false information. Additionally, ES does not have transactions or is ACID. By converting these into tasks we execute for management we:

* potentially free disk for ES to do additional work
* give a better chance for the rollover to be successful
May need to add a task to "unblock" the read-only index identified in the BZ
/cc @ewolinetz



### Links
backport of 4.6 https://github.com/openshift/elasticsearch-operator/pull/627
https://bugzilla.redhat.com/show_bug.cgi?id=1919075