### PR TITLE
Bump golang builder to 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### This is a generated file from Dockerfile.in ###
 #@follow_tag(openshift-golang-builder:1.14)
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8 AS builder
 
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}
@@ -25,7 +25,7 @@ ADD ${REMOTE_SOURCE}/Makefile ${REMOTE_SOURCE}/main.go ${REMOTE_SOURCE}/go.mod $
 RUN make build
 
 #@follow_tag(openshift-ose-base:ubi8)
-FROM registry.ci.openshift.org/ocp/4.7:base
+FROM registry.ci.openshift.org/ocp/4.8:base
 LABEL \
         io.k8s.display-name="OpenShift elasticsearch-operator" \
         io.k8s.description="This is the component that manages an Elasticsearch cluster on a kubernetes based platform" \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 ### This is a generated file from Dockerfile.in ###
 #@follow_tag(openshift-golang-builder:1.14)
-FROM registry.ci.openshift.org/openshift/release:golang-1.14 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
 
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}

--- a/dev-meta.yaml
+++ b/dev-meta.yaml
@@ -1,6 +1,6 @@
 from:
 - source: openshift-golang-builder\:v(?:[\.0-9\-]*).*
-  target: registry.ci.openshift.org/openshift/release:golang-1.14 AS builder
+  target: registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
 - source: openshift-ose-base\:v(?:[\.0-9\-]*)
   target: docker.io/centos:8 AS centos
 env:

--- a/origin-meta.yaml
+++ b/origin-meta.yaml
@@ -1,8 +1,8 @@
 from:
 - source: openshift-golang-builder\:v(?:[\.0-9\-]*).*
-  target: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
+  target: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8 AS builder
 - source: openshift-ose-base\:v(?:[\.0-9\-]*)
-  target: registry.ci.openshift.org/ocp/4.7:base
+  target: registry.ci.openshift.org/ocp/4.8:base
 env:
 - source: RUNBOOK_BASE_URL=.*
   target: RUNBOOK_BASE_URL="https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md"


### PR DESCRIPTION
### Description
This PR is a follow-up on #775 as per controller-runtime `v0.9.2` and k8s `1.21` require golang 1.16.

/cc @igor-karpukhin 