### PR TITLE
[release-5.3] LOG-2110: add a mutex to function generating certificates

### DIFF
--- a/internal/elasticsearch/certificates.go
+++ b/internal/elasticsearch/certificates.go
@@ -28,11 +28,10 @@ import (
 )
 
 type certificate struct {
-	cert      []byte
-	key       []byte
-	x509Cert  *x509.Certificate
-	privKey   *rsa.PrivateKey
-	certMutex sync.Mutex
+	cert     []byte
+	key      []byte
+	x509Cert *x509.Certificate
+	privKey  *rsa.PrivateKey
 }
 
 type certCA struct {
@@ -115,6 +114,10 @@ var (
 	// In ASN.1, "2 5 29 17" is the OID for subjectAltName (SAN)
 	// The FullBytes are ASN.1-encoded 1.2.3.4.5.5
 	sanIdentifier asn1.ObjectIdentifier = asn1.ObjectIdentifier{2, 5, 29, 17}
+	// Fixing a race condition between GenerateComponentsCerts and GenerateKibanaCerts functions
+	// Here make mutex global. Probably temporary solution, need more deep refactoring of code related to certificate
+	// generation. Problem was founded during working on issue: https://issues.redhat.com/browse/LOG-1923
+	certMutex = sync.Mutex{}
 )
 
 type CertificateRequest struct {
@@ -168,6 +171,8 @@ func (cr *CertificateRequest) getSigningSecretName() string {
 }
 
 func (cr *CertificateRequest) GenerateComponentCerts(secretName, cn string) {
+	certMutex.Lock()
+	defer certMutex.Unlock()
 	key := client.ObjectKey{Name: secretName, Namespace: cr.Namespace}
 	s, err := secret.Get(context.TODO(), cr.K8sClient, key)
 	if err != nil && !apierrors.IsNotFound(kverrors.Root(err)) {
@@ -205,6 +210,8 @@ func (cr *CertificateRequest) GenerateComponentCerts(secretName, cn string) {
 }
 
 func (cr *CertificateRequest) GenerateKibanaCerts(componentName string) {
+	certMutex.Lock()
+	defer certMutex.Unlock()
 	key := client.ObjectKey{Name: kibanaSecretName, Namespace: cr.Namespace}
 	s, err := secret.Get(context.TODO(), cr.K8sClient, key)
 	if err != nil && !apierrors.IsNotFound(kverrors.Root(err)) {
@@ -281,6 +288,8 @@ func (cr *CertificateRequest) GenerateKibanaCerts(componentName string) {
 }
 
 func (cr *CertificateRequest) GenerateElasticsearchCerts(clusterName string) {
+	certMutex.Lock()
+	defer certMutex.Unlock()
 	// get from secret
 	key := client.ObjectKey{Name: clusterName, Namespace: cr.Namespace}
 	s, err := secret.Get(context.TODO(), cr.K8sClient, key)
@@ -358,9 +367,6 @@ func (cr *CertificateRequest) persistCA(caCert *certCA) error {
 }
 
 func (cr *CertificateRequest) ensureCA(caCert *certCA) error {
-	caCert.certMutex.Lock()
-	defer caCert.certMutex.Unlock()
-
 	secretName := cr.getSigningSecretName()
 
 	// get the ca from the secret if we can
@@ -406,9 +412,6 @@ func (cr *CertificateRequest) ensureCA(caCert *certCA) error {
 }
 
 func (cr *CertificateRequest) incrementCertSerial(ca *certCA) (*big.Int, error) {
-	ca.certMutex.Lock()
-	defer ca.certMutex.Unlock()
-
 	ca.serial.Add(ca.serial, bigOne)
 	serial := big.NewInt(0)
 	serial.Set(ca.serial)
@@ -460,9 +463,6 @@ func (cr *CertificateRequest) generateCert(componentName string, cert *certifica
 	if err != nil {
 		return err
 	}
-
-	cert.certMutex.Lock()
-	defer cert.certMutex.Unlock()
 
 	x509Cert := &x509.Certificate{
 		SerialNumber:       serial,
@@ -591,7 +591,6 @@ func genCA() (*certCA, error) {
 			keyPEMBytes,
 			ca,
 			caPrivKey,
-			sync.Mutex{},
 		},
 		serial,
 		caPubKeySHA1[:],
@@ -793,7 +792,6 @@ func validateCASecret(secret *v1.Secret) (*certCA, error) {
 			keyBytes,
 			x509Cert,
 			rsaKey,
-			sync.Mutex{},
 		},
 		serial,
 		pubKeySHA1[:],


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR:
- is a manual backport of #822
- assists upgrade scenarios where CLO is upgraded before EO.
- solves race condition between GenerateComponentsCerts and GenerateKibanaCerts methods, by adding global mutex.

/cc @shwetaap <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign one approver from top-level OWNERS file -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-2110
