### PR TITLE
[release-5.2] Fix mutating serviceaccount annotations on updates

### DIFF
--- a/internal/elasticsearch/serviceaccount.go
+++ b/internal/elasticsearch/serviceaccount.go
@@ -14,7 +14,7 @@ func (er *ElasticsearchRequest) CreateOrUpdateServiceAccount() error {
 	sa := serviceaccount.New(dpl.Name, dpl.Namespace, map[string]string{})
 	er.cluster.AddOwnerRefTo(sa)
 
-	err := serviceaccount.CreateOrUpdate(context.TODO(), er.client, sa)
+	err := serviceaccount.CreateOrUpdate(context.TODO(), er.client, sa, serviceaccount.AnnotationsEqual, serviceaccount.MutateAnnotationsOnly)
 	if err != nil {
 		return kverrors.Wrap(err, "failed to create or update elasticsearch serviceaccount",
 			"cluster", dpl.Name,

--- a/internal/kibana/serviceaccount.go
+++ b/internal/kibana/serviceaccount.go
@@ -14,7 +14,7 @@ func (clusterRequest *KibanaRequest) CreateOrUpdateServiceAccount(name string, a
 
 	utils.AddOwnerRefToObject(sa, getOwnerRef(clusterRequest.cluster))
 
-	err := serviceaccount.CreateOrUpdate(context.TODO(), clusterRequest.client, sa)
+	err := serviceaccount.CreateOrUpdate(context.TODO(), clusterRequest.client, sa, serviceaccount.AnnotationsEqual, serviceaccount.MutateAnnotationsOnly)
 	if err != nil {
 		return kverrors.Wrap(err, "failed to create or update kibana serviceaccount",
 			"cluster", clusterRequest.cluster.Name,


### PR DESCRIPTION
### Description
This PR provides a fix on updating service accounts during reconciliation. I.e. updating serviceaccounts should mutate only Eo provided annotations for now. This ensures that k8s serviceaccount-controller owned fields on SAs namely `ServiceAccount.Secrets` and `ServiceAccount.ImagePullSecrets`.

To address: https://issues.redhat.com/browse/LOG-1589

/cc @igor-karpukhin 