### PR TITLE
Update IndexManagement CronJobs API from v1beta1 to v1

### DIFF
--- a/internal/indexmanagement/index_management_test.go
+++ b/internal/indexmanagement/index_management_test.go
@@ -10,7 +10,7 @@ import (
 	elasticsearch "github.com/openshift/elasticsearch-operator/apis/logging/v1"
 	"github.com/openshift/elasticsearch-operator/internal/constants"
 	"github.com/openshift/elasticsearch-operator/test/helpers"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -116,7 +116,7 @@ var _ = Describe("Index Management", func() {
 			It("should suspend all cronjobs when non available", func() {
 				Expect(req.createOrUpdateIndexManagement()).To(BeNil())
 
-				cj := &batchv1beta1.CronJob{}
+				cj := &batchv1.CronJob{}
 				key := client.ObjectKey{Name: "elasticsearch-im-infra", Namespace: "openshift-logging"}
 				Expect(req.client.Get(context.TODO(), key, cj)).To(BeNil())
 				Expect(*cj.Spec.Suspend).To(BeTrue())
@@ -126,7 +126,7 @@ var _ = Describe("Index Management", func() {
 				req.client = fake.NewFakeClient(esPods...)
 				Expect(req.createOrUpdateIndexManagement()).To(BeNil())
 
-				cj := &batchv1beta1.CronJob{}
+				cj := &batchv1.CronJob{}
 				key := client.ObjectKey{Name: "elasticsearch-im-infra", Namespace: "openshift-logging"}
 				Expect(req.client.Get(context.TODO(), key, cj)).To(BeNil())
 				Expect(*cj.Spec.Suspend).To(BeFalse())

--- a/internal/indexmanagement/reconcile.go
+++ b/internal/indexmanagement/reconcile.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/ViaQ/logerr/kverrors"
 	"github.com/go-logr/logr"
-	batch "k8s.io/api/batch/v1beta1"
+	batch "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/internal/indexmanagement/reconcile_test.go
+++ b/internal/indexmanagement/reconcile_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	batch "k8s.io/api/batch/v1beta1"
+	batch "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/manifests/cronjob/build.go
+++ b/internal/manifests/cronjob/build.go
@@ -2,14 +2,13 @@ package cronjob
 
 import (
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Builder represents the type to build Cronjob objects
 type Builder struct {
-	cj *batchv1beta1.CronJob
+	cj *batchv1.CronJob
 }
 
 // New returns a new Builder for Cronjob objects
@@ -17,19 +16,19 @@ func New(name, namespace string, labels map[string]string) *Builder {
 	return &Builder{cj: newCronjob(name, namespace, labels)}
 }
 
-func newCronjob(name, namespace string, labels map[string]string) *batchv1beta1.CronJob {
-	return &batchv1beta1.CronJob{
+func newCronjob(name, namespace string, labels map[string]string) *batchv1.CronJob {
+	return &batchv1.CronJob{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "CronJob",
-			APIVersion: batchv1beta1.SchemeGroupVersion.String(),
+			APIVersion: batchv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels:    labels,
 		},
-		Spec: batchv1beta1.CronJobSpec{
-			JobTemplate: batchv1beta1.JobTemplateSpec{
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -44,10 +43,10 @@ func newCronjob(name, namespace string, labels map[string]string) *batchv1beta1.
 }
 
 // Build returns the final Cronjob object
-func (b *Builder) Build() *batchv1beta1.CronJob { return b.cj }
+func (b *Builder) Build() *batchv1.CronJob { return b.cj }
 
 // WithConcurrencyPolicy sets the concurrency policy for the cronjob
-func (b *Builder) WithConcurrencyPolicy(cp batchv1beta1.ConcurrencyPolicy) *Builder {
+func (b *Builder) WithConcurrencyPolicy(cp batchv1.ConcurrencyPolicy) *Builder {
 	b.cj.Spec.ConcurrencyPolicy = cp
 	return b
 }

--- a/internal/manifests/cronjob/cronjob.go
+++ b/internal/manifests/cronjob/cronjob.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ViaQ/logerr/kverrors"
 	"github.com/ViaQ/logerr/log"
 
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1beta1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"

--- a/internal/utils/resources.go
+++ b/internal/utils/resources.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ViaQ/logerr/log"
 
 	apps "k8s.io/api/apps/v1"
-	batch "k8s.io/api/batch/v1beta1"
+	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )


### PR DESCRIPTION
Signed-off-by: Shweta Padubidri <spadubid@redhat.com>

### Description

This PR will ensure EO CronJobs will use the v1 API instead of v1beta1

/cc @periklis
/assign @igor-karpukhin 

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
Links
JIRA: https://issues.redhat.com/browse/LOG-1787
