### PR TITLE
LOG-1351: Preventing upgrade when changes done to the storage

### DIFF
--- a/internal/k8shandler/deployment.go
+++ b/internal/k8shandler/deployment.go
@@ -357,7 +357,7 @@ func (node *deploymentNode) executeUpdate() error {
 		}
 
 		if ArePodTemplateSpecDifferent(currentDeployment.Spec.Template, node.self.Spec.Template) {
-			currentDeployment.Spec.Template = CopyPodTemplateSpec(node.self.Spec.Template, currentDeployment.Spec.Template, true)
+			currentDeployment.Spec.Template = CreateUpdatablePodTemplateSpec(currentDeployment.Spec.Template, node.self.Spec.Template)
 
 			if err := node.client.Update(context.TODO(), &currentDeployment); err != nil {
 				log.Info("Failed to update node resource", "error", err)

--- a/internal/k8shandler/podtemplate_test.go
+++ b/internal/k8shandler/podtemplate_test.go
@@ -145,8 +145,8 @@ var _ = Describe("podtemplate", func() {
 			}
 		})
 
-		It("should recognize a volume change", func() {
-			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeTrue())
+		It("shouldn't recognize a volume change", func() {
+			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeFalse())
 		})
 	})
 
@@ -173,8 +173,8 @@ var _ = Describe("podtemplate", func() {
 			}
 		})
 
-		It("should recognize a volume change", func() {
-			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeTrue())
+		It("shouldn't recognize a volume change", func() {
+			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeFalse())
 		})
 	})
 
@@ -203,8 +203,8 @@ var _ = Describe("podtemplate", func() {
 			}
 		})
 
-		It("should recognize a volume change", func() {
-			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeTrue())
+		It("shouldn't recognize a volume change", func() {
+			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeFalse())
 		})
 	})
 
@@ -222,8 +222,8 @@ var _ = Describe("podtemplate", func() {
 			}
 		})
 
-		It("should recognize a volume change", func() {
-			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeTrue())
+		It("shouldn't recognize a volume change", func() {
+			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeFalse())
 		})
 	})
 
@@ -249,8 +249,8 @@ var _ = Describe("podtemplate", func() {
 			}
 		})
 
-		It("should recognize a volume change", func() {
-			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeTrue())
+		It("shouldn't recognize a volume change", func() {
+			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeFalse())
 		})
 	})
 
@@ -268,8 +268,8 @@ var _ = Describe("podtemplate", func() {
 			}
 		})
 
-		It("should recognize a volume change", func() {
-			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeTrue())
+		It("shouldn't recognize a volume change", func() {
+			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeFalse())
 		})
 	})
 
@@ -294,8 +294,8 @@ var _ = Describe("podtemplate", func() {
 			}
 		})
 
-		It("should recognize a volume change", func() {
-			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeTrue())
+		It("shouldn't recognize a volume change", func() {
+			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeFalse())
 		})
 	})
 
@@ -313,8 +313,8 @@ var _ = Describe("podtemplate", func() {
 			}
 		})
 
-		It("should recognize a volume change", func() {
-			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeTrue())
+		It("shouldn't recognize a volume change", func() {
+			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeFalse())
 		})
 	})
 
@@ -339,8 +339,8 @@ var _ = Describe("podtemplate", func() {
 			}
 		})
 
-		It("should recognize a volume change", func() {
-			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeTrue())
+		It("shouldn't recognize a volume change", func() {
+			Expect(ArePodTemplateSpecDifferent(lhs, rhs)).To(BeFalse())
 		})
 	})
 

--- a/internal/k8shandler/statefulset.go
+++ b/internal/k8shandler/statefulset.go
@@ -318,7 +318,7 @@ func (n *statefulSetNode) executeUpdate() error {
 		}
 
 		if ArePodTemplateSpecDifferent(currentStatefulSet.Spec.Template, n.self.Spec.Template) {
-			currentStatefulSet.Spec.Template = CopyPodTemplateSpec(n.self.Spec.Template, currentStatefulSet.Spec.Template, true)
+			currentStatefulSet.Spec.Template = CreateUpdatablePodTemplateSpec(currentStatefulSet.Spec.Template, n.self.Spec.Template)
 
 			if updateErr := n.client.Update(context.TODO(), &currentStatefulSet); updateErr != nil {
 				n.L().Error(err, "Failed to update node resource")

--- a/internal/k8shandler/status.go
+++ b/internal/k8shandler/status.go
@@ -327,7 +327,18 @@ func (er *ElasticsearchRequest) updateStorageConditions(status *api.Elasticsearc
 				return nil
 			}
 
-			if !reflect.DeepEqual(current.Spec.StorageClassName, specVol.StorageClassName) {
+			// Generally, this won't last very long with the exception of the case of
+			// moving from ephermeral storage to a persistent one. Since the volume is
+			// never created after the intial create, a PVC should never remain in the
+			// the pending state for a long period of time with the exception of this case.
+			isPVCPending := reflect.DeepEqual(current.Status.Phase, v1.ClaimPending)
+			if isUsingPVCStorageSpec && isPVCPending {
+				structureStatus = v1.ConditionTrue
+				return nil
+			}
+
+			isDefaultName := specVol.StorageClassName == nil && current.Spec.StorageClassName != nil
+			if !isDefaultName && !reflect.DeepEqual(current.Spec.StorageClassName, specVol.StorageClassName) {
 				nameStatus = v1.ConditionTrue
 			}
 


### PR DESCRIPTION
Prevents the ES cluster from upgrading when a user is making an unsupported change to the storage spec. This also fixes the ephemeral to persistent volume claim case. 

As a note, this PR also makes the `StorageStructureChangeIgnored` status appear when the cluster is first spinning up. However, this status will disappear before the cluster goes `green`. The status will then not appear unless the user attempts to add storage after the cluster has been created.

In order to remove this condition when the user has attempted to add storage, the user must remove the PVC that is created by their change. This PVC will be stuck in the pending state as the cluster will not actually make the PV accompanying it, since it will overwrite those expected changes with the original volumes. Once the user has done a `oc delete pvc/<claim>`, the status will be removed after a few seconds.

/cc @lukas-vlcek 
/assign @ewolinetz 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1351
