### PR TITLE
Use stable as channel name for elasticsearch e2e operator registry

### DIFF
--- a/olm_deploy/operatorregistry/elasticsearch-operator.package.yaml
+++ b/olm_deploy/operatorregistry/elasticsearch-operator.package.yaml
@@ -1,4 +1,9 @@
 packageName: elasticsearch-operator
+defaultChannel: "stable"
 channels:
 - name: "5.2"
+  currentCSV: elasticsearch-operator.v5.2.0
+- name: "stable"
+  currentCSV: elasticsearch-operator.v5.2.0
+- name: "stable-5.2"
   currentCSV: elasticsearch-operator.v5.2.0

--- a/olm_deploy/scripts/operator-install.sh
+++ b/olm_deploy/scripts/operator-install.sh
@@ -23,7 +23,7 @@ echo "##################"
 oc create -n ${ELASTICSEARCH_OPERATOR_NAMESPACE} -f olm_deploy/subscription/operator-group.yaml
 
 # create the subscription
-export OPERATOR_PACKAGE_CHANNEL="$(echo \"$LOGGING_VERSION\")"
+export OPERATOR_PACKAGE_CHANNEL="stable"
 subscription=$(envsubst < olm_deploy/subscription/subscription.yaml)
 echo "Creating:"
 echo "$subscription"


### PR DESCRIPTION
### Description
This PR addresses some preparation issues for openshift/release#20604. I.e, switches the channel name from `5.2` to `stable` as per ci-built operator registry is using the operator bundle image. Latter provides a slight different channel naming introduced by #734 namely:
```Dockerfile
LABEL operators.operatorframework.io.bundle.channels.v1=stable,stable-5.2
LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
``` 

/cc @sasagarw @jcantrill 