### PR TITLE
LOG-1273: Fix cronjob exit code handler for combined delete and rollover exec

### DIFF
--- a/internal/indexmanagement/reconcile.go
+++ b/internal/indexmanagement/reconcile.go
@@ -385,22 +385,17 @@ func (imr *IndexManagementRequest) reconcileIndexManagementCronjob(policy apis.I
 }
 
 func formatCmd(policy apis.IndexManagementPolicySpec) string {
-	cmd := []string{}
-	result := []string{}
+	cmd := ""
 	if policy.Phases.Delete != nil {
-		cmd = append(cmd, "./delete", "delete_rc=$?")
-		result = append(result, "exit $delete_rc")
+		cmd = "./delete"
 	}
 	if policy.Phases.Hot != nil {
-		cmd = append(cmd, "./rollover", "rollover_rc=$?")
-		result = append(result, "exit $rollover_rc")
+		cmd = "./rollover"
 	}
-	if len(cmd) == 0 {
-		return ""
+	if policy.Phases.Delete != nil && policy.Phases.Hot != nil {
+		cmd = "./delete-then-rollover"
 	}
-	cmd = append(cmd, fmt.Sprintf("$(%s)", strings.Join(result, "&&")))
-	script := strings.Join(cmd, ";")
-	return script
+	return cmd
 }
 
 func areCronJobsSame(lhs, rhs *batch.CronJob) bool {

--- a/internal/indexmanagement/reconcile_test.go
+++ b/internal/indexmanagement/reconcile_test.go
@@ -60,20 +60,20 @@ var _ = Describe("Index Management", func() {
 		Context("with delete phase", func() {
 			It("should format the command for delete", func() {
 				policy.Phases.Delete = &apis.IndexManagementDeletePhaseSpec{}
-				Expect(formatCmd(policy)).To(Equal("./delete;delete_rc=$?;$(exit $delete_rc)"))
+				Expect(formatCmd(policy)).To(Equal("./delete"))
 			})
 		})
 		Context("with rollover phase", func() {
 			It("should format the command for rollover", func() {
 				policy.Phases.Hot = &apis.IndexManagementHotPhaseSpec{}
-				Expect(formatCmd(policy)).To(Equal("./rollover;rollover_rc=$?;$(exit $rollover_rc)"))
+				Expect(formatCmd(policy)).To(Equal("./rollover"))
 			})
 		})
 		Context("with delete and rollover phases", func() {
 			It("should format the command for all phases", func() {
 				policy.Phases.Delete = &apis.IndexManagementDeletePhaseSpec{}
 				policy.Phases.Hot = &apis.IndexManagementHotPhaseSpec{}
-				Expect(formatCmd(policy)).To(Equal("./delete;delete_rc=$?;./rollover;rollover_rc=$?;$(exit $delete_rc&&exit $rollover_rc)"))
+				Expect(formatCmd(policy)).To(Equal("./delete-then-rollover"))
 			})
 		})
 	})


### PR DESCRIPTION
### Description
This PR is a follow-up on #726 to fix the exit code handler for combined execution of rollover and delete scripts in a single cronjob run. The following cmd used before didn't handle the exit code properly and defaults always to exit code 0:
```
./delete;delete_rc=$?;./rollover;rollover_rc=$?;$(exit $delete_rc&&exit$rollover_rc)
```

/cc @ewolinetz 
/assign @ewolinetz 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1273
