### PR TITLE
[release-4.6] Bug 1983994: Prometheus Rule for ElasticsearchClusterNotHealthy description has wrong URL

### DIFF
--- a/files/prometheus_alerts.yml
+++ b/files/prometheus_alerts.yml
@@ -4,7 +4,7 @@
   "rules":
   - "alert": "ElasticsearchClusterNotHealthy"
     "annotations":
-      "message": "Cluster {{ $labels.cluster }} health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md.md#Elasticsearch-Cluster-Health-is-Red"
+      "message": "Cluster {{ $labels.cluster }} health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet. For more information refer to https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Health-is-Red"
       "summary": "Cluster health status is RED"
     "expr": |
       sum by (cluster) (es_cluster_status == 2)


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR:
- Corrects the URL provided in description of the prometheus rule.

/cc @periklis <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @igor-karpukhin <!-- MANDATORY: Assign one approver from top-level OWNERS file -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1983994