### PR TITLE
LOG-1327: Port fix to 5.1.0 for BZ-1945168

### DIFF
--- a/internal/k8shandler/kibana/reconciler.go
+++ b/internal/k8shandler/kibana/reconciler.go
@@ -223,7 +223,7 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaDeployment(proxyConfig 
 
 	kibanaPodSpec := newKibanaPodSpec(
 		clusterRequest,
-		fmt.Sprintf("%s.%s.svc.cluster.local", clusterName, clusterRequest.cluster.Namespace),
+		fmt.Sprintf("%s.%s.svc", clusterName, clusterRequest.cluster.Namespace),
 		proxyConfig,
 		kibanaTrustBundle,
 	)


### PR DESCRIPTION
### Description
This PR provides a port of the merged fix #691 (Target Version `4.6.z`) for `5.1.0`

/cc @blockloop 
/assign @ewolinetz 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1945168
- JIRA: https://issues.redhat.com/browse/LOG-1327
