### PR TITLE
Log 1870: Removing deprecated map values

### DIFF
--- a/internal/indexmanagement/index_management_test.go
+++ b/internal/indexmanagement/index_management_test.go
@@ -219,7 +219,7 @@ var _ = Describe("Index Management", func() {
 							"number_of_shards": "3"
 						}
 					},
-					"template": "node.infra*"
+					"index_patterns": ["node.infra*"]
 				}`)
 		})
 	})

--- a/internal/types/elasticsearch/types.go
+++ b/internal/types/elasticsearch/types.go
@@ -2,7 +2,7 @@ package elasticsearch
 
 func NewIndexTemplate(pattern string, aliases []string, shards, replicas int32) *IndexTemplate {
 	template := IndexTemplate{
-		Template: pattern,
+		IndexPatterns: []string{pattern},
 		Settings: IndexSettings{
 			Index: &IndexingSettings{
 				NumberOfShards:   shards,
@@ -49,9 +49,9 @@ type Index struct {
 }
 
 type IndexTemplate struct {
-	Template string                `json:"template,omitempty"`
-	Settings IndexSettings         `json:"settings,omitempty"`
-	Aliases  map[string]IndexAlias `json:"aliases,omitempty"`
+	IndexPatterns []string              `json:"index_patterns,omitempty"`
+	Settings      IndexSettings         `json:"settings,omitempty"`
+	Aliases       map[string]IndexAlias `json:"aliases,omitempty"`
 }
 
 type GetIndexTemplate struct {


### PR DESCRIPTION
Removes deprecated values from the template.

Companion to: https://github.com/openshift/origin-aggregated-logging/pull/2194

/cc @lukas-vlcek 
/assign @igor-karpukhin 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1870
