### PR TITLE
Bug 1924657: Fix missing metrics port in manifests and bundle

### DIFF
--- a/bundle/manifests/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
     "operatorframework.io/suggested-namespace": openshift-operators-redhat
     "operatorframework.io/cluster-monitoring": "true"
     categories: "OpenShift Optional, Logging & Tracing"
-    capabilities: "Seamless Upgrades"
+    capabilities: "Full Lifecycle"
     certified: "false"
     description: |-
       The Elasticsearch Operator for OKD provides a means for configuring and managing an Elasticsearch cluster for tracing and cluster logging.
@@ -82,16 +82,39 @@ metadata:
         ]
 spec:
   version: 4.6.0
-  displayName: Elasticsearch Operator
+  displayName: OpenShift Elasticsearch Operator
   minKubeVersion: 1.18.3
 
   description: |
-    The Elasticsearch Operator for OKD provides a means for configuring and managing an Elasticsearch cluster for use in tracing and cluster logging.
-    This operator only supports OKD Cluster Logging and Jaeger.  It is tightly coupled to each and is not currently capable of
-    being used as a general purpose manager of Elasticsearch clusters running on OKD.
+    The Elasticsearch Operator for OCP provides a means for configuring and managing an Elasticsearch cluster for use in tracing 
+    and cluster logging as well as a Kibana instance to connect to it.
+    This operator only supports OCP Cluster Logging and Jaeger.  It is tightly coupled to each and is not currently capable of
+    being used as a general purpose manager of Elasticsearch clusters running on OCP.
+    
+    Please note: For a general purpose Elasticsearch operator, please use Elastic's Elasticsearch (ECK) Operator [here](https://catalog.redhat.com/software/containers/elastic/eck-operator/5fabf6d1ecb52450895164be?container-tabs=gti)
 
-    Once installed, the operator provides the following features:
-    * **Create/Destroy**: Deploy an Elasticsearch cluster to the same namespace in which the Elasticsearch custom resource is created.
+    It is recommended that this operator be installed in the `openshift-operators-redhat` namespace to 
+    properly support the Cluster Logging and Jaeger use cases.
+
+    Once installed, the operator provides the following features for **Elasticsearch**:
+    * **Create/Destroy**: Deploy an Elasticsearch cluster to the same namespace in which the elasticsearch CR is created.
+    * **Update**: Changes to the elasticsearch CR will be scheduled and applied to the cluster in a controlled manner (most often as a rolling upgrade).
+    * **Cluster health**: The operator will periodically poll the cluster to evaluate its current health (such as the number of active shards and if any cluster nodes have reached their storage watermark usage).
+    * **Redeploys**: In the case where the provided secrets are updated, the Elasticsearch Operator will schedule and perform a full cluster restart.
+    * **Index management**: The Elasticsearch Operator will create cronjobs to perform index management such as roll over and deletion.
+    
+    Once installed, the operator provides the following features for **Kibana**:
+    * **Create/Destroy**: Deploy a Kibana instance to the same namespace in which the kibana CR is created (this should be the same namespace as the elasticsearch CR).
+    * **Update**: Changes to the kibana CR will be scheduled and applied to the cluster in a controlled manner.
+    * **Redeploys**: In the case where the provided secrets are updated, the Elasticsearch Operator will perform a restart.
+    
+    ### Additionally provided features
+    * Out of the box multitenancy that is integrated with OCP user access control.
+    * Document Level Security
+    * mTLS communication between Elasticsearch, Kibana, Index Management cronjobs, and CLO's Fluentd
+    * OCP prometheus dashboard for Elasticsearch clusters
+    * Prometheus Alerting rules
+
 
   keywords: ['elasticsearch', 'jaeger']
 

--- a/bundle/manifests/logging.openshift.io_kibanas_crd.yaml
+++ b/bundle/manifests/logging.openshift.io_kibanas_crd.yaml
@@ -209,4 +209,5 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}

--- a/manifests/4.6/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/elasticsearch-operator.v4.6.0.clusterserviceversion.yaml
@@ -287,8 +287,10 @@ spec:
                   command:
                   - elasticsearch-operator
                   ports:
-                  - containerPort: 60000
-                    name: metrics
+                  - containerPort: 8383
+                    name: http-metrics
+                  - containerPort: 8686
+                    name: cr-metrics
                   env:
                     - name: WATCH_NAMESPACE
                       valueFrom:


### PR DESCRIPTION
### Description
This PR provides a small fix in the ClusterServiceVersion deployment manifest for the elasticsearch-operator. The fix provides the correct container ports to expose http and cr metrics as expected by OLM-managed deployments.

/cc @blockloop 
/assign @ewolinetz 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1924657
