### PR TITLE
Fix license labels to Apache-2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ LABEL \
         io.k8s.description="This is the component that manages an Elasticsearch cluster on a kubernetes based platform" \
         io.openshift.tags="openshift,logging,elasticsearch" \
         com.redhat.delivery.appregistry="false" \
+        License="Apache-2.0" \
         maintainer="AOS Logging <aos-logging@redhat.com>" \
         name="openshift-logging/elasticsearch-rhel8-operator" \
         com.redhat.component="elasticsearch-operator-container" \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -31,6 +31,7 @@ LABEL \
         io.k8s.description="This is the component that manages an Elasticsearch cluster on a kubernetes based platform" \
         io.openshift.tags="openshift,logging,elasticsearch" \
         com.redhat.delivery.appregistry="false" \
+        License="Apache-2.0" \
         maintainer="AOS Logging <aos-logging@redhat.com>" \
         name="openshift-logging/elasticsearch-rhel8-operator" \
         com.redhat.component="elasticsearch-operator-container" \

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -33,6 +33,7 @@ LABEL \
         io.k8s.description="This is the component that manages an Elasticsearch cluster on a kubernetes based platform" \
         io.openshift.tags="openshift,logging,elasticsearch" \
         com.redhat.delivery.appregistry="false" \
+        License="Apache-2.0" \
         maintainer="AOS Logging <aos-logging@redhat.com>" \
         name="openshift-logging/elasticsearch-rhel8-operator" \
         com.redhat.component="elasticsearch-operator-container" \

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -22,7 +22,7 @@ LABEL \
     com.redhat.component="elasticsearch-operator" \
     version="v1.1" \
     name="elasticsearch-operator" \
-    License="ASL 2.0" \
+    License="Apache-2.0" \
     io.k8s.display-name="elasticsearch-operator bundle" \
     io.k8s.description="bundle for the elasticsearch-operator" \
     summary="This is the bundle for the elasticsearch-operator" \


### PR DESCRIPTION
### Description
This PR syncs the correct license labels from midstream to upstream.

To address: https://issues.redhat.com/browse/LOG-1750

/cc @igor-karpukhin 