### PR TITLE
Skip cleanup for test-e2e ci target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,11 +164,16 @@ test-e2e-olm: $(GO_JUNIT_REPORT) $(JUNITMERGE) $(JUNITREPORT) junitreportdir
 	$(JUNITMERGE) $$(find $$JUNIT_REPORT_OUTPUT_DIR -iname "*.xml") > $(JUNIT_REPORT_OUTPUT_DIR)/junit.xml
 .PHONY: test-e2e-olm
 
+#
+# test-e2e is a future replacement target for test-e2e-olm that is used only upstream CI, until we merge:
+# https://github.com/openshift/release/pull/21383
+# This PR will make use of CI-managed operator installs/cleanups using the bundle w/o olm_deploy.
+#
 E2E_RANDOM_SUFFIX:=$(shell echo $$RANDOM)
 E2E_TEST_NAMESPACE?="e2e-test-${RANDOM_SUFFIX}"
 test-e2e: DEPLOYMENT_NAMESPACE="${E2E_TEST_NAMESPACE}"
 test-e2e: $(GO_JUNIT_REPORT) $(JUNITMERGE) $(JUNITREPORT) junitreportdir
-	TEST_NAMESPACE=${E2E_TEST_NAMESPACE} DO_SETUP="false" hack/test-e2e.sh
+	TEST_NAMESPACE=${E2E_TEST_NAMESPACE} DO_SETUP="false" SKIP_CLEANUP="true" hack/test-e2e.sh
 	echo "Completed test-e2e"
 	$(JUNITMERGE) $$(find $$JUNIT_REPORT_OUTPUT_DIR -iname "*.xml") > $(JUNIT_REPORT_OUTPUT_DIR)/junit.xml
 .PHONY: test-e2e

--- a/hack/testing-olm/test-001-operator-sdk-e2e.sh
+++ b/hack/testing-olm/test-001-operator-sdk-e2e.sh
@@ -24,13 +24,12 @@ cleanup(){
   os::log::info "Running cleanup"
   end_seconds=$(date +%s)
   runtime="$(($end_seconds - $start_seconds))s"
+
+  if [ "$return_code" != "0" ] ; then
+    gather_logging_resources ${TEST_NAMESPACE} $test_artifact_dir
+  fi
   
   if [ "${SKIP_CLEANUP:-false}" == "false" ] ; then
-
-    if [ "$return_code" != "0" ] ; then
-      gather_logging_resources ${TEST_NAMESPACE} $test_artifact_dir
-    fi
-
     ${repo_dir}/olm_deploy/scripts/catalog-uninstall.sh
     ${repo_dir}/olm_deploy/scripts/operator-uninstall.sh
     oc delete ns/${TEST_NAMESPACE} --wait=true --ignore-not-found --force --grace-period=0

--- a/hack/testing-olm/test-200-verify-es-metrics-access.sh
+++ b/hack/testing-olm/test-200-verify-es-metrics-access.sh
@@ -34,11 +34,12 @@ cleanup(){
   os::log::info "Running cleanup"
   end_seconds=$(date +%s)
   runtime="$(($end_seconds - $start_seconds))s"
-  
-  if [ "${DO_CLEANUP:-true}" == "true" ] ; then
-    if [ "$return_code" != "0" ] ; then
+
+  if [ "$return_code" != "0" ] ; then
       gather_logging_resources ${TEST_NAMESPACE} $test_artifact_dir
-    fi
+  fi
+
+  if [ "${SKIP_CLEANUP:-false}" == "false" ] ; then
     for item in "ns/${TEST_NAMESPACE}" "ns/openshift-operators-redhat"; do
       oc delete $item --wait=true --ignore-not-found --force --grace-period=0
     done

--- a/hack/testing-olm/test-657-im-block-autocreate-for-write-suffix.sh
+++ b/hack/testing-olm/test-657-im-block-autocreate-for-write-suffix.sh
@@ -29,11 +29,12 @@ cleanup(){
   os::log::info "Running cleanup"
   end_seconds=$(date +%s)
   runtime="$(($end_seconds - $start_seconds))s"
-  
-  if [ "${DO_CLEANUP:-true}" == "true" ] ; then
-    if [ "$return_code" != "0" ] ; then
+
+  if [ "$return_code" != "0" ] ; then
       gather_logging_resources ${TEST_NAMESPACE} $test_artifact_dir
-    fi
+  fi
+
+  if [ "${SKIP_CLEANUP:-false}" == "false" ] ; then
     for item in "ns/${TEST_NAMESPACE}" "ns/openshift-operators-redhat"; do
       oc delete $item --wait=true --ignore-not-found --force --grace-period=0
     done


### PR DESCRIPTION
### Description
This PR is preparation work for openshift/release#21383 to enable ci-managed operator installs/cleanups during e2e testing. 

/cc @igor-karpukhin 