### PR TITLE
Adding percentage-based index management

### DIFF
--- a/apis/logging/v1/index_management_types.go
+++ b/apis/logging/v1/index_management_types.go
@@ -49,6 +49,10 @@ type IndexManagementDeletePhaseSpec struct {
 	// The minimum age of an index before it should be deleted (e.g. 10d)
 	MinAge TimeUnit `json:"minAge"`
 
+	// The threshold percentage of ES disk usage that when reached, old indices should be deleted (e.g. 75)
+	// +optional
+	DiskThresholdPercent int64 `json:"diskThresholdPercent,omitempty"`
+
 	// How often to run a new prune-namespaces job
 	// +optional
 	PruneNamespacesInterval TimeUnit `json:"pruneNamespacesInterval,omitempty"`

--- a/bundle/manifests/logging.openshift.io_elasticsearches.yaml
+++ b/bundle/manifests/logging.openshift.io_elasticsearches.yaml
@@ -98,6 +98,12 @@ spec:
                             delete:
                               nullable: true
                               properties:
+                                diskThresholdPercent:
+                                  description: The threshold percentage of ES disk
+                                    usage that when reached, old indices should be
+                                    deleted (e.g. 75)
+                                  format: int64
+                                  type: integer
                                 minAge:
                                   description: The minimum age of an index before
                                     it should be deleted (e.g. 10d)

--- a/config/crd/bases/logging.openshift.io_elasticsearches.yaml
+++ b/config/crd/bases/logging.openshift.io_elasticsearches.yaml
@@ -91,6 +91,10 @@ spec:
                             delete:
                               nullable: true
                               properties:
+                                diskThresholdPercent:
+                                  description: The threshold percentage of ES disk usage that when reached, old indices should be deleted (e.g. 75)
+                                  format: int64
+                                  type: integer
                                 minAge:
                                   description: The minimum age of an index before it should be deleted (e.g. 10d)
                                   pattern: ^([0-9]+)([yMwdhHms]{0,1})$

--- a/internal/indexmanagement/reconcile.go
+++ b/internal/indexmanagement/reconcile.go
@@ -359,9 +359,16 @@ func (imr *IndexManagementRequest) reconcileIndexManagementCronjob(policy apis.I
 			return err
 		}
 
+		diskThreshold := policy.Phases.Delete.DiskThresholdPercent
+		if diskThreshold < 0 || diskThreshold > 100 {
+			err := fmt.Errorf("invalid percentage value")
+			return kverrors.Wrap(err, ", %d should be between 0 and 100", diskThreshold)
+		}
+
 		envvars = append(envvars,
 			corev1.EnvVar{Name: "MIN_AGE", Value: strconv.FormatUint(minAgeMillis, 10)},
 			corev1.EnvVar{Name: "NAMESPACE_SPECS", Value: namespaceSpecsString},
+			corev1.EnvVar{Name: "DISK_THRESHOLD", Value: strconv.FormatInt(diskThreshold, 10)},
 		)
 
 		metrics.SetIndexRetentionDocumentAge(true, mapping.Name, minAgeMillis/millisPerSecond)


### PR DESCRIPTION
### Description
This PR adds the functionality of deleting old indices based on the used disk space of ES nodes.

/cc @sasagarw @shwetaap 

### Links
- JIRA: [LOG-1546](https://issues.redhat.com/browse/LOG-1546) and [LOG-2129](https://issues.redhat.com/browse/LOG-2129)
- Enhancement Proposal: https://github.com/openshift/enhancements/blob/master/enhancements/cluster-logging/elasticsearch-percentage-index-management.md
- Implementation details: https://docs.google.com/document/d/1Wtaa3ZWC1kQYAg_xu5YThlLtSZedgxQVvNAWZMaiSWw/edit#
