### PR TITLE
Fix storage class for e2e-upgrades running on GCP

### DIFF
--- a/hack/testing-olm-upgrade/resources/cr.yaml
+++ b/hack/testing-olm-upgrade/resources/cr.yaml
@@ -21,7 +21,7 @@ spec:
     - data
     - master
     storage:
-      storageClassName: gp2
+      storageClassName: standard
       size: 10G
   redundancyPolicy: SingleRedundancy
   indexManagement:


### PR DESCRIPTION
### Description
This PR provides a small fix for the default storage class name used in E2E upgrade tests for the `Elasticsearch` custom resource.

/cc @jcantrill 
/assign @jcantrill 
