### PR TITLE
Updating dockerfile to just copy necessary files for building image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/openshift/elasticsearch-operator
-COPY . .
-RUN make build
+COPY apis apis
+COPY controllers controllers
+COPY files files
+COPY internal internal
+COPY manifests manifests
+COPY vendor vendor
+COPY version version
+ADD Makefile main.go ./
+RUN go build -o bin/elasticsearch-operator main.go
 
 FROM registry.ci.openshift.org/ocp/4.7:base
 

--- a/Dockerfile.centos.patch
+++ b/Dockerfile.centos.patch
@@ -4,8 +4,15 @@
 -FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 +FROM registry.ci.openshift.org/openshift/release:golang-1.14 AS builder
  WORKDIR /go/src/github.com/openshift/elasticsearch-operator
- COPY . .
- RUN make build
+ COPY apis apis
+ COPY controllers controllers
+ COPY files files
+ COPY internal internal
+ COPY manifests manifests
+ COPY vendor vendor
+ COPY version version
+ ADD Makefile main.go ./
+ RUN go build -o bin/elasticsearch-operator main.go
  
 -FROM registry.ci.openshift.org/ocp/4.7:base
 +FROM docker.io/centos:8 AS centos


### PR DESCRIPTION
### Description
Slimming our operator image to only copy over necessary files for building our binary and running the operator in a cluster.

/cc @blockloop @periklis 

### Links
- Github issue: https://github.com/openshift/elasticsearch-operator/issues/635
