### PR TITLE
LOG-1268: Suspend cronjobs when ES is scaled to zero nodes

### DIFF
--- a/internal/indexmanagement/index_management_test.go
+++ b/internal/indexmanagement/index_management_test.go
@@ -1,6 +1,7 @@
 package indexmanagement
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
@@ -9,7 +10,11 @@ import (
 	elasticsearch "github.com/openshift/elasticsearch-operator/apis/logging/v1"
 	"github.com/openshift/elasticsearch-operator/internal/constants"
 	"github.com/openshift/elasticsearch-operator/test/helpers"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -44,6 +49,87 @@ var _ = Describe("Index Management", func() {
 		Context("when IndexManagement is not spec'd", func() {
 			It("should process the resource as a noop", func() {
 				Expect(request.createOrUpdateIndexManagement()).To(BeNil())
+			})
+		})
+
+		Context("when elasticsearch pods", func() {
+			var (
+				req    *IndexManagementRequest
+				esPods []runtime.Object
+			)
+
+			BeforeEach(func() {
+				esPods = []runtime.Object{
+					&corev1.Pod{
+
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "elasticsearch-deadbeef-cdm-acabacab-1",
+							Namespace: "openshift-logging",
+							Labels: map[string]string{
+								"cluster-name": "elasticsearch",
+								"component":    "elasticsearch",
+							},
+						},
+					},
+				}
+
+				req = &IndexManagementRequest{
+					client: fake.NewFakeClient(),
+					cluster: &elasticsearch.Elasticsearch{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "elasticsearch",
+							Namespace: "openshift-logging",
+						},
+						Spec: elasticsearch.ElasticsearchSpec{
+							IndexManagement: &elasticsearch.IndexManagementSpec{
+								Policies: []elasticsearch.IndexManagementPolicySpec{
+									{
+										Name:         "infra-policy",
+										PollInterval: elasticsearch.TimeUnit("1m"),
+										Phases: elasticsearch.IndexManagementPhasesSpec{
+											Hot: &elasticsearch.IndexManagementHotPhaseSpec{
+												Actions: elasticsearch.IndexManagementActionsSpec{
+													Rollover: &elasticsearch.IndexManagementActionSpec{
+														MaxAge: elasticsearch.TimeUnit("2m"),
+													},
+												},
+											},
+											Delete: &elasticsearch.IndexManagementDeletePhaseSpec{
+												MinAge: elasticsearch.TimeUnit("5m"),
+											},
+										},
+									},
+								},
+								Mappings: []elasticsearch.IndexManagementPolicyMappingSpec{
+									{
+										Name:      "infra",
+										PolicyRef: "infra-policy",
+										Aliases:   []string{"infra", "logs.infra"},
+									},
+								},
+							},
+						},
+					},
+				}
+			})
+
+			It("should suspend all cronjobs when non available", func() {
+				Expect(req.createOrUpdateIndexManagement()).To(BeNil())
+
+				cj := &batchv1beta1.CronJob{}
+				key := client.ObjectKey{Name: "elasticsearch-im-infra", Namespace: "openshift-logging"}
+				Expect(req.client.Get(context.TODO(), key, cj)).To(BeNil())
+				Expect(*cj.Spec.Suspend).To(BeTrue())
+			})
+
+			It("should unsuspend all cronjobs when at least on elasticsearch pod running", func() {
+				req.client = fake.NewFakeClient(esPods...)
+				Expect(req.createOrUpdateIndexManagement()).To(BeNil())
+
+				cj := &batchv1beta1.CronJob{}
+				key := client.ObjectKey{Name: "elasticsearch-im-infra", Namespace: "openshift-logging"}
+				Expect(req.client.Get(context.TODO(), key, cj)).To(BeNil())
+				Expect(*cj.Spec.Suspend).To(BeFalse())
 			})
 		})
 	})

--- a/internal/indexmanagement/reconcile_test.go
+++ b/internal/indexmanagement/reconcile_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Index Management", func() {
 		selector := map[string]string{}
 		tolerations := []core.Toleration{}
 		name := fmt.Sprintf("%s-im-%s", cluster.Name, mapping.Name)
-		cronjob = newCronJob(cluster.Name, cluster.Namespace, name, "*/5 * * * *", "", selector, tolerations, []core.EnvVar{})
+		cronjob = newCronJob(cluster.Name, cluster.Namespace, name, "*/5 * * * *", "", selector, tolerations, []core.EnvVar{}, false)
 	})
 	Describe("#formatCmd", func() {
 		Context("with no policies", func() {
@@ -82,7 +82,7 @@ var _ = Describe("Index Management", func() {
 			selector := map[string]string{}
 			tolerations := []core.Toleration{}
 			name := fmt.Sprintf("%s-rollover-%s", cluster.Name, policy.Name)
-			cronjob = newCronJob(cluster.Name, cluster.Namespace, name, "*/5 * * * *", "", selector, tolerations, []core.EnvVar{})
+			cronjob = newCronJob(cluster.Name, cluster.Namespace, name, "*/5 * * * *", "", selector, tolerations, []core.EnvVar{}, false)
 			policy.Phases.Hot = &apis.IndexManagementHotPhaseSpec{
 				Actions: apis.IndexManagementActionsSpec{
 					Rollover: &apis.IndexManagementActionSpec{
@@ -98,7 +98,7 @@ var _ = Describe("Index Management", func() {
 			It("should not create the cronjob and return the error", func() {
 				policy.PollInterval = "notavalue"
 				imr := &IndexManagementRequest{client: apiclient, cluster: cluster}
-				Expect(imr.reconcileIndexManagementCronjob(policy, mapping, primaryShards)).To(Not(Succeed()))
+				Expect(imr.reconcileIndexManagementCronjob(policy, mapping, primaryShards, false)).To(Not(Succeed()))
 			})
 		})
 		Describe("when trying to create the cronjob", func() {
@@ -108,7 +108,7 @@ var _ = Describe("Index Management", func() {
 					policy.Phases.Hot = nil
 					apiclient = fake.NewFakeClient(cronjob)
 					imr := &IndexManagementRequest{client: apiclient, cluster: cluster}
-					err := imr.reconcileIndexManagementCronjob(policy, mapping, primaryShards)
+					err := imr.reconcileIndexManagementCronjob(policy, mapping, primaryShards, false)
 					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 				})
 			})
@@ -117,7 +117,7 @@ var _ = Describe("Index Management", func() {
 					policy.Phases.Delete = nil
 					apiclient = fake.NewFakeClient(cronjob)
 					imr := &IndexManagementRequest{client: apiclient, cluster: cluster}
-					err := imr.reconcileIndexManagementCronjob(policy, mapping, primaryShards)
+					err := imr.reconcileIndexManagementCronjob(policy, mapping, primaryShards, false)
 					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 				})
 			})
@@ -126,7 +126,7 @@ var _ = Describe("Index Management", func() {
 					policy.Phases.Hot = nil
 					apiclient = fake.NewFakeClient(cronjob)
 					imr := &IndexManagementRequest{client: apiclient, cluster: cluster}
-					err := imr.reconcileIndexManagementCronjob(policy, mapping, primaryShards)
+					err := imr.reconcileIndexManagementCronjob(policy, mapping, primaryShards, false)
 					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 				})
 			})
@@ -134,14 +134,14 @@ var _ = Describe("Index Management", func() {
 				It("should return without error", func() {
 					apiclient = fake.NewFakeClient(cronjob)
 					imr := &IndexManagementRequest{client: apiclient, cluster: cluster}
-					err := imr.reconcileIndexManagementCronjob(policy, mapping, primaryShards)
+					err := imr.reconcileIndexManagementCronjob(policy, mapping, primaryShards, false)
 					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 				})
 			})
 			Context("and errors for reasons other then already existing", func() {
 				It("should return the error", func() {
 					imr := &IndexManagementRequest{client: apiclient, cluster: cluster}
-					err := imr.reconcileIndexManagementCronjob(policy, mapping, primaryShards)
+					err := imr.reconcileIndexManagementCronjob(policy, mapping, primaryShards, false)
 					Expect(err).To(BeNil())
 				})
 			})
@@ -152,7 +152,7 @@ var _ = Describe("Index Management", func() {
 						cronjob.Spec.Schedule = newSchedule
 						apiclient = fake.NewFakeClient(cronjob)
 						imr := &IndexManagementRequest{client: apiclient, cluster: cluster}
-						err := imr.reconcileIndexManagementCronjob(policy, mapping, primaryShards)
+						err := imr.reconcileIndexManagementCronjob(policy, mapping, primaryShards, false)
 						Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 						Expect(cronjob.Spec.Schedule).To(Equal(newSchedule), "Exp. to update the cronjob")
 					})

--- a/internal/manifests/cronjob/build.go
+++ b/internal/manifests/cronjob/build.go
@@ -82,6 +82,12 @@ func (b *Builder) WithParallelism(p int32) *Builder {
 	return b
 }
 
+// WithSuspend sets the cronjob's suspend state
+func (b *Builder) WithSuspend(s bool) *Builder {
+	b.cj.Spec.Suspend = &s
+	return b
+}
+
 // WithPodSpec sets the cronjob pod spec and its name
 func (b *Builder) WithPodSpec(containerName string, spec *corev1.PodSpec) *Builder {
 	b.cj.Spec.JobTemplate.Spec.Template.ObjectMeta.Name = containerName


### PR DESCRIPTION
### Description
The following PR provides a fix to suspend the Index management cronjobs when ES cluster is shut down. Suspending the cronjobs prevents them to run till `BackoffLimitExceeded` which in turn requires manual cronjob removal.

/cc @ewolinetz 
/assign @ewolinetz 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1268
