### PR TITLE
LOG 1868: Cronjob Restarts

### DIFF
--- a/internal/indexmanagement/reconcile.go
+++ b/internal/indexmanagement/reconcile.go
@@ -545,7 +545,6 @@ func newCronJob(clusterName, namespace, name, schedule, script string, nodeSelec
 		WithNodeSelectors(nodeSelector).
 		WithTolerations(tolerations...).
 		WithRestartPolicy(corev1.RestartPolicyNever).
-		WithRestartPolicy(corev1.RestartPolicyNever).
 		WithTerminationGracePeriodSeconds(300 * time.Second).
 		Build()
 
@@ -555,7 +554,7 @@ func newCronJob(clusterName, namespace, name, schedule, script string, nodeSelec
 		WithSuccessfulJobsHistoryLimit(jobHistoryLimitSuccess).
 		WithFailedJobsHistoryLimit(jobHistoryLimitFailed).
 		WithSchedule(schedule).
-		WithBackoffLimit(0).
+		WithBackoffLimit(2).
 		WithParallelism(1).
 		WithPodSpec(containerName, podSpec).
 		Build()


### PR DESCRIPTION
This PR changes the backoff limit of the index management cronjobs. Previously, when a job was unable to succeed, it would immediately fail. However, this can cause alerts to go off, which can lead to a lot of hassle. Thus, the jobs will attempt three times to complete the delete & rollover activity successfully before being declared as a failure. 

/cc @sasagarw 
/assign @periklis 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1868
