### PR TITLE
LOG-1420: Annotate with infrastructure features

### DIFF
--- a/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
@@ -108,6 +108,7 @@ metadata:
     olm.skipRange: '>=4.6.0-0 <5.1.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
+    operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     support: AOS Cluster Logging, Jaeger

--- a/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
@@ -101,6 +101,7 @@ metadata:
     olm.skipRange: '>=4.6.0-0 <5.1.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
+    operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     support: AOS Cluster Logging, Jaeger

--- a/internal/k8shandler/podtemplate.go
+++ b/internal/k8shandler/podtemplate.go
@@ -94,7 +94,7 @@ func ArePodSpecDifferent(lhs, rhs v1.PodSpec, strictTolerations bool) bool {
 func CreateUpdatablePodTemplateSpec(current, desired v1.PodTemplateSpec) v1.PodTemplateSpec {
 	desiredCopy := desired
 	desiredCopy.Spec.Volumes = current.Spec.Volumes
-	
+
 	return desiredCopy
 }
 

--- a/manifests/5.2/elasticsearch-operator.v5.2.0.clusterserviceversion.yaml
+++ b/manifests/5.2/elasticsearch-operator.v5.2.0.clusterserviceversion.yaml
@@ -108,6 +108,7 @@ metadata:
     olm.skipRange: '>=4.6.0-0 <5.1.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
+    operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     support: AOS Cluster Logging, Jaeger


### PR DESCRIPTION
### Description
Update the operator to identify infrastructure features:
* disconnected
* proxy-aware

### Links
* https://issues.redhat.com/browse/LOG-1420
* https://docs.openshift.com/container-platform/4.7/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-manual-annotations_osdk-generating-csvs

@ewolinetz  I believe this applies to EO as well.  I may need to clone this issue specifically for EO and its backports for QE validation