### PR TITLE
Bug 1916911: make es status nullable for nodes and pods

### DIFF
--- a/apis/logging/v1/elasticsearch_types.go
+++ b/apis/logging/v1/elasticsearch_types.go
@@ -92,6 +92,7 @@ type ElasticsearchSpec struct {
 // ElasticsearchStatus defines the observed state of Elasticsearch
 // +k8s:openapi-gen=true
 type ElasticsearchStatus struct {
+	// +nullable
 	// +optional
 	Nodes []ElasticsearchNodeStatus `json:"nodes,omitempty"`
 	// +optional
@@ -100,6 +101,7 @@ type ElasticsearchStatus struct {
 	Cluster ClusterHealth `json:"cluster,omitempty"`
 	// +optional
 	ShardAllocationEnabled ShardAllocationState `json:"shardAllocationEnabled,omitempty"`
+	// +nullable
 	// +optional
 	Pods map[ElasticsearchNodeRole]PodStateMap `json:"pods,omitempty"`
 	// +optional

--- a/bundle/manifests/logging.openshift.io_elasticsearches.yaml
+++ b/bundle/manifests/logging.openshift.io_elasticsearches.yaml
@@ -550,6 +550,7 @@ spec:
                           type: string
                       type: object
                   type: object
+                nullable: true
                 type: array
               pods:
                 additionalProperties:
@@ -558,6 +559,7 @@ spec:
                       type: string
                     type: array
                   type: object
+                nullable: true
                 type: object
               shardAllocationEnabled:
                 type: string

--- a/config/crd/bases/logging.openshift.io_elasticsearches.yaml
+++ b/config/crd/bases/logging.openshift.io_elasticsearches.yaml
@@ -647,6 +647,7 @@ spec:
                           type: string
                       type: object
                   type: object
+                nullable: true
                 type: array
               pods:
                 additionalProperties:
@@ -655,6 +656,7 @@ spec:
                       type: string
                     type: array
                   type: object
+                nullable: true
                 type: object
               shardAllocationEnabled:
                 type: string

--- a/manifests/5.1/logging.openshift.io_elasticsearches_crd.yaml
+++ b/manifests/5.1/logging.openshift.io_elasticsearches_crd.yaml
@@ -550,6 +550,7 @@ spec:
                           type: string
                       type: object
                   type: object
+                nullable: true
                 type: array
               pods:
                 additionalProperties:
@@ -558,6 +559,7 @@ spec:
                       type: string
                     type: array
                   type: object
+                nullable: true
                 type: object
               shardAllocationEnabled:
                 type: string


### PR DESCRIPTION
This PR is the rebased version of this one: https://github.com/openshift/elasticsearch-operator/pull/630

/cc @periklis  
/assign @ewolinetz 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1916911