### PR TITLE
LOG-1075: Enable prometheus.query.metrics in ES config

### DIFF
--- a/internal/elasticsearch/configmaps_test.go
+++ b/internal/elasticsearch/configmaps_test.go
@@ -146,6 +146,7 @@ path:
 
 prometheus:
   indices: false
+  query.metrics: true
 
 # increase the max header size above 8kb default
 http.max_header_size: 128kb

--- a/internal/elasticsearch/configuration_tmpl.go
+++ b/internal/elasticsearch/configuration_tmpl.go
@@ -34,6 +34,7 @@ path:
 
 prometheus:
   indices: false
+  query.metrics: true
 
 # increase the max header size above 8kb default
 http.max_header_size: 128kb


### PR DESCRIPTION
### Description

Query metrics (subject of [LOG-1075](https://issues.redhat.com/browse/LOG-1075)) are by default disabled.
We need to enable them in order to be able to scrape metrics defined by provided query (i.e. query metrics).

/cc @sasagarw 
/assign @jcantrill 

### Links
- JIRA: <https://issues.redhat.com/browse/LOG-1075>
