### PR TITLE
Log 2125: CreateOrUpdate Method Flow Fix

### DIFF
--- a/internal/manifests/persistentvolume/persistentvolumeclaim.go
+++ b/internal/manifests/persistentvolume/persistentvolumeclaim.go
@@ -21,8 +21,9 @@ type EqualityPVCFunc func(current, desired *corev1.PersistentVolumeClaim) bool
 // by applying the values from the desired persistentvolumeclaim.
 type MutatePVCFunc func(current, desired *corev1.PersistentVolumeClaim)
 
-// CreateOrUpdatePVC attempts first to create the given persistentvolumeclaim. If the
-// persistentvolumeclaim already exists and the provided comparison func detects any changes
+// CreateOrUpdatePVC attempts first to get the given persistentvolumeclaim. If the
+// persistentvolumeclaim does not exist, the persistentvolumeclaim will be created. Otherwise,
+// if the persistentvolumeclaim exists and the provided comparison func detects any changes
 // an update is attempted. Updates are retried with backoff (See retry.DefaultRetry).
 // Returns on failure an non-nil error.
 func CreateOrUpdatePVC(ctx context.Context, c client.Client, pvc *corev1.PersistentVolumeClaim, equal EqualityPVCFunc, mutate MutatePVCFunc) error {

--- a/internal/manifests/serviceaccount/serviceaccount.go
+++ b/internal/manifests/serviceaccount/serviceaccount.go
@@ -21,27 +21,29 @@ type EqualityFunc func(current, desired *corev1.ServiceAccount) bool
 // by applying the values from the desired serviceaccount.
 type MutateFunc func(current, desired *corev1.ServiceAccount)
 
-// CreateOrUpdate attempts first to create the given serviceaccount. If the
-// serviceaccount already exists and the provided comparison func detects any changes
+// CreateOrUpdate attempts first to get the given serviceaccount. If the
+// serviceaccount does not exist, the serviceaccount will be created. Otherwise,
+// if the serviceaccount exists and the provided comparison func detects any changes
 // an update is attempted. Updates are retried with backoff (See retry.DefaultRetry).
 // Returns on failure an non-nil error.
 func CreateOrUpdate(ctx context.Context, c client.Client, sa *corev1.ServiceAccount, equal EqualityFunc, mutate MutateFunc) error {
-	err := c.Create(ctx, sa)
-	if err == nil {
-		return nil
-	}
-
-	if !apierrors.IsAlreadyExists(kverrors.Root(err)) {
-		return kverrors.Wrap(err, "failed to create serviceaccount",
-			"name", sa.Name,
-			"namespace", sa.Namespace,
-		)
-	}
-
 	current := &corev1.ServiceAccount{}
 	key := client.ObjectKey{Name: sa.Name, Namespace: sa.Namespace}
-	err = c.Get(ctx, key, current)
+	err := c.Get(ctx, key, current)
 	if err != nil {
+		if apierrors.IsNotFound(kverrors.Root(err)) {
+			err = c.Create(ctx, sa)
+
+			if err == nil {
+				return nil
+			}
+
+			return kverrors.Wrap(err, "failed to create serviceaccount",
+				"name", sa.Name,
+				"namespace", sa.Namespace,
+			)
+		}
+
 		return kverrors.Wrap(err, "failed to get serviceaccount",
 			"name", sa.Name,
 			"namespace", sa.Namespace,

--- a/internal/manifests/servicemonitor/servicemonitor.go
+++ b/internal/manifests/servicemonitor/servicemonitor.go
@@ -22,27 +22,29 @@ type EqualityFunc func(current, desired *monitoringv1.ServiceMonitor) bool
 // by applying the values from the desired service.
 type MutateFunc func(current, desired *monitoringv1.ServiceMonitor)
 
-// CreateOrUpdate attempts first to create the given servicemonitor. If the
-// servicemonitor already exists and the provided comparison func detects any changes
+// CreateOrUpdate attempts first to get the given servicemonitor. If the
+// servicemonitor does not exist, the servicemonitor will be created. Otherwise,
+// if the servicemonitor exists and the provided comparison func detects any changes
 // an update is attempted. Updates are retried with backoff (See retry.DefaultRetry).
-// Returns on failure a non-nil error.
+// Returns on failure an non-nil error.
 func CreateOrUpdate(ctx context.Context, c client.Client, sm *monitoringv1.ServiceMonitor, equal EqualityFunc, mutate MutateFunc) error {
-	err := c.Create(ctx, sm)
-	if err == nil {
-		return nil
-	}
-
-	if !apierrors.IsAlreadyExists(kverrors.Root(err)) {
-		return kverrors.Wrap(err, "failed to create servicemonitor",
-			"name", sm.Name,
-			"namespace", sm.Namespace,
-		)
-	}
-
 	current := &monitoringv1.ServiceMonitor{}
 	key := client.ObjectKey{Name: sm.Name, Namespace: sm.Namespace}
-	err = c.Get(ctx, key, current)
+	err := c.Get(ctx, key, current)
 	if err != nil {
+		if apierrors.IsNotFound(kverrors.Root(err)) {
+			err = c.Create(ctx, sm)
+
+			if err == nil {
+				return nil
+			}
+
+			return kverrors.Wrap(err, "failed to create servicemonitor",
+				"name", sm.Name,
+				"namespace", sm.Namespace,
+			)
+		}
+
 		return kverrors.Wrap(err, "failed to get servicemonitor",
 			"name", sm.Name,
 			"namespace", sm.Namespace,


### PR DESCRIPTION
This PR changes the CreateOrUpdate flow. Instead of first creating the object and the attempting to update, the method will attempt to find the object first and if it does not exist, create it.

/cc @sasagarw 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2125
