### PR TITLE
Fix upgrade tests for multi-container operator deployment

### DIFF
--- a/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
@@ -420,7 +420,7 @@ spec:
                 - --tls-cert-file=/var/run/secrets/serving-cert/tls.crt
                 - --tls-private-key-file=/var/run/secrets/serving-cert/tls.key
                 - --v=2
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+                image: quay.io/openshift/origin-kube-rbac-proxy:latest
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: quay.io/openshift/origin-kube-rbac-proxy:latest
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/hack/testing-olm-upgrade/upgrade-common
+++ b/hack/testing-olm-upgrade/upgrade-common
@@ -39,7 +39,8 @@ cleanup(){
   oc -n openshift-operators-redhat -o yaml get configmaps > $ARTIFACT_DIR/openshift-operators-redhat-configmaps.yml 2>&1 ||:
   oc -n openshift-operators-redhat describe deployment/elasticsearch-operator > $ARTIFACT_DIR/elasticsearch-operator.describe 2>&1 ||:
 
-  oc logs -n "openshift-operators-redhat" deployment/elasticsearch-operator > $ARTIFACT_DIR/elasticsearch-operator.log 2>&1 ||:
+  oc logs -n "openshift-operators-redhat" -c elasticsearch-operator deployment/elasticsearch-operator > $ARTIFACT_DIR/elasticsearch-operator.log 2>&1 ||:
+  oc logs -n "openshift-operators-redhat" -c kube-rbac-proxy deployment/elasticsearch-operator > $ARTIFACT_DIR/kube-rbac-proxy.log 2>&1 ||:
   oc  -n openshift-operator-lifecycle-manager logs --since=$runtime deployment/catalog-operator > $ARTIFACT_DIR/catalog-operator.logs 2>&1 ||:
   oc  -n openshift-operator-lifecycle-manager logs --since=$runtime deployment/olm-operator > $ARTIFACT_DIR/olm-operator.logs 2>&1 ||:
 
@@ -568,5 +569,5 @@ check_deployment_rolled_out() {
   log::info "Checking if deployment successfully updated..."
   IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-registry.ci.openshift.org/logging/${version}:elasticsearch-operator}
   log::info "Checking if deployment version is ${IMAGE_ELASTICSEARCH_OPERATOR}..."
-  try_until_text "oc -n openshift-operators-redhat get deployment elasticsearch-operator -o jsonpath={.spec.template.spec.containers[0].image}" "${IMAGE_ELASTICSEARCH_OPERATOR}" ${TIMEOUT_MIN}
+  try_until_text "oc -n openshift-operators-redhat get deployment elasticsearch-operator -o jsonpath={.spec.template.spec.containers[1].image}" "${IMAGE_ELASTICSEARCH_OPERATOR}" ${TIMEOUT_MIN}
 }

--- a/manifests/5.1/elasticsearch-operator.v5.1.0.clusterserviceversion.yaml
+++ b/manifests/5.1/elasticsearch-operator.v5.1.0.clusterserviceversion.yaml
@@ -420,7 +420,7 @@ spec:
                 - --tls-cert-file=/var/run/secrets/serving-cert/tls.crt
                 - --tls-private-key-file=/var/run/secrets/serving-cert/tls.key
                 - --v=2
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+                image: quay.io/openshift/origin-kube-rbac-proxy:latest
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/olm_deploy/scripts/catalog-deploy.sh
+++ b/olm_deploy/scripts/catalog-deploy.sh
@@ -4,6 +4,7 @@ OCP_VERSION=${OCP_VERSION:-4.7}
 LOGGING_VERSION=${LOGGING_VERSION:-5.1}
 LOGGING_IS=${LOGGING_IS:-logging}
 export IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY=${IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:elasticsearch-operator-registry}
+export IMAGE_KUBE_RBAC_PROXY=${IMAGE_KUBE_RBAC_PROXY:-registry.ci.openshift.org/ocp/${OCP_VERSION}:kube-rbac-proxy}
 export IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:elasticsearch-operator}
 export IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:logging-elasticsearch6}
 export IMAGE_ELASTICSEARCH_PROXY=${IMAGE_ELASTICSEARCH_PROXY:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:elasticsearch-proxy}
@@ -14,6 +15,7 @@ ELASTICSEARCH_OPERATOR_NAMESPACE=${ELASTICSEARCH_OPERATOR_NAMESPACE:-openshift-o
 echo "Using images: "
 echo "elastic operator registry: ${IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY}"
 echo "elastic operator: ${IMAGE_ELASTICSEARCH_OPERATOR}"
+echo "kube rbac proxy: ${IMAGE_KUBE_RBAC_PROXY}"
 echo "elastic6: ${IMAGE_ELASTICSEARCH6}"
 echo "elasticsearch proxy: ${IMAGE_ELASTICSEARCH_PROXY}"
 echo "kibana: ${IMAGE_LOGGING_KIBANA6}"

--- a/olm_deploy/scripts/registry-init.sh
+++ b/olm_deploy/scripts/registry-init.sh
@@ -7,6 +7,7 @@ env | grep IMAGE
 echo -e "\n\n"
 
 IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-quay.io/openshift/origin-elasticsearch-operator:latest}
+IMAGE_KUBE_RBAC_PROXY=${IMAGE_KUBE_RBAC_PROXY:-quay.io/openshift/origin-kube-rbac-proxy:latest}
 IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-quay.io/openshift/origin-logging-elasticsearch6:latest}
 IMAGE_ELASTICSEARCH_PROXY=${IMAGE_ELASTICSEARCH_PROXY:-quay.io/openshift/origin-elasticsearch-proxy:latest}
 IMAGE_OAUTH_PROXY=${IMAGE_OAUTH_PROXY:-quay.io/openshift/origin-oauth-proxy:latest}
@@ -14,6 +15,7 @@ IMAGE_LOGGING_KIBANA6=${IMAGE_LOGGING_KIBANA6:-quay.io/openshift/origin-logging-
 
 # update the manifest with the image built by ci
 sed -i "s,quay.io/openshift/origin-elasticsearch-operator:latest,${IMAGE_ELASTICSEARCH_OPERATOR}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift/origin-kube-rbac-proxy:latest,${IMAGE_KUBE_RBAC_PROXY}," /manifests/*/*clusterserviceversion.yaml
 sed -i "s,quay.io/openshift/origin-logging-elasticsearch6:latest,${IMAGE_ELASTICSEARCH6}," /manifests/*/*clusterserviceversion.yaml
 sed -i "s,quay.io/openshift/origin-elasticsearch-proxy:latest,${IMAGE_ELASTICSEARCH_PROXY}," /manifests/*/*clusterserviceversion.yaml
 sed -i "s,quay.io/openshift/origin-oauth-proxy:latest,${IMAGE_OAUTH_PROXY}," /manifests/*/*clusterserviceversion.yaml


### PR DESCRIPTION
### Description
This PR is a mandatory follow up for #665 and #653. I.e. it includes the missing bits for running E2E tests safely on our CI:
- Use only `registry.ci.openshift.org` hosted images. In contrast the EO deployment used `gcr.io` to pull the image for `kube-rbac-proxy`. Later is the additional sidecar introduced by #653 to protect the operator metrics.
- Match deployment image after patching the subscription by using `containers[1].image` instead of `containers[0].image`. On index zero we have the `kube-rbac-proxy` container and on index one the `elasticsearch-operator` container.

/cc @huikang 
/assign @ewolinetz 