### PR TITLE
BUG 1918920: requeue secret update event when the cluster is being ce…

### DIFF
--- a/controllers/logging/secret_controller.go
+++ b/controllers/logging/secret_controller.go
@@ -41,7 +41,10 @@ func (r *SecretReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 
-	err = k8shandler.SecretReconcile(cluster, r.Client)
+	ok, err := k8shandler.SecretReconcile(cluster, r.Client)
+	if !ok {
+		return reconcileResult, err
+	}
 	return ctrl.Result{}, err
 }
 

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -30,7 +30,8 @@ func (er *ElasticsearchRequest) L() logr.Logger {
 	return er.ll
 }
 
-func SecretReconcile(requestCluster *elasticsearchv1.Elasticsearch, requestClient client.Client) error {
+// SecretReconcile returns false if the event needs to be requeued
+func SecretReconcile(requestCluster *elasticsearchv1.Elasticsearch, requestClient client.Client) (bool, error) {
 	var secretChanged bool
 
 	elasticsearchRequest := ElasticsearchRequest{
@@ -42,6 +43,32 @@ func SecretReconcile(requestCluster *elasticsearchv1.Elasticsearch, requestClien
 	// evaluate if we are missing the required secret/certs
 	if ok, missing := elasticsearchRequest.hasRequiredSecrets(); !ok {
 		elasticsearchRequest.UpdateDegradedCondition(true, "Missing Required Secrets", missing)
+	}
+
+	// check if cluster is in the mid of cert redeploy
+	certRestartNodes := elasticsearchRequest.getScheduledCertRedeployNodes()
+	stillRecovering := containsClusterCondition(elasticsearchv1.Recovering, corev1.ConditionTrue, &elasticsearchRequest.cluster.Status)
+	if len(certRestartNodes) > 0 || stillRecovering {
+		// Requeue if there are nodes being scheduled CertRedeploy or under recovering
+		// and reset the certRedeploy status
+		for _, node := range nodes[nodeMapKey(requestCluster.Name, requestCluster.Namespace)] {
+			_, nodeStatus := getNodeStatus(node.name(), &elasticsearchRequest.cluster.Status)
+			nodeStatus.UpgradeStatus.ScheduledForCertRedeploy = corev1.ConditionFalse
+		}
+
+		updateESNodeCondition(&elasticsearchRequest.cluster.Status, &elasticsearchv1.ClusterCondition{
+			Type:   elasticsearchv1.Recovering,
+			Status: corev1.ConditionFalse,
+		})
+		updateESNodeCondition(&elasticsearchRequest.cluster.Status, &elasticsearchv1.ClusterCondition{
+			Type:   elasticsearchv1.Restarting,
+			Status: corev1.ConditionFalse,
+		})
+
+		if err := requestClient.Status().Update(context.TODO(), elasticsearchRequest.cluster); err != nil {
+			return true, err
+		}
+		return false, nil
 	}
 
 	newSecretHash := getSecretDataHash(requestCluster.Name, requestCluster.Namespace, requestClient)
@@ -77,12 +104,12 @@ func SecretReconcile(requestCluster *elasticsearchv1.Elasticsearch, requestClien
 	})
 
 	if retryErr != nil {
-		return kverrors.Wrap(retryErr, "failed to update status for cert redeploys",
+		return false, kverrors.Wrap(retryErr, "failed to update status for cert redeploys",
 			"cluster", requestCluster.Name,
 			"retries", nretries)
 	}
 
-	return nil
+	return true, nil
 }
 
 func Reconcile(requestCluster *elasticsearchv1.Elasticsearch, requestClient client.Client) error {


### PR DESCRIPTION
…rtRedeploy

### Description
In current implementation, when two secret update events occur in a short amount of time, the second event will not cause the cluster to be redeployed. This is because the cluster node state has already set to `nodeStatus.UpgradeStatus.ScheduledForCertRedeploy = corev1.ConditionTrue` by the first event. This PR adds the check of current cluster status in the secret reconciliation: requeue the event when the cluster is being `ScheduledForCertRedeploy`

/cc @ewolinetz 
/assign @periklis 

/cherry-pick release-5.0

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1918920
