### PR TITLE
ES configuration uses PKCS12 format instead of JKS

### DIFF
--- a/docs/pvc-recovery.md
+++ b/docs/pvc-recovery.md
@@ -77,12 +77,12 @@ To begin, this guide assumes you have a currently running cluster in the `opensh
       ssl:
         verification_mode: certificate
         truststore:
-          path: /etc/elasticsearch/secret/truststore
+          path: /etc/elasticsearch/secret/truststore.p12
           password: tspass
-          type: jks
+          type: p12
         keystore:
-          path: /etc/elasticsearch/secret/key
-          type: jks
+          path: /etc/elasticsearch/secret/key.p12
+          type: p12
           password: kspass
     ```
     - e.g.
@@ -101,12 +101,12 @@ To begin, this guide assumes you have a currently running cluster in the `opensh
       ssl:
         verification_mode: certificate
         truststore:
-          path: /etc/elasticsearch/secret/truststore
+          path: /etc/elasticsearch/secret/truststore.p12
           password: tspass
-          type: jks
+          type: p12
         keystore:
-          path: /etc/elasticsearch/secret/key
-          type: jks
+          path: /etc/elasticsearch/secret/key.p12
+          type: p12
           password: kspass
     ```
 

--- a/internal/k8shandler/configmaps_test.go
+++ b/internal/k8shandler/configmaps_test.go
@@ -160,20 +160,20 @@ opendistro_security:
     transport:
       enabled: true
       enforce_hostname_verification: false
-      keystore_type: JKS
-      keystore_filepath: /etc/elasticsearch/secret/searchguard.key
+      keystore_type: PKCS12
+      keystore_filepath: /etc/elasticsearch/secret/searchguard-key.p12
       keystore_password: kspass
-      truststore_type: JKS
-      truststore_filepath: /etc/elasticsearch/secret/searchguard.truststore
+      truststore_type: PKCS12
+      truststore_filepath: /etc/elasticsearch/secret/searchguard-truststore.p12
       truststore_password: tspass
     http:
       enabled: true
-      keystore_type: JKS
-      keystore_filepath: /etc/elasticsearch/secret/key
+      keystore_type: PKCS12
+      keystore_filepath: /etc/elasticsearch/secret/key.p12
       keystore_password: kspass
       clientauth_mode: OPTIONAL
-      truststore_type: JKS
-      truststore_filepath: /etc/elasticsearch/secret/truststore
+      truststore_type: PKCS12
+      truststore_filepath: /etc/elasticsearch/secret/truststore.p12
       truststore_password: tspass`)
 		})
 	})

--- a/internal/k8shandler/configuration_tmpl.go
+++ b/internal/k8shandler/configuration_tmpl.go
@@ -48,20 +48,20 @@ opendistro_security:
     transport:
       enabled: true
       enforce_hostname_verification: false
-      keystore_type: JKS
-      keystore_filepath: /etc/elasticsearch/secret/searchguard.key
+      keystore_type: PKCS12
+      keystore_filepath: /etc/elasticsearch/secret/searchguard-key.p12
       keystore_password: kspass
-      truststore_type: JKS
-      truststore_filepath: /etc/elasticsearch/secret/searchguard.truststore
+      truststore_type: PKCS12
+      truststore_filepath: /etc/elasticsearch/secret/searchguard-truststore.p12
       truststore_password: tspass
     http:
       enabled: true
-      keystore_type: JKS
-      keystore_filepath: /etc/elasticsearch/secret/key
+      keystore_type: PKCS12
+      keystore_filepath: /etc/elasticsearch/secret/key.p12
       keystore_password: kspass
       clientauth_mode: OPTIONAL
-      truststore_type: JKS
-      truststore_filepath: /etc/elasticsearch/secret/truststore
+      truststore_type: PKCS12
+      truststore_filepath: /etc/elasticsearch/secret/truststore.p12
       truststore_password: tspass`
 
 const log4j2PropertiesTmpl = `


### PR DESCRIPTION
Changing the Elasticsearch configuration to use PKCS12 format instead of JKS. As far as I can tell, it does not matter if JKS is already running or not (though when I changed the config map, I don't think I noticed my pod restarting).

/cc @blockloop 
/assign @ewolinetz 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-958
