### PR TITLE
Adding storage volume conditions to Elasticsearch

### DIFF
--- a/apis/logging/v1/elasticsearch_types.go
+++ b/apis/logging/v1/elasticsearch_types.go
@@ -336,4 +336,7 @@ const (
 	NodeStorage              ClusterConditionType = "NodeStorage"
 	CustomImage              ClusterConditionType = "CustomImageIgnored"
 	DegradedState            ClusterConditionType = "Degraded"
+	StorageClassName	 ClusterConditionType = "StorageClassNameChangeIgnored"
+	StorageSize		 ClusterConditionType = "StorageSizeChangeIgnored"
+	StorageStructure	 ClusterConditionType = "StorageStructureChangeIgnored"
 )

--- a/internal/k8shandler/deployment.go
+++ b/internal/k8shandler/deployment.go
@@ -357,7 +357,8 @@ func (node *deploymentNode) executeUpdate() error {
 		}
 
 		if ArePodTemplateSpecDifferent(currentDeployment.Spec.Template, node.self.Spec.Template) {
-			currentDeployment.Spec.Template = node.self.Spec.Template
+			currentDeployment.Spec.Template = CopyPodTemplateSpec(node.self.Spec.Template, currentDeployment.Spec.Template, true)
+
 			if err := node.client.Update(context.TODO(), &currentDeployment); err != nil {
 				log.Info("Failed to update node resource", "error", err)
 				return err

--- a/internal/k8shandler/statefulset.go
+++ b/internal/k8shandler/statefulset.go
@@ -318,8 +318,7 @@ func (n *statefulSetNode) executeUpdate() error {
 		}
 
 		if ArePodTemplateSpecDifferent(currentStatefulSet.Spec.Template, n.self.Spec.Template) {
-
-			currentStatefulSet.Spec.Template = n.self.Spec.Template
+			currentStatefulSet.Spec.Template = CopyPodTemplateSpec(n.self.Spec.Template, currentStatefulSet.Spec.Template, true)
 
 			if updateErr := n.client.Update(context.TODO(), &currentStatefulSet); updateErr != nil {
 				n.L().Error(err, "Failed to update node resource")

--- a/main.go
+++ b/main.go
@@ -114,7 +114,6 @@ func main() {
 	log.Info("Registering custom metrics for Elasticsearch Operator.")
 	metrics.RegisterCustomMetrics()
 
-	ll.Info("This operator no longer honors the image specified by the custom resources so that it is able to properly coordinate the configuration with the image.")
 	ll.Info("Starting the manager.")
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {


### PR DESCRIPTION
This PR adds the following capabilities:
- Adds a condition when the storage volume JSON structure has changed
- Adds a condition when the storage class name has changed
- Adds a condition when the size of the storage has changed
- Ignores changes to the volume deployment

/cc @lukas-vlcek 
/assign @ewolinetz 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-920
