### PR TITLE
Bug 1924657: Fix metrics ports exposed by operator deployment

### DIFF
--- a/bundle/manifests/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
@@ -264,8 +264,10 @@ spec:
                   command:
                   - elasticsearch-operator
                   ports:
-                  - containerPort: 60000
-                    name: metrics
+                  - containerPort: 8383
+                    name: http-metrics
+                  - containerPort: 8686
+                    name: cr-metrics
                   env:
                     - name: WATCH_NAMESPACE
                       valueFrom:


### PR DESCRIPTION
### Description
This PR provides a small fix in the ClusterServiceVersion deployment manifest for the elasticsearch-operator. The fix provides the correct container ports to expose http and cr metrics as expected by OLM-managed deployments.

/cc @blockloop 
/assign @ewolinetz 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1924657
