### PR TITLE
Log 2303: Special Tolerations Block Operator Update

### DIFF
--- a/internal/utils/comparators/tolerations.go
+++ b/internal/utils/comparators/tolerations.go
@@ -53,9 +53,21 @@ func isTolerationSame(lhs, rhs v1.Toleration) bool {
 		}
 	}
 
+	tolerationEffectBool := lhs.Effect == rhs.Effect
+	if lhs.Effect == "" || rhs.Effect == "" {
+		tolerationEffectBool = true
+	}
+
+	// A toleration with the exists operator can leave the key empty to tolerate everything
+	if (lhs.Operator == rhs.Operator) && (lhs.Operator == v1.TolerationOpExists) {
+		if lhs.Key == "" || rhs.Key == "" {
+			return true
+		}
+	}
+
 	return (lhs.Key == rhs.Key) &&
 		(lhs.Operator == rhs.Operator) &&
 		(lhs.Value == rhs.Value) &&
-		(lhs.Effect == rhs.Effect) &&
+		tolerationEffectBool &&
 		tolerationSecondsBool
 }


### PR DESCRIPTION
This PR fixes a bug in which we do not consider the special case tolerations (defined here: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to be matches. This causes the operator to never mark successful pod deployments as complete and prevents updates.

/cc @xperimental 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2303