### PR TITLE
use image env vars instead of IMAGE_FORMAT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,8 +180,6 @@ test-e2e-upgrade:
 # IMAGE_ELASTICSEARCH_PROXY
 # IMAGE_LOGGING_KIBANA6
 # IMAGE_OAUTH_PROXY
-# or the image format:
-# IMAGE_FORMAT
 #
 # You must also set:
 # ELASTICSEARCH_OPERATOR_NAMESPACE (Default: openshift-operators-redhat)

--- a/hack/testing-olm-upgrade/upgrade-common
+++ b/hack/testing-olm-upgrade/upgrade-common
@@ -566,10 +566,7 @@ patch_subscription() {
 
 check_deployment_rolled_out() {
   log::info "Checking if deployment successfully updated..."
-  IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-registry.svc.ci.openshift.org/ocp/${version}:elasticsearch-operator}
-  if [ -n "${IMAGE_FORMAT:-}" ] ; then
-    IMAGE_ELASTICSEARCH_OPERATOR=$(echo $IMAGE_FORMAT | sed -e "s,\${component},elasticsearch-operator,")
-  fi
+  IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-registry.ci.openshift.org/logging/${version}:elasticsearch-operator}
   log::info "Checking if deployment version is ${IMAGE_ELASTICSEARCH_OPERATOR}..."
   try_until_text "oc -n openshift-operators-redhat get deployment elasticsearch-operator -o jsonpath={.spec.template.spec.containers[0].image}" "${IMAGE_ELASTICSEARCH_OPERATOR}" ${TIMEOUT_MIN}
 }

--- a/olm_deploy/scripts/catalog-deploy.sh
+++ b/olm_deploy/scripts/catalog-deploy.sh
@@ -1,22 +1,14 @@
 #!/bin/bash
 set -eou pipefail
-OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.7}
-export IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY=${IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:elasticsearch-operator-registry}
-export IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:elasticsearch-operator}
-export IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:logging-elasticsearch6}
-export IMAGE_ELASTICSEARCH_PROXY=${IMAGE_ELASTICSEARCH_PROXY:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:elasticsearch-proxy}
-export IMAGE_LOGGING_KIBANA6=${IMAGE_LOGGING_KIBANA6:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:logging-kibana6}
-export IMAGE_OAUTH_PROXY=${IMAGE_OAUTH_PROXY:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:oauth-proxy}
+OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-tech-preview}
+LOGGING_IS=${LOGGING_IS:-logging}
+export IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY=${IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY:-registry.ci.openshift.org/${LOGGING_IS}/${OPENSHIFT_VERSION}:elasticsearch-operator-registry}
+export IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-registry.ci.openshift.org/${LOGGING_IS}/${OPENSHIFT_VERSION}:elasticsearch-operator}
+export IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-registry.ci.openshift.org/${LOGGING_IS}/${OPENSHIFT_VERSION}:logging-elasticsearch6}
+export IMAGE_ELASTICSEARCH_PROXY=${IMAGE_ELASTICSEARCH_PROXY:-registry.ci.openshift.org/${LOGGING_IS}/${OPENSHIFT_VERSION}:elasticsearch-proxy}
+export IMAGE_LOGGING_KIBANA6=${IMAGE_LOGGING_KIBANA6:-registry.ci.openshift.org/${LOGGING_IS}/${OPENSHIFT_VERSION}:logging-kibana6}
+export IMAGE_OAUTH_PROXY=${IMAGE_OAUTH_PROXY:-registry.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:oauth-proxy}
 ELASTICSEARCH_OPERATOR_NAMESPACE=${ELASTICSEARCH_OPERATOR_NAMESPACE:-openshift-operators-redhat}
-
-if [ -n "${IMAGE_FORMAT:-}" ] ; then
-  export IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY=$(echo $IMAGE_FORMAT | sed -e "s,\${component},elasticsearch-operator-registry,")
-  export IMAGE_ELASTICSEARCH_OPERATOR=$(echo $IMAGE_FORMAT | sed -e "s,\${component},elasticsearch-operator,")
-  export IMAGE_ELASTICSEARCH6=$(echo $IMAGE_FORMAT | sed -e "s,\${component},logging-elasticsearch6,")
-  export IMAGE_ELASTICSEARCH_PROXY=$(echo $IMAGE_FORMAT | sed -e "s,\${component},elasticsearch-proxy,")
-  export IMAGE_LOGGING_KIBANA6=$(echo $IMAGE_FORMAT | sed -e "s,\${component},logging-kibana6,")
-  export IMAGE_OAUTH_PROXY=$(echo $IMAGE_FORMAT | sed -e "s,\${component},oauth-proxy,")
-fi
 
 echo "Using images: "
 echo "elastic operator registry: ${IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY}"

--- a/olm_deploy/scripts/registry-init.sh
+++ b/olm_deploy/scripts/registry-init.sh
@@ -20,7 +20,7 @@ sed -i "s,quay.io/openshift/origin-oauth-proxy:latest,${IMAGE_OAUTH_PROXY}," /ma
 sed -i "s,quay.io/openshift/origin-logging-kibana6:latest,${IMAGE_LOGGING_KIBANA6}," /manifests/*/*clusterserviceversion.yaml
 
 # update the manifest to pull always the operator image for non-CI environments
-if [ -z "${IMAGE_FORMAT:-}" ] ; then
+if [ "${OPENSHIFT_CI:-false}" == "false" ] ; then
     echo -e "Set operator deployment's imagePullPolicy to 'Always'\n\n"
     sed -i 's,imagePullPolicy:\ IfNotPresent,imagePullPolicy:\ Always,' /manifests/*/*clusterserviceversion.yaml
 fi


### PR DESCRIPTION
(cherry picked from commit 01a3b161bc97e15acff9d1ad68cc1cb7b6243028)
### Description
This PR
* removes IMAGE_FORMAT in deference to images defined via env vars
* IMAGE_FORMAT has been deprecated for over a year
* CI was modified to tag in image refs via "pipelines" that are consumable by env vars
* update dev imagestream to be "logging"
/cc @periklis @vimalk78 @ewolinetz 

backport of https://github.com/openshift/elasticsearch-operator/pull/655