### PR TITLE
Bug 1945168: Remove hardcoded cluster local domain

### DIFF
--- a/pkg/k8shandler/kibana/reconciler.go
+++ b/pkg/k8shandler/kibana/reconciler.go
@@ -226,7 +226,7 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaDeployment(proxyConfig 
 
 	kibanaPodSpec := newKibanaPodSpec(
 		clusterRequest,
-		fmt.Sprintf("%s.%s.svc.cluster.local", clusterName, clusterRequest.cluster.Namespace),
+		fmt.Sprintf("%s.%s.svc", clusterName, clusterRequest.cluster.Namespace),
 		proxyConfig,
 		kibanaTrustBundle,
 	)


### PR DESCRIPTION
### Description
This PR provides a small fix for OCP environments with custom internal DNS, where using `cluster.local` for accessing Elasticsearch from Kibana is not valid.

/cc @blockloop 
/assign @ewolinetz 

**Note:** Needs porting to 5.0.x and 5.1.x

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1945168
