### PR TITLE
Updating registry to registry.ci.openshift.org

### DIFF
--- a/hack/common
+++ b/hack/common
@@ -22,7 +22,7 @@ REMOTE_REGISTRY=${REMOTE_REGISTRY:-false}
 # elasticsearch is running
 REMOTE_CLUSTER=${REMOTE_CLUSTER:-false}
 
-UBI_IMAGE=${UBI_IMAGE:-registry.svc.ci.openshift.org/ocp/4.0:base}
+UBI_IMAGE=${UBI_IMAGE:-registry.ci.openshift.org/ocp/4.0:base}
 
 function image_is_ubi() {
     # dockerfile is arg $1
@@ -32,10 +32,10 @@ function image_is_ubi() {
 function image_needs_private_repo() {
     # dockerfile is arg $1
     image_is_ubi $1 || \
-        grep -q "^FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base" $1
+        grep -q "^FROM registry.ci.openshift.org/openshift/origin-v4.0:base" $1
 }
 
-CI_REGISTRY=${CI_REGISTRY:-registry.svc.ci.openshift.org}
+CI_REGISTRY=${CI_REGISTRY:-registry.ci.openshift.org}
 CI_CLUSTER_NAME=${CI_CLUSTER_NAME:-api-ci-openshift-org:443}
 
 function get_context_for_cluster() {

--- a/hack/testing-olm-upgrade/test-020-olm-upgrade-4.4-4.5.sh
+++ b/hack/testing-olm-upgrade/test-020-olm-upgrade-4.4-4.5.sh
@@ -170,7 +170,7 @@ try_until_success "oc -n openshift-operators-redhat patch clusterserviceversion 
 #verify deployment is rolled out
 log::info "Checking if deployment successfully updated..."
 OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.5}
-IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:elasticsearch-operator}
+IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-registry.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:elasticsearch-operator}
 if [ -n "${IMAGE_FORMAT:-}" ] ; then
   IMAGE_ELASTICSEARCH_OPERATOR=$(echo $IMAGE_FORMAT | sed -e "s,\${component},elasticsearch-operator,")
 fi

--- a/olm_deploy/operatorregistry/Dockerfile
+++ b/olm_deploy/operatorregistry/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/operator-framework/upstream-registry-builder AS registry-builder
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12
+FROM registry.ci.openshift.org/openshift/release:golang-1.12
 
 WORKDIR /
 COPY manifests/ /manifests

--- a/olm_deploy/scripts/catalog-deploy.sh
+++ b/olm_deploy/scripts/catalog-deploy.sh
@@ -1,12 +1,12 @@
 #!/bin/sh 
 set -eou pipefail
 OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.6}
-export IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY=${IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:elasticsearch-operator-registry}
-export IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:elasticsearch-operator}
-export IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:logging-elasticsearch6}
-export IMAGE_ELASTICSEARCH_PROXY=${IMAGE_ELASTICSEARCH_PROXY:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:elasticsearch-proxy}
-export IMAGE_LOGGING_KIBANA6=${IMAGE_LOGGING_KIBANA6:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:logging-kibana6}
-export IMAGE_OAUTH_PROXY=${IMAGE_OAUTH_PROXY:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:oauth-proxy}
+export IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY=${IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY:-registry.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:elasticsearch-operator-registry}
+export IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-registry.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:elasticsearch-operator}
+export IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-registry.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:logging-elasticsearch6}
+export IMAGE_ELASTICSEARCH_PROXY=${IMAGE_ELASTICSEARCH_PROXY:-registry.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:elasticsearch-proxy}
+export IMAGE_LOGGING_KIBANA6=${IMAGE_LOGGING_KIBANA6:-registry.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:logging-kibana6}
+export IMAGE_OAUTH_PROXY=${IMAGE_OAUTH_PROXY:-registry.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:oauth-proxy}
 ELASTICSEARCH_OPERATOR_NAMESPACE=${ELASTICSEARCH_OPERATOR_NAMESPACE:-openshift-operators-redhat}
 
 if [ -n "${IMAGE_FORMAT:-}" ] ; then


### PR DESCRIPTION
It looks like the 4.6 release was not included in the registry update, this PR so lets this release uses the latest.

/cc @periklis 
/assign @jcantrill 