### PR TITLE
LOG-1309: Sometimes the metric count "rolling_restart" doesn't increase after ES cluster perform rolling restart.

### DIFF
--- a/internal/k8shandler/cluster.go
+++ b/internal/k8shandler/cluster.go
@@ -108,6 +108,7 @@ func (er *ElasticsearchRequest) CreateOrUpdateElasticsearchCluster() error {
 			}
 		}
 
+		metrics.IncrementRestartCounterRolling()
 		_ = er.UpdateClusterStatus()
 	}
 


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR:
- Fixes the issue of `eo_elasticsearch_cr_restart_total{reason="rolling_restart"}` not getting incremented sometimes while the ES cluster performs rolling restart.

The metric wasn't getting incremented because when the ES cluster is scheduled for rolling restart, it doesn't finish the restart in the same iteration most of the time and hence the scheduled node goes into `inProgress` state. The restart becomes successful in subsequent iterations and hence the metric should be incremented when `inProgress` nodes have restarted successfully additional to when the restart becomes successful in the first iteration itself.

/cc @QiaolingTang 
/assign @ewolinetz <!-- MANDATORY: Assign one approver from top-level OWNERS file -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-1309