### PR TITLE
Reducing the number of service accounts added to scc role binding

### DIFF
--- a/internal/elasticsearch/rbac.go
+++ b/internal/elasticsearch/rbac.go
@@ -142,11 +142,18 @@ func (er *ElasticsearchRequest) CreateOrUpdateRBAC() error {
 		)
 	}
 
+	subject = rbac.NewSubject(
+		"ServiceAccount",
+		dpl.Name,
+		dpl.Namespace,
+	)
+	subject.APIGroup = ""
+	
 	sccRoleBinding := rbac.NewRoleBinding(
 		"elasticsearch-restricted",
 		dpl.Namespace,
 		"elasticsearch-restricted",
-		subjects,
+		rbac.NewSubjects(subject),
 	)
 
 	err = rbac.CreateOrUpdateRoleBinding(context.TODO(), er.client, sccRoleBinding)


### PR DESCRIPTION
This PR fixes the subject field of the SCC role binding applied to the elasticsearch cluster. Originally, this was the same amount of subjects as applied to the proxy, which included the service account for the cluster.

/cc @xperimental 
/assign @periklis 