### PR TITLE
Removing StorageClassName for Upgrade Test CR

### DIFF
--- a/hack/testing-olm-upgrade/resources/cr.yaml
+++ b/hack/testing-olm-upgrade/resources/cr.yaml
@@ -21,7 +21,6 @@ spec:
     - data
     - master
     storage:
-      storageClassName: standard
       size: 10G
   redundancyPolicy: SingleRedundancy
   indexManagement:


### PR DESCRIPTION
This PR removes the `standard` storage class name for the upgrade test CR. There isn't a `standard` storage class in AWS and thus the upgrade test is unable to properly provision the operator.

/cc @shwetaap 
/assign @jcantrill