### PR TITLE
LOG-1552: Suspend cronjobs when ES is scaled to zero nodes

### DIFF
--- a/internal/indexmanagement/reconcile.go
+++ b/internal/indexmanagement/reconcile.go
@@ -137,7 +137,7 @@ func ReconcileCurationConfigmap(apiclient client.Client, cluster *apis.Elasticse
 	return errCtx.Wrap(err, "failed to update configmap")
 }
 
-func ReconcileIndexManagementCronjob(apiclient client.Client, cluster *apis.Elasticsearch, policy apis.IndexManagementPolicySpec, mapping apis.IndexManagementPolicyMappingSpec, primaryShards int32) error {
+func ReconcileIndexManagementCronjob(apiclient client.Client, cluster *apis.Elasticsearch, policy apis.IndexManagementPolicySpec, mapping apis.IndexManagementPolicyMappingSpec, primaryShards int32, suspend bool) error {
 	if policy.Phases.Delete == nil && policy.Phases.Hot == nil {
 		log.V(1).Info("Skipping indexmanagement cronjob for policymapping; no phases are defined", "policymapping", mapping.Name)
 		return nil
@@ -180,7 +180,7 @@ func ReconcileIndexManagementCronjob(apiclient client.Client, cluster *apis.Elas
 
 	name := fmt.Sprintf("%s-im-%s", cluster.Name, mapping.Name)
 	script := formatCmd(policy)
-	desired := newCronJob(cluster.Name, cluster.Namespace, name, schedule, script, cluster.Spec.Spec.NodeSelector, cluster.Spec.Spec.Tolerations, envvars)
+	desired := newCronJob(cluster.Name, cluster.Namespace, name, schedule, script, cluster.Spec.Spec.NodeSelector, cluster.Spec.Spec.Tolerations, envvars, suspend)
 
 	cluster.AddOwnerRefTo(desired)
 	return reconcileCronJob(apiclient, cluster, desired, areCronJobsSame)
@@ -312,7 +312,7 @@ func newContainer(clusterName, name, image, scriptPath string, envvars []corev1.
 	return container
 }
 
-func newCronJob(clusterName, namespace, name, schedule, script string, nodeSelector map[string]string, tolerations []corev1.Toleration, envvars []corev1.EnvVar) *batch.CronJob {
+func newCronJob(clusterName, namespace, name, schedule, script string, nodeSelector map[string]string, tolerations []corev1.Toleration, envvars []corev1.EnvVar, suspend bool) *batch.CronJob {
 	containerName := "indexmanagement"
 	podSpec := corev1.PodSpec{
 		ServiceAccountName: clusterName,
@@ -337,6 +337,7 @@ func newCronJob(clusterName, namespace, name, schedule, script string, nodeSelec
 			Labels:    imLabels,
 		},
 		Spec: batch.CronJobSpec{
+			Suspend:                    &suspend,
 			ConcurrencyPolicy:          batch.ForbidConcurrent,
 			SuccessfulJobsHistoryLimit: jobHistoryLimitSuccess,
 			FailedJobsHistoryLimit:     jobHistoryLimitFailed,

--- a/internal/indexmanagement/reconcile_test.go
+++ b/internal/indexmanagement/reconcile_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Index Management", func() {
 		selector := map[string]string{}
 		tolerations := []core.Toleration{}
 		name := fmt.Sprintf("%s-im-%s", cluster.Name, mapping.Name)
-		cronjob = newCronJob(cluster.Name, cluster.Namespace, name, "*/5 * * * *", "", selector, tolerations, []core.EnvVar{})
+		cronjob = newCronJob(cluster.Name, cluster.Namespace, name, "*/5 * * * *", "", selector, tolerations, []core.EnvVar{}, false)
 	})
 	Describe("#formatCmd", func() {
 		Context("with no policies", func() {
@@ -129,7 +129,7 @@ var _ = Describe("Index Management", func() {
 			selector := map[string]string{}
 			tolerations := []core.Toleration{}
 			name := fmt.Sprintf("%s-rollover-%s", cluster.Name, policy.Name)
-			cronjob = newCronJob(cluster.Name, cluster.Namespace, name, "*/5 * * * *", "", selector, tolerations, []core.EnvVar{})
+			cronjob = newCronJob(cluster.Name, cluster.Namespace, name, "*/5 * * * *", "", selector, tolerations, []core.EnvVar{}, false)
 			policy.Phases.Hot = &apis.IndexManagementHotPhaseSpec{
 				Actions: apis.IndexManagementActionsSpec{
 					Rollover: &apis.IndexManagementActionSpec{
@@ -144,7 +144,7 @@ var _ = Describe("Index Management", func() {
 		Describe("for invalid poll interval", func() {
 			It("should not create the cronjob and return the error", func() {
 				policy.PollInterval = "notavalue"
-				Expect(ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)).To(Not(Succeed()))
+				Expect(ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards, false)).To(Not(Succeed()))
 			})
 		})
 		Describe("when trying to create the cronjob", func() {
@@ -153,7 +153,7 @@ var _ = Describe("Index Management", func() {
 					policy.Phases.Delete = nil
 					policy.Phases.Hot = nil
 					apiclient = fake.NewFakeClient(cronjob)
-					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards, false)
 					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 				})
 			})
@@ -161,7 +161,7 @@ var _ = Describe("Index Management", func() {
 				It("should return without error", func() {
 					policy.Phases.Delete = nil
 					apiclient = fake.NewFakeClient(cronjob)
-					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards, false)
 					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 				})
 			})
@@ -169,20 +169,20 @@ var _ = Describe("Index Management", func() {
 				It("should return without error", func() {
 					policy.Phases.Hot = nil
 					apiclient = fake.NewFakeClient(cronjob)
-					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards, false)
 					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 				})
 			})
 			Context("and does not error", func() {
 				It("should return without error", func() {
 					apiclient = fake.NewFakeClient(cronjob)
-					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards, false)
 					Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 				})
 			})
 			Context("and errors for reasons other then already existing", func() {
 				It("should return the error", func() {
-					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
+					err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards, false)
 					Expect(err).To(BeNil())
 				})
 			})
@@ -192,7 +192,7 @@ var _ = Describe("Index Management", func() {
 						newSchedule := "*/5 10 * * * *"
 						cronjob.Spec.Schedule = newSchedule
 						apiclient = fake.NewFakeClient(cronjob)
-						err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards)
+						err := ReconcileIndexManagementCronjob(apiclient, cluster, policy, mapping, primaryShards, false)
 						Expect(err).To(BeNil(), fmt.Sprintf("Error: %v", err))
 						Expect(cronjob.Spec.Schedule).To(Equal(newSchedule), "Exp. to update the cronjob")
 					})


### PR DESCRIPTION
### Description
This is a manual backport of #723 to introduce suspending indexmanagement cronjobs when no elasticsearch nodes available. 

/cc @ewolinetz 
/assign @ewolinetz 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1552
