### PR TITLE
Deleting Kibana console link after CLO CR deletion

### DIFF
--- a/controllers/logging/elasticsearch_controller.go
+++ b/controllers/logging/elasticsearch_controller.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/openshift/elasticsearch-operator/internal/indexmanagement"
+	"github.com/openshift/elasticsearch-operator/internal/manifests/console"
 	"github.com/openshift/elasticsearch-operator/internal/metrics"
 
 	"github.com/ViaQ/logerr/log"
@@ -45,6 +46,9 @@ func (r *ElasticsearchReconciler) Reconcile(ctx context.Context, request ctrl.Re
 			log.Info("Flushing nodes", "objectKey", request.NamespacedName)
 			elasticsearch.FlushNodes(request.NamespacedName.Name, request.NamespacedName.Namespace)
 			elasticsearch.RemoveDashboardConfigMap(r.Client)
+			if err := console.DeleteKibanaConsoleLink(context.TODO(), r.Client); err != nil {
+				log.Error(err, "failed to delete consolelink")
+			}
 			return ctrl.Result{}, nil
 		}
 

--- a/internal/manifests/console/consolelink.go
+++ b/internal/manifests/console/consolelink.go
@@ -13,6 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const KibanaConsoleLinkName = "kibana-public-url"
+
 // ConsoleLinkEqualityFunc is the type for functions that compare two consolelinks.
 // Return true if two consolelinks are equal.
 type ConsoleLinkEqualityFunc func(current, desired *consolev1.ConsoleLink) bool
@@ -66,6 +68,21 @@ func CreateOrUpdateConsoleLink(ctx context.Context, c client.Client, cl *console
 			)
 		}
 		return nil
+	}
+
+	return nil
+}
+
+func DeleteKibanaConsoleLink(ctx context.Context, c client.Client) error {
+
+	current := NewConsoleLink(KibanaConsoleLinkName, "", "", "")
+
+	if err := c.Delete(ctx, current); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return kverrors.Wrap(err, "failed to delete consolelink",
+				"name", KibanaConsoleLinkName,
+			)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
### Description
This PR is a fix for [LOG-1919](https://issues.redhat.com/browse/LOG-1919), it deletes the Kibana console link from the openshift web console after CLO is removed.


### Links
- JIRA: https://issues.redhat.com/browse/LOG-1919
