### PR TITLE
Bug 1946776: fix es crd status incompatible when upgrading operator

### DIFF
--- a/apis/logging/v1/elasticsearch_types.go
+++ b/apis/logging/v1/elasticsearch_types.go
@@ -92,6 +92,7 @@ type ElasticsearchSpec struct {
 // ElasticsearchStatus defines the observed state of Elasticsearch
 // +k8s:openapi-gen=true
 type ElasticsearchStatus struct {
+	// +nullable
 	// +optional
 	Nodes []ElasticsearchNodeStatus `json:"nodes,omitempty"`
 	// +optional
@@ -100,6 +101,7 @@ type ElasticsearchStatus struct {
 	Cluster ClusterHealth `json:"cluster,omitempty"`
 	// +optional
 	ShardAllocationEnabled ShardAllocationState `json:"shardAllocationEnabled,omitempty"`
+	// +nullable
 	// +optional
 	Pods map[ElasticsearchNodeRole]PodStateMap `json:"pods,omitempty"`
 	// +optional

--- a/bundle/manifests/logging.openshift.io_elasticsearches.yaml
+++ b/bundle/manifests/logging.openshift.io_elasticsearches.yaml
@@ -550,6 +550,7 @@ spec:
                           type: string
                       type: object
                   type: object
+                nullable: true
                 type: array
               pods:
                 additionalProperties:
@@ -558,6 +559,7 @@ spec:
                       type: string
                     type: array
                   type: object
+                nullable: true
                 type: object
               shardAllocationEnabled:
                 type: string

--- a/config/crd/bases/logging.openshift.io_elasticsearches.yaml
+++ b/config/crd/bases/logging.openshift.io_elasticsearches.yaml
@@ -647,6 +647,7 @@ spec:
                           type: string
                       type: object
                   type: object
+                nullable: true
                 type: array
               pods:
                 additionalProperties:
@@ -655,6 +656,7 @@ spec:
                       type: string
                     type: array
                   type: object
+                nullable: true
                 type: object
               shardAllocationEnabled:
                 type: string

--- a/manifests/5.0/logging.openshift.io_elasticsearches_crd.yaml
+++ b/manifests/5.0/logging.openshift.io_elasticsearches_crd.yaml
@@ -550,6 +550,7 @@ spec:
                           type: string
                       type: object
                   type: object
+                nullable: true
                 type: array
               pods:
                 additionalProperties:
@@ -558,6 +559,7 @@ spec:
                       type: string
                     type: array
                   type: object
+                nullable: true
                 type: object
               shardAllocationEnabled:
                 type: string


### PR DESCRIPTION
Manual cherry pick of: https://github.com/openshift/elasticsearch-operator/pull/686

Fix crd incompability during upgrading from 4.5 to 4.6

/assign @ewolinetz