### PR TITLE
Sync with midstream dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ### This is a generated file from Dockerfile.in ###
-#@follow_tag(openshift-golang-builder:1.14)
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.16)
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8 AS builder
+
 
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}
@@ -24,7 +25,7 @@ ADD ${REMOTE_SOURCE}/Makefile ${REMOTE_SOURCE}/main.go ${REMOTE_SOURCE}/go.mod $
 
 RUN make build
 
-#@follow_tag(openshift-ose-base:ubi8)
+#@follow_tag(registry.redhat.io/ubi8:latest)
 FROM registry.ci.openshift.org/ocp/4.8:base
 LABEL \
         io.k8s.display-name="OpenShift elasticsearch-operator" \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,7 @@
 ### This is a generated file from Dockerfile.in ###
-#@follow_tag(openshift-golang-builder:1.14)
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.16)
 FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
+
 
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}
@@ -24,7 +25,7 @@ ADD ${REMOTE_SOURCE}/Makefile ${REMOTE_SOURCE}/main.go ${REMOTE_SOURCE}/go.mod $
 
 RUN make build
 
-#@follow_tag(openshift-ose-base:ubi8)
+#@follow_tag(registry.redhat.io/ubi8:latest)
 FROM docker.io/centos:8 AS centos
 LABEL \
         io.k8s.display-name="OpenShift elasticsearch-operator" \

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,5 +1,6 @@
-#@follow_tag(openshift-golang-builder:1.14)
-FROM openshift-golang-builder:v1.14.4-9 AS builder
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.16)
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.16.6-202107291435.el8.git.83c4106 AS builder
+
 
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}
@@ -26,8 +27,8 @@ ADD ${REMOTE_SOURCE}/Makefile ${REMOTE_SOURCE}/main.go ${REMOTE_SOURCE}/go.mod $
 
 RUN make build
 
-#@follow_tag(openshift-ose-base:ubi8)
-FROM openshift-ose-base:v4.0-202009120053.11408
+#@follow_tag(registry.redhat.io/ubi8:latest)
+FROM registry.redhat.io/ubi8:8.4-209
 LABEL \
         io.k8s.display-name="OpenShift elasticsearch-operator" \
         io.k8s.description="This is the component that manages an Elasticsearch cluster on a kubernetes based platform" \

--- a/dev-meta.yaml
+++ b/dev-meta.yaml
@@ -1,7 +1,7 @@
 from:
-- source: openshift-golang-builder\:v(?:[\.0-9\-]*).*
+- source: registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder\:v(?:[\.0-9\-]*).*
   target: registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
-- source: openshift-ose-base\:v(?:[\.0-9\-]*)
+- source: registry.redhat.io/ubi8:8.(\d)-([\.0-9])*
   target: docker.io/centos:8 AS centos
 env:
 - source: RUNBOOK_BASE_URL=.*

--- a/origin-meta.yaml
+++ b/origin-meta.yaml
@@ -1,7 +1,7 @@
 from:
-- source: openshift-golang-builder\:v(?:[\.0-9\-]*).*
+- source: registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder\:v(?:[\.0-9\-]*).*
   target: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8 AS builder
-- source: openshift-ose-base\:v(?:[\.0-9\-]*)
+- source: registry.redhat.io/ubi8:8.(\d)-([\.0-9])*
   target: registry.ci.openshift.org/ocp/4.8:base
 env:
 - source: RUNBOOK_BASE_URL=.*


### PR DESCRIPTION
### Description
This PR synchronizes the midstream Dockerfiles (which use the RHEL-8 based golang builder) with upstream.

To address: https://issues.redhat.com/browse/LOG-1750

/cc @igor-karpukhin 
/assign @igor-karpukhin 
