### PR TITLE
Remove support of 'years' and 'months' timeunits from CRD

### DIFF
--- a/apis/logging/v1/index_management_types.go
+++ b/apis/logging/v1/index_management_types.go
@@ -21,7 +21,7 @@ type IndexManagementSpec struct {
 
 // TimeUnit is a time unit like h,m,d
 //
-// +kubebuilder:validation:Pattern:="^([0-9]+)([yMwdhHms]{0,1})$"
+// +kubebuilder:validation:Pattern:="^([0-9]+)([wdhHms]{0,1})$"
 type TimeUnit string
 
 // IndexManagementPolicySpec is a definition of an index management policy

--- a/bundle/manifests/logging.openshift.io_elasticsearches.yaml
+++ b/bundle/manifests/logging.openshift.io_elasticsearches.yaml
@@ -107,7 +107,7 @@ spec:
                                 minAge:
                                   description: The minimum age of an index before
                                     it should be deleted (e.g. 10d)
-                                  pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                                  pattern: ^([0-9]+)([wdhHms]{0,1})$
                                   type: string
                                 namespaceSpec:
                                   description: The per namespace specification to
@@ -118,7 +118,7 @@ spec:
                                         description: Delete the records matching the
                                           namespaces which are older than this MinAge
                                           (e.g. 1d)
-                                        pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                                        pattern: ^([0-9]+)([wdhHms]{0,1})$
                                         type: string
                                       namespace:
                                         description: Target Namespace to delete logs
@@ -133,7 +133,7 @@ spec:
                                 pruneNamespacesInterval:
                                   description: How often to run a new prune-namespaces
                                     job
-                                  pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                                  pattern: ^([0-9]+)([wdhHms]{0,1})$
                                   type: string
                               required:
                               - minAge
@@ -150,7 +150,7 @@ spec:
                                           description: The maximum age of an index
                                             before it should be rolled over (e.g.
                                             7d)
-                                          pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                                          pattern: ^([0-9]+)([wdhHms]{0,1})$
                                           type: string
                                       required:
                                       - maxAge
@@ -161,7 +161,7 @@ spec:
                         pollInterval:
                           description: How often to check an index meets the desired
                             criteria (e.g. 1m)
-                          pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                          pattern: ^([0-9]+)([wdhHms]{0,1})$
                           type: string
                       required:
                       - name

--- a/config/crd/bases/logging.openshift.io_elasticsearches.yaml
+++ b/config/crd/bases/logging.openshift.io_elasticsearches.yaml
@@ -98,13 +98,15 @@ spec:
                               nullable: true
                               properties:
                                 diskThresholdPercent:
-                                  description: The threshold percentage of ES disk usage that when reached, old indices should be deleted (e.g. 75)
+                                  description: The threshold percentage of ES disk
+                                    usage that when reached, old indices should be
+                                    deleted (e.g. 75)
                                   format: int64
                                   type: integer
                                 minAge:
                                   description: The minimum age of an index before
                                     it should be deleted (e.g. 10d)
-                                  pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                                  pattern: ^([0-9]+)([wdhHms]{0,1})$
                                   type: string
                                 namespaceSpec:
                                   description: The per namespace specification to
@@ -115,7 +117,7 @@ spec:
                                         description: Delete the records matching the
                                           namespaces which are older than this MinAge
                                           (e.g. 1d)
-                                        pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                                        pattern: ^([0-9]+)([wdhHms]{0,1})$
                                         type: string
                                       namespace:
                                         description: Target Namespace to delete logs
@@ -130,7 +132,7 @@ spec:
                                 pruneNamespacesInterval:
                                   description: How often to run a new prune-namespaces
                                     job
-                                  pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                                  pattern: ^([0-9]+)([wdhHms]{0,1})$
                                   type: string
                               required:
                               - minAge
@@ -147,7 +149,7 @@ spec:
                                           description: The maximum age of an index
                                             before it should be rolled over (e.g.
                                             7d)
-                                          pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                                          pattern: ^([0-9]+)([wdhHms]{0,1})$
                                           type: string
                                       required:
                                       - maxAge
@@ -158,7 +160,7 @@ spec:
                         pollInterval:
                           description: How often to check an index meets the desired
                             criteria (e.g. 1m)
-                          pattern: ^([0-9]+)([yMwdhHms]{0,1})$
+                          pattern: ^([0-9]+)([wdhHms]{0,1})$
                           type: string
                       required:
                       - name

--- a/internal/indexmanagement/validations.go
+++ b/internal/indexmanagement/validations.go
@@ -8,7 +8,7 @@ import (
 	esapi "github.com/openshift/elasticsearch-operator/apis/logging/v1"
 )
 
-var reTimeUnit = regexp.MustCompile("^(?P<number>\\d+)(?P<unit>[yMwdhHms])$")
+var reTimeUnit = regexp.MustCompile("^(?P<number>\\d+)(?P<unit>[wdhHms])$")
 
 const (
 	pollIntervalFailMessage  = "The pollInterval is missing or requires a valid time unit (e.g. 3d)"


### PR DESCRIPTION
### Description
This PR removes the support of `y` and `M` time units that are specified in Elasticsearch CRD (`yMwdhHms`).


/cc @sasagarw 
/assign @periklis 


### Links
- JIRA: [LOG-2418](https://issues.redhat.com/browse/LOG-2418)
