### PR TITLE
Log-316: Elasticsearch Operator Telemetry

### DIFF
--- a/controllers/logging/elasticsearch_controller.go
+++ b/controllers/logging/elasticsearch_controller.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/openshift/elasticsearch-operator/internal/metrics"
+
 	"github.com/ViaQ/logerr/log"
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
@@ -49,8 +51,12 @@ func (r *ElasticsearchReconciler) Reconcile(request ctrl.Request) (ctrl.Result, 
 	}
 
 	if cluster.Spec.ManagementState == loggingv1.ManagementStateUnmanaged {
+		// Cluster state changes from Managed -> Unmanaged, so set "unmanaged" as 1 and set "managed" as 0.
+		metrics.SetEsClusterManagementStateUnmanaged()
 		return ctrl.Result{}, nil
 	}
+	// Cluster state changes from Unmanaged -> Managed, so set "managed" as 1 and set "unmanaged" as 0.
+	metrics.SetEsClusterManagementStateManaged()
 
 	if cluster.Spec.Spec.Image != "" {
 		if cluster.Status.Conditions == nil {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,83 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	CertRestart 		string = "cert_restart"
+	RollingRestart 		string = "rolling_restart"
+	ScheduledRestart 	string = "scheduled_restart"
+	ManagedState		string = "managed"
+	UnmanagedState		string = "unmanaged"
+)
+
+var (
+	restartCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eo_elasticsearch_cr_restart_total",
+			Help: "Total number of times the nodes restarted due to Cert Restart or Rolling Restart or Scheduled Restart.",
+		}, []string{"reason"})
+
+	esClusterManagementState = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "eo_elasticsearch_cr_cluster_management_state",
+			Help: "Number of Elasticsearch cluster that are in Managed state or Unmanaged state.",
+		}, []string{"state"})
+
+	metricList = []prometheus.Collector{
+		restartCounter,
+		esClusterManagementState,
+	}
+)
+
+//This function registers the custom metrics to the kubernetes controller-runtime default metrics.
+func RegisterCustomMetrics() {
+	for _, metric := range metricList {
+		metrics.Registry.MustRegister(metric)
+	}
+}
+
+//Increment the metric value by "1" when the node restarts due to cert.
+func IncrementRestartCounterCert() {
+	restartCounter.With(prometheus.Labels{
+		"reason": CertRestart,
+	}).Inc()
+}
+
+//Increment the metric value by "1" when the node restarts due to rolling.
+func IncrementRestartCounterRolling() {
+	restartCounter.With(prometheus.Labels{
+		"reason": RollingRestart,
+	}).Inc()
+}
+
+//Increment the metric value by "1" when the node is scheduled for cert restart or rolling restart.
+func IncrementRestartCounterScheduled() {
+	restartCounter.With(prometheus.Labels{
+		"reason": ScheduledRestart,
+	}).Inc()
+}
+
+//Sets the metric value to "n" when the ES Cluster Management State is Managed.
+func SetEsClusterManagementStateManaged() {
+	esClusterManagementState.With(prometheus.Labels{
+		"state": ManagedState,
+	}).Set(1)
+
+	esClusterManagementState.With(prometheus.Labels{
+		"state": UnmanagedState,
+	}).Set(0)
+}
+
+//Sets the metric value to "n" when the ES Cluster Management State is Unmanaged.
+func SetEsClusterManagementStateUnmanaged() {
+	esClusterManagementState.With(prometheus.Labels{
+		"state": ManagedState,
+	}).Set(0)
+
+	esClusterManagementState.With(prometheus.Labels{
+		"state": UnmanagedState,
+	}).Set(1)
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/openshift/elasticsearch-operator/internal/metrics"
 	"os"
 	"runtime"
 
@@ -108,6 +109,9 @@ func main() {
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder
+
+	log.Info("Registering custom metrics for Elasticsearch Operator.")
+	metrics.RegisterCustomMetrics()
 
 	ll.Info("This operator no longer honors the image specified by the custom resources so that it is able to properly coordinate the configuration with the image.")
 	ll.Info("Starting the manager.")


### PR DESCRIPTION
### Description
This PR:
- Exposes custom metrics which can be scraped by monitoring prometheus.
- This can be queried via the OCP dashboard (Monitoring -> Metrics).

/cc @periklis 
/assign @ewolinetz 

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-316