### PR TITLE
Fix cachito failure for missing required module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/utils v0.0.0-20210527160623-6fdb442a123b
 	sigs.k8s.io/controller-runtime v0.9.2
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -497,6 +497,7 @@ k8s.io/klog/v2
 # k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
 k8s.io/kube-openapi/pkg/util/proto
 # k8s.io/utils v0.0.0-20210527160623-6fdb442a123b
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer


### PR DESCRIPTION
### Description
This PR provides the missing required go module `k8s.io/utils` as a direct dependency to fix cachito failures.

/cc @btaani 
/assign @periklis 