### PR TITLE
Add test-e2e target using ci managed operator install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,10 +181,19 @@ RANDOM_SUFFIX:=$(shell echo $$RANDOM)
 TEST_NAMESPACE?="e2e-test-${RANDOM_SUFFIX}"
 test-e2e-olm: DEPLOYMENT_NAMESPACE="${TEST_NAMESPACE}"
 test-e2e-olm: $(GO_JUNIT_REPORT) $(JUNITMERGE) $(JUNITREPORT) junitreportdir
-	TEST_NAMESPACE=${TEST_NAMESPACE} hack/test-e2e-olm.sh
-	echo "Complete e2e olm test"
+	TEST_NAMESPACE=${TEST_NAMESPACE} hack/test-e2e.sh
+	echo "Completed test-e2e"
 	$(JUNITMERGE) $$(find $$JUNIT_REPORT_OUTPUT_DIR -iname "*.xml") > $(JUNIT_REPORT_OUTPUT_DIR)/junit.xml
 .PHONY: test-e2e-olm
+
+E2E_RANDOM_SUFFIX:=$(shell echo $$RANDOM)
+E2E_TEST_NAMESPACE?="e2e-test-${RANDOM_SUFFIX}"
+test-e2e: DEPLOYMENT_NAMESPACE="${E2E_TEST_NAMESPACE}"
+test-e2e: $(GO_JUNIT_REPORT) $(JUNITMERGE) $(JUNITREPORT) junitreportdir
+	TEST_NAMESPACE=${E2E_TEST_NAMESPACE} DO_SETUP="false" hack/test-e2e.sh
+	echo "Completed test-e2e"
+	$(JUNITMERGE) $$(find $$JUNIT_REPORT_OUTPUT_DIR -iname "*.xml") > $(JUNIT_REPORT_OUTPUT_DIR)/junit.xml
+.PHONY: test-e2e
 
 elasticsearch-catalog: elasticsearch-catalog-build elasticsearch-catalog-deploy
 

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -7,6 +7,7 @@ source "${current_dir}/lib/init.sh"
 
 source "${current_dir}/../.bingo/variables.env"
 
+export DO_SETUP="${DO_SETUP:-true}"
 export GO_JUNIT_REPORT="${GO_JUNIT_REPORT:-go-junit-report}"
 export JUNITREPORT="${JUNITREPORT:-junitreport}"
 export JUNIT_REPORT_OUTPUT="${JUNIT_REPORT_OUTPUT_DIR:-/tmp/artifacts/junit}/junit.out"

--- a/hack/testing-olm/test-001-operator-sdk-e2e.sh
+++ b/hack/testing-olm/test-001-operator-sdk-e2e.sh
@@ -41,15 +41,17 @@ cleanup(){
 }
 trap cleanup exit
 
-if oc get namespace ${TEST_NAMESPACE} > /dev/null 2>&1 ; then
-  echo using existing project ${TEST_NAMESPACE}
-else
-  oc create namespace ${TEST_NAMESPACE}
-fi
+if [ "${DO_SETUP:-true}" == "true" ] ; then
+    if oc get namespace ${TEST_NAMESPACE} > /dev/null 2>&1 ; then
+        echo using existing project ${TEST_NAMESPACE}
+    else
+        oc create namespace ${TEST_NAMESPACE}
+    fi
 
-# install the catalog containing the elasticsearch operator csv
-export ELASTICSEARCH_OPERATOR_NAMESPACE=${TEST_NAMESPACE}
-deploy_elasticsearch_operator
+    # install the catalog containing the elasticsearch operator csv
+    export ELASTICSEARCH_OPERATOR_NAMESPACE=${TEST_NAMESPACE}
+    deploy_elasticsearch_operator
+fi
 
 TEST_OPERATOR_NAMESPACE=${TEST_NAMESPACE} \
 TEST_WATCH_NAMESPACE=${TEST_NAMESPACE} \


### PR DESCRIPTION
### Description
This PR addresses preparation issues to resolve openshift/release#20604. In detail it provides a new make target `test-e2e` that leverages the ci managed operator installation.

/cc @sasagarw 
