### PR TITLE
Abort rollover when target index exists but read-only

### DIFF
--- a/internal/indexmanagement/scripts.go
+++ b/internal/indexmanagement/scripts.go
@@ -229,9 +229,11 @@ function rollover() {
   echo "Next write index for ${policy}-write: $nextIndex"
   echo "Checking if $nextIndex exists"
 
-  # if true, ensure next index was created
+  # if true, ensure next index was created and
+  # cluster permits operations on it, e.g. not in read-only
+  # state because of low disk space.
   code="$(checkIndexExists "$nextIndex")"
-  if [ "$code" == "404" ] ; then
+  if [ "$code" == "404" ] || [ "$code" == "403" ] ; then
     cat /tmp/response.txt
     return 1
   fi


### PR DESCRIPTION
### Description
The fix provided ensures that the rollover job is aborted with a failure exit code when the target index exists but is read-only. In various situations (e.g. low on disk space) the ES cluster can decide to put indices into read-only until a human operator takes action to expand disk volume.

/cc @ewolinetz 
/assign @ewolinetz
/cherry-pick release-5.1
/cherry-pick release-5.0

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1273
