### PR TITLE
[release-5.0] Removing resource request and limits from EO deployment definition

### DIFF
--- a/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
@@ -440,13 +440,7 @@ spec:
                 ports:
                 - containerPort: 60000
                   name: metrics
-                resources:
-                  limits:
-                    cpu: 200m
-                    memory: 128Mi
-                  requests:
-                    cpu: 100m
-                    memory: 64Mi
+                resources: {}
               nodeSelector:
                 kubernetes.io/os: linux
               serviceAccountName: elasticsearch-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,13 +23,7 @@ spec:
         image: quay.io/openshift/origin-elasticsearch-operator:latest
         name: elasticsearch-operator
         imagePullPolicy: IfNotPresent
-        resources:
-          limits:
-            cpu: 200m
-            memory: 128Mi
-          requests:
-            cpu: 100m
-            memory: 64Mi
+        resources: {}
         env:
           - name: WATCH_NAMESPACE
             valueFrom:

--- a/manifests/5.0/elasticsearch-operator.v5.0.0.clusterserviceversion.yaml
+++ b/manifests/5.0/elasticsearch-operator.v5.0.0.clusterserviceversion.yaml
@@ -440,13 +440,7 @@ spec:
                 ports:
                 - containerPort: 60000
                   name: metrics
-                resources:
-                  limits:
-                    cpu: 200m
-                    memory: 128Mi
-                  requests:
-                    cpu: 100m
-                    memory: 64Mi
+                resources: {}
               nodeSelector:
                 kubernetes.io/os: linux
               serviceAccountName: elasticsearch-operator


### PR DESCRIPTION
### Description
Resolves regression seen in https://bugzilla.redhat.com/show_bug.cgi?id=1939979 where we introduce a resource request/limit for the elasticsearch operator.

/cc @vimalk78 @jcantrill 

Manual cherrypick of https://github.com/openshift/elasticsearch-operator/pull/683

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1939979
