### PR TITLE
Bug 2005955: Limit elasticsearch-operator bundle only on OCP 4.6.z

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,3 +5,5 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: elasticsearch-operator
+  com.redhat.delivery.operator.bundle: true
+  com.redhat.openshift.versions: =v4.6


### PR DESCRIPTION
### Description
This PR pins in retrospect all upcoming `4.6.z` bundles to be available only on OCP 4.6.z registries.

To address: https://bugzilla.redhat.com/show_bug.cgi?id=2005955 (https://issues.redhat.com/browse/LOG-1751)

More info:
- [Managing OpenShift versions](https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions)
- [Slack conversation](https://coreos.slack.com/archives/GGUR75P60/p1631773045120500)

/cc @igor-karpukhin  
/assign @igor-karpukhin  

