### PR TITLE
WIP: Add reconciliation of kibana cluster uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-logr/zapr v0.2.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/go-cmp v0.5.0
+	github.com/google/uuid v1.1.1
 	github.com/inhies/go-bytesize v0.0.0-20151001220322-5990f52c6ad6
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1

--- a/internal/k8shandler/kibana/reconciler_test.go
+++ b/internal/k8shandler/kibana/reconciler_test.go
@@ -25,7 +25,7 @@ func TestNewKibanaPodSpecSetsProxyToUseServiceAccountAsOAuthClient(t *testing.T)
 			},
 		},
 	}
-	spec := newKibanaPodSpec(cluster, "kibana", nil, nil)
+	spec := newKibanaPodSpec(cluster, "kibana", nil, nil, "")
 	for _, arg := range spec.Containers[1].Args {
 		keyValue := strings.Split(arg, "=")
 		if len(keyValue) >= 2 && keyValue[0] == "-client-id" {
@@ -49,7 +49,7 @@ func TestNewKibanaPodSpecWhenFieldsAreUndefined(t *testing.T) {
 			},
 		},
 	}
-	podSpec := newKibanaPodSpec(cluster, "test-app-name", nil, nil)
+	podSpec := newKibanaPodSpec(cluster, "test-app-name", nil, nil, "")
 
 	if len(podSpec.Containers) != 2 {
 		t.Error("Exp. there to be 2 container")
@@ -99,7 +99,7 @@ func TestNewKibanaPodSpecWhenResourcesAreDefined(t *testing.T) {
 		},
 	}
 
-	podSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil)
+	podSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil, "")
 
 	limitMemory := resource.MustParse("100Gi")
 	requestMemory := resource.MustParse("120Gi")
@@ -154,7 +154,7 @@ func TestNewKibanaPodSpecWhenNodeSelectorIsDefined(t *testing.T) {
 		},
 	}
 
-	podSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil)
+	podSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil, "")
 
 	// check kibana
 	if !reflect.DeepEqual(podSpec.NodeSelector, expSelector) {
@@ -175,7 +175,7 @@ func TestNewKibanaPodNoTolerations(t *testing.T) {
 		},
 	}
 
-	podSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil)
+	podSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil, "")
 	tolerations := podSpec.Tolerations
 
 	if !utils.AreTolerationsSame(tolerations, expTolerations) {
@@ -204,7 +204,7 @@ func TestNewKibanaPodWithTolerations(t *testing.T) {
 		},
 	}
 
-	podSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil)
+	podSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil, "")
 	tolerations := podSpec.Tolerations
 
 	if !utils.AreTolerationsSame(tolerations, expTolerations) {
@@ -253,6 +253,7 @@ func TestNewKibanaPodSpecWhenProxyConfigExists(t *testing.T) {
 				constants.TrustedCABundleKey: caBundle,
 			},
 		},
+		"",
 	)
 
 	if len(podSpec.Containers) != 2 {
@@ -277,7 +278,7 @@ func TestDeploymentDifferentWithKibanaEnvVar(t *testing.T) {
 		},
 	}
 
-	lhsPodSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil)
+	lhsPodSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil, "")
 
 	lhsDeployment := NewDeployment(
 		"kibana",
@@ -287,7 +288,7 @@ func TestDeploymentDifferentWithKibanaEnvVar(t *testing.T) {
 		lhsPodSpec,
 	)
 
-	rhsPodSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil)
+	rhsPodSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil, "")
 
 	index := -1
 	for k, v := range rhsPodSpec.Containers {
@@ -336,7 +337,7 @@ func TestDeploymentDifferentWithKibanaReplicas(t *testing.T) {
 			},
 		},
 	}
-	lhsPodSpec := newKibanaPodSpec(ClusterRequest, "test-app-name", nil, nil)
+	lhsPodSpec := newKibanaPodSpec(ClusterRequest, "test-app-name", nil, nil, "")
 	lhsDeployment := NewDeployment(
 		"kibana",
 		ClusterRequest.cluster.Namespace,
@@ -345,7 +346,7 @@ func TestDeploymentDifferentWithKibanaReplicas(t *testing.T) {
 		lhsPodSpec,
 	)
 
-	rhsPodSpec := newKibanaPodSpec(ClusterRequest, "test-app-name", nil, nil)
+	rhsPodSpec := newKibanaPodSpec(ClusterRequest, "test-app-name", nil, nil, "")
 	rhsDeployment := NewDeployment(
 		"kibana",
 		ClusterRequest.cluster.Namespace,
@@ -374,7 +375,7 @@ func TestDeploymentDifferentWithProxyEnvVar(t *testing.T) {
 		},
 	}
 
-	lhsPodSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil)
+	lhsPodSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil, "")
 
 	lhsDeployment := NewDeployment(
 		"kibana",
@@ -384,7 +385,7 @@ func TestDeploymentDifferentWithProxyEnvVar(t *testing.T) {
 		lhsPodSpec,
 	)
 
-	rhsPodSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil)
+	rhsPodSpec := newKibanaPodSpec(clusterRequest, "test-app-name", nil, nil, "")
 
 	index := -1
 	for k, v := range rhsPodSpec.Containers {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -49,6 +49,7 @@ github.com/google/go-cmp/cmp/internal/value
 # github.com/google/gofuzz v1.1.0
 github.com/google/gofuzz
 # github.com/google/uuid v1.1.1
+## explicit
 github.com/google/uuid
 # github.com/googleapis/gnostic v0.3.1
 github.com/googleapis/gnostic/OpenAPIv2


### PR DESCRIPTION
### Description
This PR add reconciliation of a pre-generated UUID for kibana clusters. This UUID is stored as a ConfigMap and in turn allows Kibana to re-use it across restarts.

/cc @blockloop 
/assign @jcantrill 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1933978
