### PR TITLE
Log-1100: Warning alerts to prevent users from reaching disk watermark thresholds

### DIFF
--- a/files/prometheus_alerts.yml
+++ b/files/prometheus_alerts.yml
@@ -141,3 +141,54 @@ groups:
     for: 10m
     labels:
       severity: warning
+
+  - alert: ElasticsearchNodeDiskWatermarkReached
+    annotations:
+      message: "Disk Low Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+      summary: "Disk Low Watermark is predicted to be reached within next 6h."
+    expr: |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+    for: 1h
+    labels:
+      severity: warning
+
+  - alert: ElasticsearchNodeDiskWatermarkReached
+    annotations:
+      message: "Disk High Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-High-Watermark-Reached"
+      summary: "Disk High Watermark is predicted to be reached within next 6h."
+    expr: |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+    for: 1h
+    labels:
+      severity: warning
+
+  - alert: ElasticsearchNodeDiskWatermarkReached
+    annotations:
+      message: "Disk Flood Stage Watermark is predicted to be reached within the next 6h at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
+      summary: "Disk Flood Stage Watermark is predicted to be reached within next 6h."
+    expr: |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+    for: 1h
+    labels:
+      severity: warning

--- a/test/files/prometheus-unit-tests/test.yml
+++ b/test/files/prometheus-unit-tests/test.yml
@@ -41,7 +41,17 @@ tests:
         # and then stay at 1 for another 10 minutes.
       - series: 'es_fs_path_available_bytes{instance="localhost:9090",pod="pod-1"}'
         values: '10-1x9 1+0x10'
-
+        # We set low watermark level to 85% for pod 2
+      - series: 'es_cluster_routing_allocation_disk_watermark_low_pct{instance="localhost:9091",pod="pod-2"}'
+        values: '85+0x29 85+0x29 85+0x29 85+0x29'
+        # Total disk available space is constant (100)
+      - series: 'es_fs_path_total_bytes{instance="localhost:9091",pod="pod-2"}'
+        values: '100+0x29 100+0x29 100+0x29 100+0x29'
+        # The remaining space on the disk drops from 100 to 71 within first 30 minutes, from 70 to 41 within next 30 minutes
+        # then increases from 40 to 59 within next 20 minutes, then decreases from 30 to 21 within next 10 minutes
+        # then stays at 20 for another 30 minutes.
+      - series: 'es_fs_path_available_bytes{instance="localhost:9091",pod="pod-2"}'
+        values: '100-1x29 70-1x29 40+1x19 30-1x9 20-0x29'
 
     # Unit test for alerting rules.
     alert_rule_test:
@@ -108,6 +118,18 @@ tests:
             exp_annotations:
               summary: "Disk Low Watermark Reached - disk saturation is 90%"
               message: "Disk Low Watermark Reached at pod-1 pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+
+      # By the end of 2h we expect the linear prediction of low watermark to be active for more than 1 hour.
+      - eval_time: 2h
+        alertname: ElasticsearchNodeDiskWatermarkReached
+        exp_alerts:
+          - exp_labels:
+              instance: localhost:9091
+              pod: pod-2
+              severity: warning
+            exp_annotations:
+              summary: "Disk Low Watermark is predicted to be reached within next 6h."
+              message: "Disk Low Watermark is predicted to be reached within the next 6h at pod-2 pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached"
 
       # --------- AggregatedLoggingSystemCPUHigh ---------
       - eval_time: 15m


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR:
- Adds warning alert for low, high and flood disk watermark thresholds
- The thresholds are predicted by taking data of past 3h and alerted if it is expected to cross the threshold within next 6h
- To avoid false positives, the alert will be fired only if it stays active for 1h
- Added unit test to verify the alert
- Added playbook for low disk watermark

/cc @lukas-vlcek 
/assign @ewolinetz 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1100