### PR TITLE
LOG-1524: Fix full cluster cert redeploy with non-data nodes

### DIFF
--- a/internal/k8shandler/deployment.go
+++ b/internal/k8shandler/deployment.go
@@ -152,8 +152,7 @@ func (node *deploymentNode) create() error {
 		}
 
 		// update the hashmaps
-		node.configmapHash = getConfigmapDataHash(node.clusterName, node.self.Namespace, node.client)
-		node.secretHash = getSecretDataHash(node.clusterName, node.self.Namespace, node.client)
+		node.refreshHashes()
 	}
 
 	return node.pause()
@@ -401,12 +400,12 @@ func (node *deploymentNode) progressNodeChanges() error {
 
 func (node *deploymentNode) refreshHashes() {
 	newConfigmapHash := getConfigmapDataHash(node.clusterName, node.self.Namespace, node.client)
-	if newConfigmapHash != node.configmapHash {
+	if newConfigmapHash != "" && newConfigmapHash != node.configmapHash {
 		node.configmapHash = newConfigmapHash
 	}
 
 	newSecretHash := getSecretDataHash(node.clusterName, node.self.Namespace, node.client)
-	if newSecretHash != node.secretHash {
+	if newSecretHash != "" && newSecretHash != node.secretHash {
 		node.secretHash = newSecretHash
 	}
 }

--- a/internal/k8shandler/statefulset.go
+++ b/internal/k8shandler/statefulset.go
@@ -237,7 +237,7 @@ func (n *statefulSetNode) setReplicaCount(replicas int32) error {
 
 		nodeCopy.Spec.Replicas = &replicas
 
-		if err := n.client.Update(context.TODO(), &n.self); err != nil {
+		if err := n.client.Update(context.TODO(), nodeCopy); err != nil {
 			n.L().Error(err, "Failed to update node resource")
 			return err
 		}
@@ -296,8 +296,7 @@ func (n *statefulSetNode) create() error {
 		}
 
 		// update the hashmaps
-		n.configmapHash = getConfigmapDataHash(n.clusterName, n.self.Namespace, n.client)
-		n.secretHash = getSecretDataHash(n.clusterName, n.self.Namespace, n.client)
+		n.refreshHashes()
 	} else {
 		n.scale()
 	}
@@ -331,12 +330,12 @@ func (n *statefulSetNode) executeUpdate() error {
 
 func (n *statefulSetNode) refreshHashes() {
 	newConfigmapHash := getConfigmapDataHash(n.clusterName, n.self.Namespace, n.client)
-	if newConfigmapHash != n.configmapHash {
+	if newConfigmapHash != "" && newConfigmapHash != n.configmapHash {
 		n.configmapHash = newConfigmapHash
 	}
 
 	newSecretHash := getSecretDataHash(n.clusterName, n.self.Namespace, n.client)
-	if newSecretHash != n.secretHash {
+	if newSecretHash != "" && newSecretHash != n.secretHash {
 		n.secretHash = newSecretHash
 	}
 }


### PR DESCRIPTION
### Description
The following change set provides a fix for the full cluster redeploy scenario with non-data ES nodes. The cause of this bug is that the elasticsearch-operator is using the wrong CR spec when updating the replica count to zero. This causes a full cluster redeploy being stuck in the scale down step forever. In turn no full cluster redeploy completes and leaves the ES cluster in an unhealthy state.

/cc @ewolinetz 
/assign @ewolinetz 

/cherry-pick release-5.1
/cherry-pick release-5.0

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1524
