### PR TITLE
Api struct fixes and fmt fixes

### DIFF
--- a/apis/logging/v1/elasticsearch_types.go
+++ b/apis/logging/v1/elasticsearch_types.go
@@ -338,7 +338,7 @@ const (
 	NodeStorage              ClusterConditionType = "NodeStorage"
 	CustomImage              ClusterConditionType = "CustomImageIgnored"
 	DegradedState            ClusterConditionType = "Degraded"
-	StorageClassName	 ClusterConditionType = "StorageClassNameChangeIgnored"
-	StorageSize		 ClusterConditionType = "StorageSizeChangeIgnored"
-	StorageStructure	 ClusterConditionType = "StorageStructureChangeIgnored"
+	StorageClassName         ClusterConditionType = "StorageClassNameChangeIgnored"
+	StorageSize              ClusterConditionType = "StorageSizeChangeIgnored"
+	StorageStructure         ClusterConditionType = "StorageStructureChangeIgnored"
 )

--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -65,7 +65,7 @@ type Client interface {
 	AddAliasForOldIndices() bool
 
 	// Index Settings API
-	GetIndexSettings(name string) (*estypes.IndexSettings, error)
+	GetIndexSettings(name string) (*estypes.Index, error)
 	UpdateIndexSettings(name string, settings *estypes.IndexSettings) error
 
 	// Nodes API

--- a/internal/elasticsearch/indices.go
+++ b/internal/elasticsearch/indices.go
@@ -93,7 +93,7 @@ func (ec *esClient) CreateIndex(name string, index *estypes.Index) error {
 	return nil
 }
 
-func (ec *esClient) GetIndexSettings(name string) (*estypes.IndexSettings, error) {
+func (ec *esClient) GetIndexSettings(name string) (*estypes.Index, error) {
 	payload := &EsRequest{
 		Method: http.MethodGet,
 		URI:    fmt.Sprintf("%s/_settings", name),
@@ -109,8 +109,14 @@ func (ec *esClient) GetIndexSettings(name string) (*estypes.IndexSettings, error
 			"response_body", payload.ResponseBody)
 	}
 
-	settings := &estypes.IndexSettings{}
-	err := json.Unmarshal([]byte(payload.RawResponseBody), settings)
+	settings := &estypes.Index{}
+	indexSettings, err := json.Marshal(payload.ResponseBody[name])
+	if err != nil {
+		return nil, kverrors.Wrap(err, "failed to decode response body",
+			"destination_type", "estypes.IndexSettings",
+			"index", name)
+	}
+	err = json.Unmarshal(indexSettings, settings)
 	if err != nil {
 		return nil, kverrors.Wrap(err, "failed to decode response body",
 			"destination_type", "estypes.IndexSettings",

--- a/internal/k8shandler/index_management_test.go
+++ b/internal/k8shandler/index_management_test.go
@@ -128,8 +128,10 @@ var _ = Describe("Index Management", func() {
 						"node.infra" : {}
 					},
 					"settings": {
-						"number_of_replicas": 1,
-						"number_of_shards": 3
+						"index": {
+							"number_of_replicas": 1,
+							"number_of_shards": 3
+						}
 					},
 					"template": "node.infra*"
 				}`)
@@ -169,8 +171,10 @@ var _ = Describe("Index Management", func() {
 							}
 						},
 						"settings": {
-							"number_of_replicas": 1,
-							"number_of_shards": 3
+							"index": {
+								"number_of_replicas": 1,
+								"number_of_shards": 3
+							}
 						}
 					}`)
 			})

--- a/internal/k8shandler/migrations/kibana5to6.go
+++ b/internal/k8shandler/migrations/kibana5to6.go
@@ -66,10 +66,12 @@ func (mr *migrationRequest) setKibanaIndexReadOnly() error {
 	}
 
 	if curSett != nil {
-		if curSett.Index != nil {
-			if curSett.Index.Blocks.Write {
-				log.Info("skipping setting index to read-only because already completed", "index", kibanaIndex)
-				return nil
+		if curSett.Settings != nil {
+			if curSett.Settings.Index != nil {
+				if curSett.Settings.Index.Blocks.Write {
+					log.Info("skipping setting index to read-only because already completed", "index", kibanaIndex)
+					return nil
+				}
 			}
 		}
 	}
@@ -111,10 +113,10 @@ func (mr *migrationRequest) createNewKibana6Index() error {
 
 	index := &estypes.Index{
 		Name: kibana6Index,
-		Settings: estypes.IndexSettings{
-			NumberOfShards: 1,
+		Settings: &estypes.IndexSettings{
 			Index: &estypes.IndexingSettings{
-				Format: 6,
+				NumberOfShards: 1,
+				Format:         6,
 				Mapper: &estypes.IndexMapperSettings{
 					Dynamic: false,
 				},

--- a/internal/k8shandler/migrations/kibana5to6_test.go
+++ b/internal/k8shandler/migrations/kibana5to6_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Migrating", func() {
 					".kibana/_settings": {
 						{
 							StatusCode: 200,
-							Body:       `{"index": {"blocks": {"write": true}}}`,
+							Body:       `{".kibana": {"settings": {"index": {"blocks": {"write": true}}}}}`,
 						},
 					},
 				})
@@ -354,8 +354,8 @@ const (
 	expectedKibana6Payload = `
 {
   "settings" : {
-    "number_of_shards" : 1,
     "index": {
+	  "number_of_shards" : 1,
       "format": 6,
       "mapper": {
         "dynamic": false

--- a/internal/k8shandler/status.go
+++ b/internal/k8shandler/status.go
@@ -302,7 +302,7 @@ func (er *ElasticsearchRequest) updateStorageConditions(status *api.Elasticsearc
 				if apierrors.IsNotFound(err) {
 					didMakePVCClaim = false
 				} else {
-					return kverrors.Wrap(err, "failed to get PVC", "claim", cluster.Name,)
+					return kverrors.Wrap(err, "failed to get PVC", "claim", cluster.Name)
 				}
 			}
 
@@ -344,7 +344,7 @@ func (er *ElasticsearchRequest) updateStorageConditions(status *api.Elasticsearc
 				LastTransitionTime: metav1.Now(),
 				Reason:             "StorageClassNameChangeIgnored",
 				Message:            "Changing the storage class name for a custom resource is not supported",
-                        })
+			})
 
 			updateESNodeCondition(status, &api.ClusterCondition{
 				Type:               api.StorageSize,

--- a/internal/types/elasticsearch/types.go
+++ b/internal/types/elasticsearch/types.go
@@ -4,8 +4,10 @@ func NewIndexTemplate(pattern string, aliases []string, shards, replicas int32) 
 	template := IndexTemplate{
 		Template: pattern,
 		Settings: IndexSettings{
-			NumberOfShards:   shards,
-			NumberOfReplicas: replicas,
+			Index: &IndexingSettings{
+				NumberOfShards:   shards,
+				NumberOfReplicas: replicas,
+			},
 		},
 		Aliases: map[string]IndexAlias{},
 	}
@@ -18,9 +20,11 @@ func NewIndexTemplate(pattern string, aliases []string, shards, replicas int32) 
 func NewIndex(name string, shards, replicas int32) *Index {
 	index := Index{
 		Name: name,
-		Settings: IndexSettings{
-			NumberOfShards:   shards,
-			NumberOfReplicas: replicas,
+		Settings: &IndexSettings{
+			Index: &IndexingSettings{
+				NumberOfShards:   shards,
+				NumberOfReplicas: replicas,
+			},
 		},
 		Aliases: map[string]IndexAlias{},
 	}
@@ -39,7 +43,7 @@ func (index *Index) AddAlias(name string, isWriteIndex bool) *Index {
 type Index struct {
 	// Name  intentionally not serialized
 	Name     string                 `json:"-"`
-	Settings IndexSettings          `json:"settings,omitempty"`
+	Settings *IndexSettings         `json:"settings,omitempty"`
 	Aliases  map[string]IndexAlias  `json:"aliases,omitempty"`
 	Mappings map[string]interface{} `json:"mappings,omitempty"`
 }
@@ -90,16 +94,16 @@ type IndexAlias struct {
 }
 
 type IndexSettings struct {
-	NumberOfShards   int32             `json:"number_of_shards,omitempty"`
-	NumberOfReplicas int32             `json:"number_of_replicas,omitempty"`
-	Index            *IndexingSettings `json:"index,omitempty"`
+	Index *IndexingSettings `json:"index,omitempty"`
 }
 
 type IndexingSettings struct {
-	Format  int32                 `json:"format,omitempty"`
-	Blocks  *IndexBlocksSettings  `json:"blocks,omitempty"`
-	Mapper  *IndexMapperSettings  `json:"mapper,omitempty"`
-	Mapping *IndexMappingSettings `json:"mapping,omitempty"`
+	NumberOfShards   int32                 `json:"number_of_shards,omitempty"`
+	NumberOfReplicas int32                 `json:"number_of_replicas,omitempty"`
+	Format           int32                 `json:"format,omitempty"`
+	Blocks           *IndexBlocksSettings  `json:"blocks,omitempty"`
+	Mapper           *IndexMapperSettings  `json:"mapper,omitempty"`
+	Mapping          *IndexMappingSettings `json:"mapping,omitempty"`
 }
 
 type IndexBlocksSettings struct {


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR:
- Fixes the struct used for Index Setting API
The response of Index Setting API is:

> ".security" : {
    "settings" : {
      "index" : {
        "number_of_shards" : "1",
        "provided_name" : ".security",
        "creation_date" : "1617190076948",
        "number_of_replicas" : "0",
        "uuid" : "Mcjw5XDXQai84jjcUjNIkA",
        "version" : {
          "created" : "6080199"
        }
      }
    }
  }

The above respose was getting parsed wrongly into the struct and was returning `nil` values.
- Minor fmt fixes

/cc @periklis @lukas-vlcek <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @ewolinetz <!-- MANDATORY: Assign one approver from top-level OWNERS file -->