### PR TITLE
[release-5.1] LOG-1309: Sometimes the metric count "rolling_restart" doesn't increase after ES cluster perform rolling restart.

### DIFF
--- a/internal/k8shandler/cluster.go
+++ b/internal/k8shandler/cluster.go
@@ -106,6 +106,7 @@ func (er *ElasticsearchRequest) CreateOrUpdateElasticsearchCluster() error {
 			}
 		}
 
+		metrics.IncrementRestartCounterRolling()
 		_ = er.UpdateClusterStatus()
 	}
 


### PR DESCRIPTION
### Description
This PR:
- Is the backport to release-5.1 for the previous PR (https://github.com/openshift/elasticsearch-operator/pull/714)

/cc @QiaolingTang
/assign @ewolinetz

### Links
JIRA: https://issues.redhat.com/browse/LOG-1309