### PR TITLE
LOG-1153: Adding logic to perform rollover and delete for json write indices

### DIFF
--- a/internal/indexmanagement/scripts.go
+++ b/internal/indexmanagement/scripts.go
@@ -132,24 +132,18 @@ function getWriteIndex() {
   local policy="$1"
 
   # find out the current write index for ${POLICY_MAPPING}-write and check if there is the next generation of it
-  aliasResponse=$(curl -s $ES_SERVICE/_alias/${policy} \
-    --cacert /etc/indexmanagement/keys/admin-ca \
-    --connect-timeout ${CONNECT_TIMEOUT} \
-    -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-    -HContent-Type:application/json \
-    --retry 5 \
-    --retry-delay 5)
+  aliasResponse="$(getAlias "${policy}")"
 
   if [ -z "$aliasResponse" ]; then
     echo "Received an empty response from elasticsearch -- server may not be ready"
-    exit 1
+    return 1
   fi
 
   jsonResponse="$(echo [$aliasResponse] | sed 's/}{/},{/g')"
 
   if ! writeIndices="$(python /tmp/scripts/getWriteIndex.py "${policy}" "$jsonResponse")" ; then
     echo $writeIndices
-    exit 1
+    return 1
   fi
 
   writeIndex="$(ensureOneWriteIndex "$policy" "$writeIndices")"
@@ -169,20 +163,222 @@ function ensureOneWriteIndex() {
       writeIndex="$index"
     else
       # extra write index -- mark it as not a write index
-      curl -s "$ES_SERVICE/_aliases" \
-        --connect-timeout ${CONNECT_TIMEOUT} \
-        --cacert /etc/indexmanagement/keys/admin-ca \
-        -HContent-Type:application/json \
-        -XPOST \
-        -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-        -o /dev/null \
-        -d '{"actions":[{"add":{"index": "'$index'", "alias": "'${POLICY_MAPPING}-write'", "is_write_index": false}}]}' \
-        --retry 5 \
-        --retry-delay 5
+      removeAsWriteIndexForAlias "$index" "$policy"
     fi
   done
 
   echo $writeIndex
+}
+
+function getWriteAliases() {
+  local policy="$1"
+
+  # "_cat/aliases/${policy}*-write?h=alias" | uniq
+  aliasResponse="$(catWriteAliases "$policy")"
+
+  if [ -z "$aliasResponse" ]; then
+    echo "Received an empty response from elasticsearch -- server may not be ready"
+    return 1
+  fi
+
+  echo $aliasResponse
+}
+
+function rollover() {
+
+  local policy="$1"
+  local decoded="$2"
+
+  echo "========================"
+  echo "Index management rollover process starting for $policy"
+  echo ""
+
+  # get current write index
+  if ! writeIndex="$(getWriteIndex "${policy}-write")" ; then
+    echo $writeIndex
+    return 1
+  fi
+
+  echo "Current write index for ${policy}-write: $writeIndex"
+
+  # try to rollover
+  code="$(rolloverForPolicy "${policy}-write" "$decoded")"
+
+  echo "Checking results from _rollover call"
+
+  if [ "$code" != "200" ] ; then
+    # already in bad state
+    echo "Calculating next write index based on current write index..."
+
+    indexGeneration="$(echo $writeIndex | cut -d'-' -f2)"
+    writeBase="$(echo $writeIndex | cut -d'-' -f1)"
+
+    # if we don't strip off the leading 0s it does math wrong...
+    generation="$(echo $indexGeneration | sed 's/^0*//')"
+    # pad the index name again with 0s
+    nextGeneration="$(printf '%06g' $(($generation + 1)))"
+    nextIndex="$writeBase-$nextGeneration"
+  else
+    # check response to see if it did roll over (field in response)
+    if ! nextIndex="$(python /tmp/scripts/checkRollover.py "/tmp/response.txt" "$writeIndex")" ; then
+      echo $nextIndex
+      return 1
+    fi
+  fi
+
+  echo "Next write index for ${policy}-write: $nextIndex"
+  echo "Checking if $nextIndex exists"
+
+  # if true, ensure next index was created
+  code="$(checkIndexExists "$nextIndex")"
+  if [ "$code" == "404" ] ; then
+    cat /tmp/response.txt
+    return 1
+  fi
+
+  echo "Checking if $nextIndex is the write index for ${policy}-write"
+
+  ## if true, ensure write-alias points to next index
+  if ! writeIndex="$(getWriteIndex "${policy}-write")" ; then
+    echo $writeIndex
+    return 1
+  fi
+
+  if [ "$nextIndex" == "$writeIndex" ] ; then
+    echo "Done!"
+    return 0
+  fi
+
+  echo "Updating alias for ${policy}-write"
+
+  # else - try to update alias to be correct
+  code="$(updateWriteIndex "$writeIndex" "$nextIndex" "${policy}-write")"
+
+  if [ "$code" == 200 ] ; then
+    echo "Done!"
+    return 0
+  fi
+  cat /tmp/response.txt
+  return 1
+}
+
+function delete() {
+
+  local policy="$1"
+  ERRORS="$(mktemp /tmp/delete-XXXXXX)"
+
+  echo "========================"
+  echo "Index management delete process starting for $policy"
+  echo ""
+
+  if ! writeIndex="$(getWriteIndex "${policy}-write")" ; then
+    echo $writeIndex
+    return 1
+  fi
+
+  indices="$(getIndicesAgeForAlias "${policy}-write")"
+
+  if [ -z "$indices" ]; then
+    echo "Received an empty response from elasticsearch -- server may not be ready"
+    return 1
+  fi
+
+  jsonResponse="$(echo [$indices] | sed 's/}{/},{/g')"
+
+  # Delete in batches of 25 for cases where there are a large number of indices to remove
+  nowInMillis=$(date +%s%3N)
+  minAgeFromEpoc=$(($nowInMillis - $MIN_AGE))
+  if ! indices=$(python /tmp/scripts/getNext25Indices.py "$minAgeFromEpoc" "$writeIndex" "$jsonResponse" 2>>$ERRORS) ; then
+    cat $ERRORS
+    rm $ERRORS
+    return 1
+  fi
+  # Dump any findings to stdout but don't error
+  if [ -s $ERRORS ]; then
+    cat $ERRORS
+    rm $ERRORS
+  fi
+
+  if [ "${indices}" == "" ] ; then
+      echo No indices to delete
+      return 0
+  else
+      echo deleting indices: "${indices}"
+  fi
+
+  for sets in ${indices}; do
+    code="$(deleteIndices "${sets}")"
+
+    if [ "$code" != 200 ] ; then
+      cat /tmp/response.txt
+      return 1
+    fi
+  done
+
+  echo "Done!"
+}
+
+function curlES() {
+  curl -s \
+  --connect-timeout "${CONNECT_TIMEOUT}" \
+  --cacert /etc/indexmanagement/keys/admin-ca \
+  -HContent-Type:application/json \
+  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  --retry 5 \
+  --retry-delay 5 \
+  "$@"
+}
+
+function getAlias() {
+  local alias="$1"
+
+  curlES "$ES_SERVICE/_alias/${alias}"
+}
+
+function getIndicesAgeForAlias() {
+  local alias="$1"
+
+  curlES "$ES_SERVICE/${alias}/_settings/index.creation_date"
+}
+
+function deleteIndices() {
+  local index="$1"
+
+  curlES "$ES_SERVICE/${index}?pretty" -w "%{response_code}" -o /tmp/response.txt -XDELETE
+}
+
+function removeAsWriteIndexForAlias() {
+  local index="$1"
+  local alias="$2"
+
+  curlES "$ES_SERVICE/_aliases" -o /dev/null -d '{"actions":[{"add":{"index": "'$index'", "alias": "'$alias'", "is_write_index": false}}]}'
+}
+
+function catWriteAliases() {
+  local policy="$1"
+
+  curlES "$ES_SERVICE/_cat/aliases/${policy}*-write?h=alias" | sort | uniq
+}
+
+function rolloverForPolicy() {
+  local policy="$1"
+  local decoded="$2"
+
+  curlES "$ES_SERVICE/${policy}/_rollover?pretty" -w "%{response_code}" -XPOST -o /tmp/response.txt -d $decoded
+}
+
+function checkIndexExists() {
+  local index="$1"
+
+  curlES "$ES_SERVICE/${index}" -w "%{response_code}" -o /dev/null
+}
+
+function updateWriteIndex() {
+  currentIndex="$1"
+  nextIndex="2"
+  alias="$3"
+
+  curlES "$ES_SERVICE/_aliases" -w "%{response_code}" -XPOST -o /tmp/response.txt -d '{"actions":[{"add":{"index": "'$currentIndex'", "alias": "'$alias'", "is_write_index": false}},{"add":{"index": "'$nextIndex'", "alias": "'$alias'", "is_write_index": true}}]}'
 }
 `
 
@@ -192,173 +388,33 @@ source /tmp/scripts/indexManagement
 
 decoded=$(echo $PAYLOAD | base64 -d)
 
-echo "Index management rollover process starting"
+# need to get a list of all mappings under ${POLICY_MAPPING}, drop suffix '-write' iterate over
+writeAliases="$(getWriteAliases "$POLICY_MAPPING")"
 
-# get current write index
-if ! writeIndex="$(getWriteIndex "${POLICY_MAPPING}-write")" ; then
-  echo $writeIndex
-  exit 1
-fi
+for aliasBase in $writeAliases; do
 
-echo "Current write index for ${POLICY_MAPPING}-write: $writeIndex"
-
-# try to rollover
-code=$(curl -s "$ES_SERVICE/${POLICY_MAPPING}-write/_rollover?pretty" \
-  -w "%{response_code}" \
-  --connect-timeout ${CONNECT_TIMEOUT} \
-  --cacert /etc/indexmanagement/keys/admin-ca \
-  -HContent-Type:application/json \
-  -XPOST \
-  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-  -o /tmp/response.txt \
-  -d $decoded \
-  --retry 5 \
-  --retry-delay 5)
-
-echo "Checking results from _rollover call"
-
-if [ "$code" != "200" ] ; then
-  # already in bad state
-  echo "Calculating next write index based on current write index..."
-
-  indexGeneration="$(echo $writeIndex | cut -d'-' -f2)"
-  writeBase="$(echo $writeIndex | cut -d'-' -f1)"
-
-  # if we don't strip off the leading 0s it does math wrong...
-  generation=$(echo $indexGeneration | sed 's/^0*//')
-  # pad the index name again with 0s
-  nextGeneration="$(printf '%06g' $(($generation + 1)))"
-  nextIndex="$writeBase-$nextGeneration"
-else
-  # check response to see if it did roll over (field in response)
-  if ! nextIndex="$(python /tmp/scripts/checkRollover.py "/tmp/response.txt" "$writeIndex")" ; then
-    echo $nextIndex
+  alias="$(echo $aliasBase | sed 's/-write$//g')"
+  if ! rollover "$alias" "$decoded" ; then
     exit 1
   fi
-fi
-
-echo "Next write index for ${POLICY_MAPPING}-write: $nextIndex"
-echo "Checking if $nextIndex exists"
-
-# if true, ensure next index was created
-code=$(curl -s "$ES_SERVICE/$nextIndex/" \
-  -w "%{response_code}" \
-  --connect-timeout ${CONNECT_TIMEOUT} \
-  --cacert /etc/indexmanagement/keys/admin-ca \
-  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-  -o /dev/null \
-  --retry 5 \
-  --retry-delay 5)
-if [ "$code" == "404" ] ; then
-  cat /tmp/response.txt
-  exit 1
-fi
-
-echo "Checking if $nextIndex is the write index for ${POLICY_MAPPING}-write"
-
-## if true, ensure write-alias points to next index
-if ! writeIndex="$(getWriteIndex "${POLICY_MAPPING}-write")" ; then
-  echo $writeIndex
-  exit 1
-fi
-
-if [ "$nextIndex" == "$writeIndex" ] ; then
-  echo "Done!"
-  exit 0
-fi
-
-echo "Updating alias for ${POLICY_MAPPING}-write"
-
-# else - try to update alias to be correct
-code=$(curl -s "$ES_SERVICE/_aliases" \
-  -w "%{response_code}" \
-  --connect-timeout ${CONNECT_TIMEOUT} \
-  --cacert /etc/indexmanagement/keys/admin-ca \
-  -HContent-Type:application/json \
-  -XPOST \
-  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-  -o /tmp/response.txt \
-  -d '{"actions":[{"add":{"index": "'$writeIndex'", "alias": "'${POLICY_MAPPING}-write'", "is_write_index": false}},{"add":{"index": "'$nextIndex'", "alias": "'${POLICY_MAPPING}-write'", "is_write_index": true}}]}' \
-  --retry 5 \
-  --retry-delay 5)
-
-if [ "$code" == 200 ] ; then
-  echo "Done!"
-  exit 0
-fi
-cat /tmp/response.txt
-exit 1
+done
 `
 
 const deleteScript = `
 set -uo pipefail
-ERRORS=/tmp/errors.txt
 
 source /tmp/scripts/indexManagement
 
-echo "" > $ERRORS
+# need to get a list of all mappings under ${POLICY_MAPPING}, drop suffix '-write' iterate over
+writeAliases="$(getWriteAliases "$POLICY_MAPPING")"
 
-echo "Index management delete process starting"
+for aliasBase in $writeAliases; do
 
-if ! writeIndex="$(getWriteIndex "${POLICY_MAPPING}-write")" ; then
-  echo $writeIndex
-  exit 1
-fi
-
-indices=$(curl -s $ES_SERVICE/${POLICY_MAPPING}/_settings/index.creation_date \
-  --cacert /etc/indexmanagement/keys/admin-ca \
-  --connect-timeout ${CONNECT_TIMEOUT} \
-  -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-  -HContent-Type:application/json \
-  --retry 5 \
-  --retry-delay 5)
-
-if [ -z "$indices" ]; then
-  echo "Received an empty response from elasticsearch -- server may not be ready"
-  exit 1
-fi
-
-jsonResponse="$(echo [$indices] | sed 's/}{/},{/g')"
-
-# Delete in batches of 25 for cases where there are a large number of indices to remove
-nowInMillis=$(date +%s%3N)
-minAgeFromEpoc=$(($nowInMillis - $MIN_AGE))
-
-if ! indices=$(python /tmp/scripts/getNext25Indices.py "$minAgeFromEpoc" "$writeIndex" "$jsonResponse" 2>>$ERRORS) ; then
-  cat $ERRORS
-  exit 1
-fi
-# Dump any findings to stdout but don't error
-if [ -s $ERRORS ]; then
-  cat $ERRORS
-fi
-
-if [ "${indices}" == "" ] ; then
-    echo No indices to delete
-    exit 0
-else
-    echo deleting indices: "${indices}"
-fi
-
-for sets in ${indices}; do
-  code=$(curl -s $ES_SERVICE/${sets}?pretty \
-    -w "%{response_code}" \
-    --connect-timeout ${CONNECT_TIMEOUT} \
-    --cacert /etc/indexmanagement/keys/admin-ca \
-    -HContent-Type:application/json \
-    -H"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-    -o /tmp/response.txt \
-    -XDELETE \
-    --retry 5 \
-    --retry-delay 5)
-
-  if [ "$code" != 200 ] ; then
-    cat /tmp/response.txt
+  alias="$(echo $aliasBase | sed 's/-write$//g')"
+  if ! delete "$alias" ; then
     exit 1
   fi
 done
-
-echo "Done!"
 `
 
 var scriptMap = map[string]string{


### PR DESCRIPTION
### Description
In anticipation for the ability to store json in Elasticsearch, we need to be able to rollover and delete any json specific write alias based on the policy for either `app`, `infra`, or `audit` (json indices/aliases will follow the pattern `<app|infra|audit>-<json-schema-name>-<write|xxxxxx>`)

Also cleaned up output of the delete and rollover scripts for ease of use:
```
========================
Index management delete process starting for infra-json

deleting indices: infra-json-000055
Done!
========================
Index management delete process starting for infra

deleting indices: infra-000074
Done!
========================
Index management rollover process starting for infra-json

Current write index for infra-json-write: infra-json-000057
Checking results from _rollover call
Next write index for infra-json-write: infra-json-000057
Checking if infra-json-000057 exists
Checking if infra-json-000057 is the write index for infra-json-write
Done!
========================
Index management rollover process starting for infra

Current write index for infra-write: infra-000076
Checking results from _rollover call
Next write index for infra-write: infra-000076
Checking if infra-000076 exists
Checking if infra-000076 is the write index for infra-write
Done!

```

```
========================
Index management delete process starting for infra-json

No indices to delete
========================
Index management delete process starting for infra

No indices to delete
========================
Index management rollover process starting for infra-json

Current write index for infra-json-write: infra-json-000037
Checking results from _rollover call
Next write index for infra-json-write: infra-json-000037
Checking if infra-json-000037 exists
Checking if infra-json-000037 is the write index for infra-json-write
Done!
========================
Index management rollover process starting for infra

Current write index for infra-write: infra-000056
Checking results from _rollover call
Next write index for infra-write: infra-000056
Checking if infra-000056 exists
Checking if infra-000056 is the write index for infra-write
Done!
```

/cc @blockloop @periklis 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1153
