### PR TITLE
LOG-981: rate limit es cluster downsizings to limit data loss

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ image: .output/image
 
 test-unit: $(GO_JUNIT_REPORT) coveragedir junitreportdir test-unit-prom
 	@set -o pipefail && \
-		go test -v -race -coverprofile=$(COVERAGE_DIR)/test-unit.cov ./internal/... ./apis/... ./controllers/... ./. 2>&1 | \
+		go test -race -coverprofile=$(COVERAGE_DIR)/test-unit.cov ./internal/... ./apis/... ./controllers/... ./. 2>&1 | \
 		tee /dev/stderr | \
 		$(GO_JUNIT_REPORT) > $(JUNIT_REPORT_OUTPUT_DIR)/junit.xml
 	@grep -v 'zz_generated\.' $(COVERAGE_DIR)/test-unit.cov > $(COVERAGE_DIR)/nogen.cov

--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -74,6 +74,7 @@ type Client interface {
 	// Replicas
 	UpdateReplicaCount(replicaCount int32) error
 	GetIndexReplicaCounts() (map[string]interface{}, error)
+	GetLowestReplicaValue() (int32, error)
 
 	// Shards API
 	ClearTransientShardAllocation() (bool, error)

--- a/internal/k8shandler/status.go
+++ b/internal/k8shandler/status.go
@@ -941,6 +941,22 @@ func updateInvalidReplicationCondition(status *api.ElasticsearchStatus, value v1
 	})
 }
 
+func updateInvalidScaleDownCondition(status *api.ElasticsearchStatus, value v1.ConditionStatus) bool {
+	var message string
+	var reason string
+	if value == v1.ConditionTrue {
+		message = "Data node scale down rate is too high based on minimum number of replicas for all indices"
+		reason = "Invalid Settings"
+	}
+
+	return updateESNodeCondition(status, &api.ClusterCondition{
+		Type:    api.InvalidRedundancy,
+		Status:  value,
+		Reason:  reason,
+		Message: message,
+	})
+}
+
 func (er *ElasticsearchRequest) UpdateDegradedCondition(value bool, reason, message string) {
 	cluster := er.cluster
 


### PR DESCRIPTION
### Description
To help protect user data more, we want to prevent users from making dangerous configuration changes when it comes to scaling down the number of ES nodes deployed to the cluster.

Based on the current minimum number of replicas for the cluster (not the redundancy policy) we determine the maximum number of nodes we can scale down at a time to help prevent data loss.

/cc @lukas-vlcek @blockloop @periklis 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-981
