### PR TITLE
Allow secret reconciler to reconcile during create

### DIFF
--- a/controllers/logging/secret_controller.go
+++ b/controllers/logging/secret_controller.go
@@ -63,7 +63,7 @@ func esSecretUpdatePredicate(r client.Client) predicate.Predicate {
 			return true
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			return false
+			return true
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return false


### PR DESCRIPTION
In addition to the PRs for the secret reconciler listed in the BZ, letting the secret reconciler fire on the create step while allow the EO to trigger a cluster restart when the secrets are changed.

/cc @periklis 
/assign @ewolinetz 

/cherry-pick release-5.0

Links:
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1918920
- JIRA: https://issues.redhat.com/browse/LOG-1205
- JIRA: https://issues.redhat.com/browse/LOG-1206
