### PR TITLE
Fix upstream origin images

### DIFF
--- a/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
@@ -93,7 +93,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
-    containerImage: quay.io/openshift/origin-elasticsearch-operator:latest
+    containerImage: quay.io/openshift-logging/elasticsearch-operator:latest
     createdAt: "2020-11-04T08:00:00Z"
     description: |
       The Elasticsearch Operator for OCP provides a means for configuring and managing an Elasticsearch cluster for tracing and cluster logging.
@@ -105,7 +105,7 @@ metadata:
       set of OCP nodes may not be large enough to support the Elasticsearch cluster.  Additional OCP nodes must be added
       to the OCP cluster if you desire to run with the recommended (or better) memory. Each ES node can operate with a
       lower memory setting though this is not recommended for production deployments.
-    olm.skipRange: '>=4.6.0-0 <5.1.0'
+    olm.skipRange: '>=4.6.0-0 <5.2.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
@@ -446,14 +446,14 @@ spec:
                 - name: PROXY_IMAGE
                   value: quay.io/openshift/origin-oauth-proxy:latest
                 - name: ELASTICSEARCH_PROXY
-                  value: quay.io/openshift/origin-elasticsearch-proxy:latest
+                  value: quay.io/openshift-logging/elasticsearch-proxy:latest
                 - name: ELASTICSEARCH_IMAGE
-                  value: quay.io/openshift/origin-logging-elasticsearch6:latest
+                  value: quay.io/openshift-logging/elasticsearch6:latest
                 - name: KIBANA_IMAGE
-                  value: quay.io/openshift/origin-logging-kibana6:latest
+                  value: quay.io/openshift-logging/kibana6:latest
                 - name: CURATOR_IMAGE
-                  value: quay.io/openshift/origin-logging-curator5:latest
-                image: quay.io/openshift/origin-elasticsearch-operator:latest
+                  value: quay.io/openshift-logging/curator5:latest
+                image: quay.io/openshift-logging/elasticsearch-operator:latest
                 imagePullPolicy: IfNotPresent
                 name: elasticsearch-operator
                 ports:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,7 +20,7 @@ spec:
         ports:
         - containerPort: 8080
           name: http
-        image: quay.io/openshift/origin-elasticsearch-operator:latest
+        image: quay.io/openshift-logging/elasticsearch-operator:latest
         name: elasticsearch-operator
         imagePullPolicy: IfNotPresent
         resources: {}
@@ -38,10 +38,10 @@ spec:
           - name: PROXY_IMAGE
             value: "quay.io/openshift/origin-oauth-proxy:latest"
           - name: ELASTICSEARCH_PROXY
-            value: "quay.io/openshift/origin-elasticsearch-proxy:latest"
+            value: "quay.io/openshift-logging/elasticsearch-proxy:latest"
           - name: ELASTICSEARCH_IMAGE
-            value: "quay.io/openshift/origin-logging-elasticsearch6:latest"
+            value: "quay.io/openshift-logging/elasticsearch6:latest"
           - name: KIBANA_IMAGE
-            value: "quay.io/openshift/origin-logging-kibana6:latest"
+            value: "quay.io/openshift-logging/kibana6:latest"
           - name: CURATOR_IMAGE
-            value: "quay.io/openshift/origin-logging-curator5:latest"
+            value: "quay.io/openshift-logging/curator5:latest"

--- a/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
-    containerImage: quay.io/openshift/origin-elasticsearch-operator:latest
+    containerImage: quay.io/openshift-logging/elasticsearch-operator:latest
     createdAt: "2020-11-04T08:00:00Z"
     description: |
       The Elasticsearch Operator for OCP provides a means for configuring and managing an Elasticsearch cluster for tracing and cluster logging.
@@ -98,7 +98,7 @@ metadata:
       set of OCP nodes may not be large enough to support the Elasticsearch cluster.  Additional OCP nodes must be added
       to the OCP cluster if you desire to run with the recommended (or better) memory. Each ES node can operate with a
       lower memory setting though this is not recommended for production deployments.
-    olm.skipRange: '>=4.6.0-0 <5.1.0'
+    olm.skipRange: '>=4.6.0-0 <5.2.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -29,7 +29,7 @@ oc create -f hack/cr.yaml
 
 ## Image customization
 
-The operator is designed to work with `quay.io/openshift/origin-logging-elasticsearch6` image.  To use
+The operator is designed to work with `quay.io/openshift-logging/elasticsearch6` image.  To use
 a different image, edit `manifests/image-references` before deployment, or edit the environment variable in the Elasticsearch Operator csv after deployment. e.g. `oc edit csv -n openshift-operators-redhat elasticsearch-operator.v4.6.0`.
 
 ## Storage configuration

--- a/hack/common
+++ b/hack/common
@@ -12,7 +12,7 @@ source "$repo_dir/hack/testing-olm/utils"
 
 VERSION=${VERSION:-$(basename $(find ${repo_dir}/manifests -type d | sort -r | head -n 1))}
 
-IMAGE_TAG=${IMAGE_TAG:-"quay.io/openshift/origin-elasticsearch-operator:latest"}
+IMAGE_TAG=${IMAGE_TAG:-"quay.io/openshift-logging/elasticsearch-operator:latest"}
 
 NAMESPACE=${NAMESPACE:-openshift-logging}
 REMOTE_REGISTRY=${REMOTE_REGISTRY:-false}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -11,9 +11,9 @@ const (
 	TrustedCABundleHashName     = "logging.openshift.io/hash"
 	KibanaTrustedCAName         = "kibana-trusted-ca-bundle"
 	SecretHashPrefix            = "logging.openshift.io/"
-	ElasticsearchDefaultImage   = "quay.io/openshift/origin-logging-elasticsearch6"
-	ProxyDefaultImage           = "quay.io/openshift/origin-elasticsearch-proxy:latest"
-	CuratorDefaultImage         = "quay.io/openshift/origin-logging-curator5"
+	ElasticsearchDefaultImage   = "quay.io/openshift-logging/elasticsearch6"
+	ProxyDefaultImage           = "quay.io/openshift-logging/elasticsearch-proxy:latest"
+	CuratorDefaultImage         = "quay.io/openshift-logging/curator5"
 	TheoreticalShardMaxSizeInMB = 40960
 
 	// OcpTemplatePrefix is the prefix all operator generated templates

--- a/internal/kibana/defaults.go
+++ b/internal/kibana/defaults.go
@@ -10,6 +10,6 @@ var (
 
 	defaultKibanaProxyMemory     = resource.MustParse("256Mi")
 	defaultKibanaProxyCPURequest = resource.MustParse("100m")
-	kibanaDefaultImage           = "quay.io/openshift/origin-logging-kibana6:latest"
+	kibanaDefaultImage           = "quay.io/openshift-logging/kibana6:latest"
 	kibanaProxyDefaultImage      = "quay.io/openshift/origin-oauth-proxy:latest"
 )

--- a/manifests/5.2/elasticsearch-operator.v5.2.0.clusterserviceversion.yaml
+++ b/manifests/5.2/elasticsearch-operator.v5.2.0.clusterserviceversion.yaml
@@ -93,7 +93,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
-    containerImage: quay.io/openshift/origin-elasticsearch-operator:latest
+    containerImage: quay.io/openshift-logging/elasticsearch-operator:latest
     createdAt: "2020-11-04T08:00:00Z"
     description: |
       The Elasticsearch Operator for OCP provides a means for configuring and managing an Elasticsearch cluster for tracing and cluster logging.
@@ -105,7 +105,7 @@ metadata:
       set of OCP nodes may not be large enough to support the Elasticsearch cluster.  Additional OCP nodes must be added
       to the OCP cluster if you desire to run with the recommended (or better) memory. Each ES node can operate with a
       lower memory setting though this is not recommended for production deployments.
-    olm.skipRange: '>=4.6.0-0 <5.1.0'
+    olm.skipRange: '>=4.6.0-0 <5.2.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
@@ -446,14 +446,14 @@ spec:
                 - name: PROXY_IMAGE
                   value: quay.io/openshift/origin-oauth-proxy:latest
                 - name: ELASTICSEARCH_PROXY
-                  value: quay.io/openshift/origin-elasticsearch-proxy:latest
+                  value: quay.io/openshift-logging/elasticsearch-proxy:latest
                 - name: ELASTICSEARCH_IMAGE
-                  value: quay.io/openshift/origin-logging-elasticsearch6:latest
+                  value: quay.io/openshift-logging/elasticsearch6:latest
                 - name: KIBANA_IMAGE
-                  value: quay.io/openshift/origin-logging-kibana6:latest
+                  value: quay.io/openshift-logging/kibana6:latest
                 - name: CURATOR_IMAGE
-                  value: quay.io/openshift/origin-logging-curator5:latest
-                image: quay.io/openshift/origin-elasticsearch-operator:latest
+                  value: quay.io/openshift-logging/curator5:latest
+                image: quay.io/openshift-logging/elasticsearch-operator:latest
                 imagePullPolicy: IfNotPresent
                 name: elasticsearch-operator
                 ports:

--- a/olm_deploy/scripts/registry-init.sh
+++ b/olm_deploy/scripts/registry-init.sh
@@ -6,20 +6,20 @@ echo -e "Dumping IMAGE env vars\n"
 env | grep IMAGE
 echo -e "\n\n"
 
-IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-quay.io/openshift/origin-elasticsearch-operator:latest}
+IMAGE_ELASTICSEARCH_OPERATOR=${IMAGE_ELASTICSEARCH_OPERATOR:-quay.io/openshift-logging/elasticsearch-operator:latest}
 IMAGE_KUBE_RBAC_PROXY=${IMAGE_KUBE_RBAC_PROXY:-quay.io/openshift/origin-kube-rbac-proxy:latest}
-IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-quay.io/openshift/origin-logging-elasticsearch6:latest}
-IMAGE_ELASTICSEARCH_PROXY=${IMAGE_ELASTICSEARCH_PROXY:-quay.io/openshift/origin-elasticsearch-proxy:latest}
+IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-quay.io/openshift-logging/elasticsearch6:latest}
+IMAGE_ELASTICSEARCH_PROXY=${IMAGE_ELASTICSEARCH_PROXY:-quay.io/openshift-logging/elasticsearch-proxy:latest}
 IMAGE_OAUTH_PROXY=${IMAGE_OAUTH_PROXY:-quay.io/openshift/origin-oauth-proxy:latest}
-IMAGE_LOGGING_KIBANA6=${IMAGE_LOGGING_KIBANA6:-quay.io/openshift/origin-logging-kibana6:latest}
+IMAGE_LOGGING_KIBANA6=${IMAGE_LOGGING_KIBANA6:-quay.io/openshift-logging/kibana6:latest}
 
 # update the manifest with the image built by ci
-sed -i "s,quay.io/openshift/origin-elasticsearch-operator:latest,${IMAGE_ELASTICSEARCH_OPERATOR}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift-logging/elasticsearch-operator:latest,${IMAGE_ELASTICSEARCH_OPERATOR}," /manifests/*/*clusterserviceversion.yaml
 sed -i "s,quay.io/openshift/origin-kube-rbac-proxy:latest,${IMAGE_KUBE_RBAC_PROXY}," /manifests/*/*clusterserviceversion.yaml
-sed -i "s,quay.io/openshift/origin-logging-elasticsearch6:latest,${IMAGE_ELASTICSEARCH6}," /manifests/*/*clusterserviceversion.yaml
-sed -i "s,quay.io/openshift/origin-elasticsearch-proxy:latest,${IMAGE_ELASTICSEARCH_PROXY}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift-logging/elasticsearch6:latest,${IMAGE_ELASTICSEARCH6}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift-logging/elasticsearch-proxy:latest,${IMAGE_ELASTICSEARCH_PROXY}," /manifests/*/*clusterserviceversion.yaml
 sed -i "s,quay.io/openshift/origin-oauth-proxy:latest,${IMAGE_OAUTH_PROXY}," /manifests/*/*clusterserviceversion.yaml
-sed -i "s,quay.io/openshift/origin-logging-kibana6:latest,${IMAGE_LOGGING_KIBANA6}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift-logging/kibana6:latest,${IMAGE_LOGGING_KIBANA6}," /manifests/*/*clusterserviceversion.yaml
 
 # update the manifest to pull always the operator image for non-CI environments
 if [ "${OPENSHIFT_CI:-false}" == "false" ] ; then


### PR DESCRIPTION
### Description
This PR provides several fixes for our upstream aka origin images hosted in 5.x under `quay.io/openshift-logging`.

/cc @igor-karpukhin 
/assign @periklis 
