### PR TITLE
LOG-1406: Check for watermark and unblock indices only when all nodes are ready

### DIFF
--- a/internal/k8shandler/cluster.go
+++ b/internal/k8shandler/cluster.go
@@ -177,9 +177,6 @@ func (er *ElasticsearchRequest) CreateOrUpdateElasticsearchCluster() error {
 		// we only want to update our replicas if we aren't in the middle up an update
 		er.updateReplicas()
 
-		// check if nodes are below watermark threshold and unblock indices if it's marked as read only
-		er.checkWatermarkAndUnblockIndices()
-
 		// add alias to old indices if they exist and don't have one
 		// this should be removed after one release...
 		if er.ClusterReady() {
@@ -193,6 +190,9 @@ func (er *ElasticsearchRequest) CreateOrUpdateElasticsearchCluster() error {
 					aliasNeededMap[nodeMapKey(er.cluster.Name, er.cluster.Namespace)] = false
 				}
 			}
+
+			// check if nodes are below watermark threshold and unblock indices if it's marked as read only
+			er.checkWatermarkAndUnblockIndices()
 		}
 	}
 


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR:
- Updates the EO to check for watermark and unblock indices only when all elasticsearch nodes are ready 

/cc @ewolinetz <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @ewolinetz <!-- MANDATORY: Assign one approver from top-level OWNERS file -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-1406