### PR TITLE
LOG-1090: Unblock elasticsearch indices when disk utilization falls below flood…

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -17,6 +17,8 @@ const (
 
 	// OcpTemplatePrefix is the prefix all operator generated templates
 	OcpTemplatePrefix = "ocp-gen"
+
+	SecurityIndex = ".security"
 )
 
 var (

--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -38,7 +38,7 @@ type Client interface {
 	// Cluster Settings API
 	GetClusterNodeVersions() ([]string, error)
 	GetThresholdEnabled() (bool, error)
-	GetDiskWatermarks() (interface{}, interface{}, error)
+	GetDiskWatermarks() (interface{}, interface{}, interface{}, error)
 	GetMinMasterNodes() (int32, error)
 	SetMinMasterNodes(numberMasters int32) (bool, error)
 	DoSynchronizedFlush() (bool, error)

--- a/internal/k8shandler/cluster_test.go
+++ b/internal/k8shandler/cluster_test.go
@@ -1,0 +1,78 @@
+package k8shandler
+
+import (
+	"testing"
+
+	elasticsearchv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
+	"github.com/openshift/elasticsearch-operator/internal/elasticsearch"
+	"github.com/openshift/elasticsearch-operator/test/helpers"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDiskUtilizationBelowFloodWatermark(t *testing.T) {
+	nodes = map[string][]NodeTypeInterface{}
+	var (
+		chatter   *helpers.FakeElasticsearchChatter
+		client    elasticsearch.Client
+		k8sClient = fake.NewFakeClient()
+		cluster   = &elasticsearchv1.Elasticsearch{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "elasticsearch",
+				Namespace: "openshift-logging",
+			},
+		}
+	)
+
+	const (
+		esCluster   = "elasticsearch"
+		esNamespace = "openshift-logging"
+	)
+
+	chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+		"_nodes/stats/fs": {
+			{
+				StatusCode: 200,
+				Body:       `{"nodes": {"7EN-Wa_EQC6LoANvWcoyHQ": {"name": "elasticsearch-cdm-1-deadbeef", "fs": {"total": {"total_in_bytes": 32737570816, "free_in_bytes": 16315211776, "available_in_bytes": 16315211776}}}}}`,
+			},
+		},
+	})
+	client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+	er := ElasticsearchRequest{
+		cluster:  cluster,
+		client:   k8sClient,
+		esClient: client,
+	}
+
+	// Populate nodes in operator memory
+	key := nodeMapKey(esCluster, esNamespace)
+	nodes[key] = populateSingleNode(esCluster)
+
+	if isDiskUtilizationBelow := er.isDiskUtilizationBelowFloodWatermark(); isDiskUtilizationBelow != true {
+		t.Errorf("Expected threshold value to be below 95 percent but got more.")
+	}
+}
+
+func populateSingleNode(clusterName string) []NodeTypeInterface {
+	nodes := []NodeTypeInterface{}
+	deployments := []runtime.Object{
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "elasticsearch-cdm-1-deadbeef",
+				Namespace: "openshift-logging",
+			},
+		},
+	}
+	for _, dpl := range deployments {
+		dpl := dpl.(*appsv1.Deployment)
+		node := &deploymentNode{
+			clusterName: clusterName,
+			self:        *dpl,
+		}
+		nodes = append(nodes, node)
+	}
+	return nodes
+}

--- a/internal/k8shandler/elasticsearch_test.go
+++ b/internal/k8shandler/elasticsearch_test.go
@@ -1,0 +1,142 @@
+package k8shandler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/openshift/elasticsearch-operator/internal/constants"
+	"github.com/openshift/elasticsearch-operator/internal/elasticsearch"
+	"github.com/openshift/elasticsearch-operator/test/helpers"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestIndexIsNotBlocked(t *testing.T) {
+	var (
+		chatter   *helpers.FakeElasticsearchChatter
+		client    elasticsearch.Client
+		k8sClient = fake.NewFakeClient()
+	)
+
+	const (
+		esCluster   = "elasticsearch"
+		esNamespace = "openshift-logging"
+	)
+
+	chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+		".security/_settings": {
+			{
+				StatusCode: 200,
+				Body:       `{".security": {"settings": {}}}`,
+			},
+		},
+	})
+	client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+	er := ElasticsearchRequest{
+		client:   k8sClient,
+		esClient: client,
+	}
+
+	if isBlocked := er.isIndexBlocked(constants.SecurityIndex); isBlocked != false {
+		t.Errorf("Expected index to be not blocked, but found blocked.")
+	}
+
+	// Get Index settings first
+	req, found := chatter.GetRequest(".security/_settings")
+	if found != true {
+		t.Errorf("Expected true but got false.")
+	}
+	if req.Method != http.MethodGet {
+		t.Errorf("Expected: %v, got: %v", http.MethodGet, req.Method)
+	}
+}
+
+func TestIndexIsBlocked(t *testing.T) {
+	var (
+		chatter   *helpers.FakeElasticsearchChatter
+		client    elasticsearch.Client
+		k8sClient = fake.NewFakeClient()
+	)
+
+	const (
+		esCluster   = "elasticsearch"
+		esNamespace = "openshift-logging"
+	)
+
+	chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+		".security/_settings": {
+			{
+				StatusCode: 200,
+				Body:       `{".security": {"settings": {"index": {"blocks": {"read_only_allow_delete": "true"}}}}}`,
+			},
+		},
+	})
+	client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+	er := ElasticsearchRequest{
+		client:   k8sClient,
+		esClient: client,
+	}
+
+	if isBlocked := er.isIndexBlocked(constants.SecurityIndex); isBlocked != true {
+		t.Errorf("Expected index to be blocked, but found unblocked.")
+	}
+
+	// Get Index settings first
+	req, found := chatter.GetRequest(".security/_settings")
+	if found != true {
+		t.Errorf("Expected true but got false.")
+	}
+	if req.Method != http.MethodGet {
+		t.Errorf("Expected: %v, got: %v", http.MethodGet, req.Method)
+	}
+}
+
+func TestCreateSettingToUnblock(t *testing.T) {
+	var (
+		chatter   *helpers.FakeElasticsearchChatter
+		client    elasticsearch.Client
+		k8sClient = fake.NewFakeClient()
+	)
+
+	const (
+		esCluster   = "elasticsearch"
+		esNamespace = "openshift-logging"
+	)
+
+	chatter = helpers.NewFakeElasticsearchChatter(map[string]helpers.FakeElasticsearchResponses{
+		"app-00001/_settings": {
+			{
+				StatusCode: 200,
+				Body:       `{}`,
+			},
+		},
+	})
+	client = helpers.NewFakeElasticsearchClient(esCluster, esNamespace, k8sClient, chatter)
+
+	er := ElasticsearchRequest{
+		client:   k8sClient,
+		esClient: client,
+	}
+
+	if err := er.unblockIndex("app-00001"); err != nil {
+		t.Errorf("Expected to unblock but got err: %v", err)
+	}
+
+	// Update Index setting
+	req, found := chatter.GetRequest("app-00001/_settings")
+	if found != true {
+		t.Errorf("Expected true but got false.")
+	}
+	if req.Method != http.MethodPut {
+		t.Errorf("Expected: %v, got: %v", http.MethodPut, req.Method)
+	}
+	helpers.ExpectJSON(req.Body).ToEqual(
+		`{
+				"index": {
+					"blocks": {
+						"read_only_allow_delete": null
+					}
+				}
+			}`)
+}

--- a/internal/k8shandler/index_management_test.go
+++ b/internal/k8shandler/index_management_test.go
@@ -129,8 +129,8 @@ var _ = Describe("Index Management", func() {
 					},
 					"settings": {
 						"index": {
-							"number_of_replicas": 1,
-							"number_of_shards": 3
+							"number_of_replicas": "1",
+							"number_of_shards": "3"
 						}
 					},
 					"template": "node.infra*"
@@ -172,8 +172,8 @@ var _ = Describe("Index Management", func() {
 						},
 						"settings": {
 							"index": {
-								"number_of_replicas": 1,
-								"number_of_shards": 3
+								"number_of_replicas": "1",
+								"number_of_shards": "3"
 							}
 						}
 					}`)

--- a/internal/k8shandler/migrations/kibana5to6_test.go
+++ b/internal/k8shandler/migrations/kibana5to6_test.go
@@ -346,7 +346,8 @@ const (
 {
   "index": {
     "blocks": {
-      "write": true
+      "write": true,
+      "read_only_allow_delete": null
     }
   }
 }
@@ -355,7 +356,7 @@ const (
 {
   "settings" : {
     "index": {
-	  "number_of_shards" : 1,
+	  "number_of_shards" : "1",
       "format": 6,
       "mapper": {
         "dynamic": false

--- a/internal/types/elasticsearch/types.go
+++ b/internal/types/elasticsearch/types.go
@@ -98,8 +98,8 @@ type IndexSettings struct {
 }
 
 type IndexingSettings struct {
-	NumberOfShards   int32                 `json:"number_of_shards,omitempty"`
-	NumberOfReplicas int32                 `json:"number_of_replicas,omitempty"`
+	NumberOfShards   int32                 `json:"number_of_shards,string,omitempty"`
+	NumberOfReplicas int32                 `json:"number_of_replicas,string,omitempty"`
 	Format           int32                 `json:"format,omitempty"`
 	Blocks           *IndexBlocksSettings  `json:"blocks,omitempty"`
 	Mapper           *IndexMapperSettings  `json:"mapper,omitempty"`
@@ -107,7 +107,8 @@ type IndexingSettings struct {
 }
 
 type IndexBlocksSettings struct {
-	Write bool `json:"write"`
+	Write               bool    `json:"write,omitempty"`
+	ReadOnlyAllowDelete *string `json:"read_only_allow_delete"`
 }
 
 type IndexMapperSettings struct {


### PR DESCRIPTION
… watermark threshold

### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR:
- Releases the lock on all elasticsearch indices except the `.security` index once the disk utilization falls below flood watermark threshold.
- Documented the work around for removing lock on `.security` index manually.

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @ewolinetz  <!-- MANDATORY: Assign one approver from top-level OWNERS file -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-1090