### PR TITLE
Updating alerts to use runbook_url and have different base URIs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,9 @@ LABEL \
         version=${CI_CONTAINER_VERSION}
 
 ENV ALERTS_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_alerts.yml"
-ENV RULES_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_rules.yml"
+ENV RULES_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_recording_rules.yml"
 ENV ES_DASHBOARD_FILE="/etc/elasticsearch-operator/files/dashboards/logging-dashboard-elasticsearch.json"
+ENV RUNBOOK_BASE_URL="https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md"
 
 COPY --from=builder /go/src/github.com/openshift/elasticsearch-operator/bin/elasticsearch-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/elasticsearch-operator/files/ /etc/elasticsearch-operator/files/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -41,8 +41,9 @@ LABEL \
         version=${CI_CONTAINER_VERSION}
 
 ENV ALERTS_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_alerts.yml"
-ENV RULES_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_rules.yml"
+ENV RULES_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_recording_rules.yml"
 ENV ES_DASHBOARD_FILE="/etc/elasticsearch-operator/files/dashboards/logging-dashboard-elasticsearch.json"
+ENV RUNBOOK_BASE_URL="https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md"
 
 COPY --from=builder /go/src/github.com/openshift/elasticsearch-operator/bin/elasticsearch-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/elasticsearch-operator/files/ /etc/elasticsearch-operator/files/

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -43,8 +43,9 @@ LABEL \
         version=${CI_CONTAINER_VERSION}
 
 ENV ALERTS_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_alerts.yml"
-ENV RULES_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_rules.yml"
+ENV RULES_FILE_PATH="/etc/elasticsearch-operator/files/prometheus_recording_rules.yml"
 ENV ES_DASHBOARD_FILE="/etc/elasticsearch-operator/files/dashboards/logging-dashboard-elasticsearch.json"
+ENV RUNBOOK_BASE_URL="https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html"
 
 COPY --from=builder /go/src/github.com/openshift/elasticsearch-operator/bin/elasticsearch-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/elasticsearch-operator/files/ /etc/elasticsearch-operator/files/

--- a/dev-meta.yaml
+++ b/dev-meta.yaml
@@ -3,3 +3,6 @@ from:
   target: registry.ci.openshift.org/openshift/release:golang-1.14 AS builder
 - source: openshift-ose-base\:v(?:[\.0-9\-]*)
   target: docker.io/centos:8 AS centos
+env:
+- source: RUNBOOK_BASE_URL=.*
+  target: RUNBOOK_BASE_URL="https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md"

--- a/files/prometheus_alerts.yml
+++ b/files/prometheus_alerts.yml
@@ -1,41 +1,46 @@
-groups:
-- name: logging_elasticsearch.alerts
-  rules:
-  - alert: ElasticsearchClusterNotHealthy
-    annotations:
-      message: "Cluster {{ $labels.cluster }} health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Health-is-Red"
-      summary: "Cluster health status is RED"
-    expr: |
+---
+"groups":
+- "name": logging_elasticsearch.alerts
+  "rules":
+  - "alert": ElasticsearchClusterNotHealthy
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet."
+      "summary": "Cluster health status is RED"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red"
+    "expr": |
       sum by (cluster) (es_cluster_status == 2)
-    for: 7m
-    labels:
-      severity: critical
+    "for": 7m
+    "labels":
+      "severity": critical
 
-  - alert: ElasticsearchClusterNotHealthy
-    annotations:
-      message: "Cluster {{ $labels.cluster }} health status has been YELLOW for at least 20m. Some shard replicas are not allocated. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Healthy-is-Yellow"
-      summary: "Cluster health status is YELLOW"
-    expr: |
+  - "alert": ElasticsearchClusterNotHealthy
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} health status has been YELLOW for at least 20m. Some shard replicas are not allocated."
+      "summary": "Cluster health status is YELLOW"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow"
+    "expr": |
       sum by (cluster) (es_cluster_status == 1)
-    for: 20m
-    labels:
-      severity: warning
+    "for": 20m
+    "labels":
+      "severity": warning
 
-  - alert: ElasticsearchWriteRequestsRejectionJumps
-    annotations:
-      message: "High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster }} cluster. This node may not be keeping up with the indexing speed. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Write-Requests-Rejection-Jumps"
-      summary: "High Write Rejection Ratio - {{ $value }}%"
-    expr: |
+  - "alert": ElasticsearchWriteRequestsRejectionJumps
+    "annotations":
+      "message": "High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster }} cluster. This node may not be keeping up with the indexing speed."
+      "summary": "High Write Rejection Ratio - {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps"
+    "expr": |
       round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
-    for: 10m
-    labels:
-      severity: warning
+    "for": 10m
+    "labels":
+      "severity": warning
 
-  - alert: ElasticsearchNodeDiskWatermarkReached
-    annotations:
-      message: "Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached"
-      summary: "Disk Low Watermark Reached - disk saturation is {{ $value }}%"
-    expr: |
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node."
+      "summary": "Disk Low Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+    "expr": |
       sum by (instance, pod) (
         round(
           (1 - (
@@ -44,15 +49,16 @@ groups:
           )
         ) * 100, 0.001)
       ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
-    for: 5m
-    labels:
-      severity: info
+    "for": 5m
+    "labels":
+      "severity": info
 
-  - alert: ElasticsearchNodeDiskWatermarkReached
-    annotations:
-      message: "Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-High-Watermark-Reached"
-      summary: "Disk High Watermark Reached - disk saturation is {{ $value }}%"
-    expr: |
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node."
+      "summary": "Disk High Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached"
+    "expr": |
       sum by (instance, pod) (
         round(
           (1 - (
@@ -61,15 +67,16 @@ groups:
           )
         ) * 100, 0.001)
       ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
-    for: 5m
-    labels:
-      severity: critical
+    "for": 5m
+    "labels":
+      "severity": critical
 
-  - alert: ElasticsearchNodeDiskWatermarkReached
-    annotations:
-      message: "Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
-      summary: "Disk Flood Stage Watermark Reached - disk saturation is {{ $value }}%"
-    expr: |
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark."
+      "summary": "Disk Flood Stage Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
+    "expr": |
       sum by (instance, pod) (
         round(
           (1 - (
@@ -78,66 +85,125 @@ groups:
           )
         ) * 100, 0.001)
       ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
-    for: 5m
-    labels:
-      severity: critical
+    "for": 5m
+    "labels":
+      "severity": critical
 
-  - alert: ElasticsearchJVMHeapUseHigh
-    annotations:
-      message: "JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-JVM-Heap-Use-is-High"
-      summary: "JVM Heap usage on the node is high"
-    expr: |
+  - "alert": ElasticsearchJVMHeapUseHigh
+    "annotations":
+      "message": "JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "JVM Heap usage on the node is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High"
+    "expr": |
       sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
-    for: 10m
-    labels:
-      severity: info
+    "for": 10m
+    "labels":
+      "severity": info
 
-  - alert: AggregatedLoggingSystemCPUHigh
-    annotations:
-      message: "System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Aggregated-Logging-System-CPU-is-High"
-      summary: "System CPU usage is high"
-    expr: |
+  - "alert": AggregatedLoggingSystemCPUHigh
+    "annotations":
+      "message": "System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "System CPU usage is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High"
+    "expr": |
       sum by (cluster, instance, node) (es_os_cpu_percent) > 90
-    for: 1m
-    labels:
-      severity: info
+    "for": 1m
+    "labels":
+      "severity": info
 
-  - alert: ElasticsearchProcessCPUHigh
-    annotations:
-      message: "ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Process-CPU-is-High"
-      summary: "ES process CPU usage is high"
-    expr: |
+  - "alert": ElasticsearchProcessCPUHigh
+    "annotations":
+      "message": "ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "ES process CPU usage is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High"
+    "expr": |
       sum by (cluster, instance, node) (es_process_cpu_percent) > 90
-    for: 1m
-    labels:
-      severity: info
+    "for": 1m
+    "labels":
+      "severity": info
 
-  - alert: ElasticsearchDiskSpaceRunningLow
-    annotations:
-      message: "Cluster {{ $labels.cluster }} is predicted to be out of disk space within the next 6h For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Disk-Space-is-Running-Low"
-      summary: "Cluster low on disk space"
-    expr: |
+  - "alert": ElasticsearchDiskSpaceRunningLow
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} is predicted to be out of disk space within the next 6h."
+      "summary": "Cluster low on disk space"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low"
+    "expr": |
       sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
-    for: 1h
-    labels:
-      severity: critical
+    "for": 1h
+    "labels":
+      "severity": critical
 
-  - alert: ElasticsearchHighFileDescriptorUsage
-    annotations:
-      message: "Cluster {{ $labels.cluster }} is predicted to be out of file descriptors within the next hour. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-FileDescriptor-Usage-is-high"
-      summary: "Cluster low on file descriptors"
-    expr: |
+  - "alert": ElasticsearchHighFileDescriptorUsage
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} is predicted to be out of file descriptors within the next hour."
+      "summary": "Cluster low on file descriptors"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high"
+    "expr": |
       predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
-    for: 10m
-    labels:
-      severity: warning
+    "for": 10m
+    "labels":
+      "severity": warning
 
-  - alert: ElasticsearchOperatorCSVNotSuccessful
-    annotations:
-      message: "Elasticsearch Operator CSV has not reconciled succesfully."
-      summary: "Elasticsearch Operator CSV Not Successful"
-    expr: |
+  - "alert": ElasticsearchOperatorCSVNotSuccessful
+    "annotations":
+      "message": "Elasticsearch Operator CSV has not reconciled succesfully."
+      "summary": "Elasticsearch Operator CSV Not Successful"
+    "expr": |
       csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
-    for: 10m
-    labels:
-      severity: warning
+    "for": 10m
+    "labels":
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Low Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node."
+      "summary": "Disk Low Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+    "for": 1h
+    "labels":
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk High Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node."
+      "summary": "Disk High Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+    "for": 1h
+    "labels":
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Flood Stage Watermark is predicted to be reached within the next 6h at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark."
+      "summary": "Disk Flood Stage Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+    "for": 1h
+    "labels":
+      "severity": warning

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/openshift/api v0.0.0-20200602204738-768b7001fe69
+	github.com/prometheus/client_golang v1.2.1
 	go.uber.org/zap v1.16.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.8

--- a/hack/generate-dockerfile-from-midstream
+++ b/hack/generate-dockerfile-from-midstream
@@ -23,6 +23,11 @@ if froms and len(froms) > 0:
   for base in froms:
     dockerfileIn = re.sub("FROM " + base['source'],"FROM " + base['target'],dockerfileIn)
 
+envs = metaYaml['env']
+if envs and len(envs) > 0:
+  for base in envs:
+    dockerfileIn = re.sub("ENV " + base['source'],"ENV " + base['target'],dockerfileIn)
+
 #Remove aliases if only one is defined otherwise it will fail
 aliases = []
 froms = 0

--- a/internal/k8shandler/prometheus_rule_test.go
+++ b/internal/k8shandler/prometheus_rule_test.go
@@ -15,7 +15,7 @@ var _ = Describe("prometheusrules", func() {
 
 	Context("rules", func() {
 		It("should build without errors", func() {
-			_, err := ruleSpec(rulePath)
+			_, err := ruleSpec("prometheus_recording_rules.yml", rulePath)
 
 			Expect(err).To(BeNil())
 		})
@@ -23,7 +23,7 @@ var _ = Describe("prometheusrules", func() {
 
 	Context("alerts", func() {
 		It("should build without errors", func() {
-			_, err := ruleSpec(alertPath)
+			_, err := ruleSpec("prometheus_alerts.yml", alertPath)
 
 			Expect(err).To(BeNil())
 		})

--- a/origin-meta.yaml
+++ b/origin-meta.yaml
@@ -3,3 +3,6 @@ from:
   target: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 - source: openshift-ose-base\:v(?:[\.0-9\-]*)
   target: registry.ci.openshift.org/ocp/4.7:base
+env:
+- source: RUNBOOK_BASE_URL=.*
+  target: RUNBOOK_BASE_URL="https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md"

--- a/test/files/prometheus-unit-tests/test.yml
+++ b/test/files/prometheus-unit-tests/test.yml
@@ -60,7 +60,8 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Cluster health status is YELLOW"
-              message: "Cluster elasticsearch health status has been YELLOW for at least 20m. Some shard replicas are not allocated. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Healthy-is-Yellow"
+              message: "Cluster elasticsearch health status has been YELLOW for at least 20m. Some shard replicas are not allocated."
+              runbook_url: "[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow"
 
       # --------- ElasticsearchClusterNotHealthy (red) ---------
       - eval_time: 38m
@@ -71,7 +72,8 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Cluster health status is RED"
-              message: "Cluster elasticsearch health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Health-is-Red"
+              message: "Cluster elasticsearch health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet."
+              runbook_url: "[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red"
 
       # --------- ElasticsearchWriteRequestsRejectionJumps ---------
       # Within the first 10m the percent of rejected requests is = 5% (the alert require > 5%)
@@ -89,7 +91,8 @@ tests:
               severity: warning
             exp_annotations:
               summary: "High Write Rejection Ratio - 10%"
-              message: "High Write Rejection Ratio at elasticsearch-cdm-1 node in elasticsearch cluster. This node may not be keeping up with the indexing speed. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Write-Requests-Rejection-Jumps"
+              message: "High Write Rejection Ratio at elasticsearch-cdm-1 node in elasticsearch cluster. This node may not be keeping up with the indexing speed."
+              runbook_url: "[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps"
 
       # --------- ElasticsearchNodeDiskWatermarkReached ---------
       # By the end of 10th minute we do not expect the low watermark has been active for more than 5 minutes.
@@ -107,7 +110,8 @@ tests:
               severity: info
             exp_annotations:
               summary: "Disk Low Watermark Reached - disk saturation is 90%"
-              message: "Disk Low Watermark Reached at pod-1 pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+              message: "Disk Low Watermark Reached at pod-1 pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node."
+              runbook_url: "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached"
 
       # --------- AggregatedLoggingSystemCPUHigh ---------
       - eval_time: 15m
@@ -120,7 +124,8 @@ tests:
               severity: info
             exp_annotations:
               summary: "System CPU usage is high"
-              message: "System CPU usage on the node elasticsearch-cdm-1 in elasticsearch cluster is 95%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Aggregated-Logging-System-CPU-is-High"
+              message: "System CPU usage on the node elasticsearch-cdm-1 in elasticsearch cluster is 95%."
+              runbook_url: "[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High"
 
       # Critical value not reached - no alert is fired
       - eval_time: 5m
@@ -138,7 +143,8 @@ tests:
               severity: info
             exp_annotations:
               summary: "ES process CPU usage is high"
-              message: "ES process CPU usage on the node elasticsearch-cdm-1 in elasticsearch cluster is 95%. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Process-CPU-is-High"
+              message: "ES process CPU usage on the node elasticsearch-cdm-1 in elasticsearch cluster is 95%."
+              runbook_url: "[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High"
 
       # Critical value not reached - no alert is fired
       - eval_time: 5m

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -119,6 +119,7 @@ github.com/openshift/api/route/v1
 # github.com/pkg/errors v0.8.1
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.2.1
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp


### PR DESCRIPTION
### Description
For upstream and downstream, we use different URLs for our playbooks.

Manual cherry-pick of https://github.com/openshift/elasticsearch-operator/pull/717

/cc @jcantrill 
