### PR TITLE
Fixing e2e-upgrade test case

### DIFF
--- a/hack/testing-olm-upgrade/upgrade-common
+++ b/hack/testing-olm-upgrade/upgrade-common
@@ -569,5 +569,6 @@ check_deployment_rolled_out() {
   log::info "Checking if deployment successfully updated..."
   IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-registry.ci.openshift.org/logging/${version}:elasticsearch-operator}
   log::info "Checking if deployment version is ${IMAGE_ELASTICSEARCH_OPERATOR}..."
+  try_until_success "oc -n openshift-operators-redhat get deployment elasticsearch-operator -o jsonpath={.spec.template.spec.containers[1].image}" ${TIMEOUT_MIN}
   try_until_text "oc -n openshift-operators-redhat get deployment elasticsearch-operator -o jsonpath={.spec.template.spec.containers[1].image}" "${IMAGE_ELASTICSEARCH_OPERATOR}" ${TIMEOUT_MIN}
 }


### PR DESCRIPTION
The rolling deployment check needs to wait until it succeeds in order to check the elasticsearch operator otherwise it will fail immediately.

/cc @periklis 
/assign @ewolinetz 