### PR TITLE
LOG-2463: Elasticsearch operator repeatedly prints error message when checking indices

### DIFF
--- a/internal/types/elasticsearch/types.go
+++ b/internal/types/elasticsearch/types.go
@@ -112,7 +112,7 @@ type IndexBlocksSettings struct {
 }
 
 type IndexMapperSettings struct {
-	Dynamic bool `json:"dynamic"`
+	Dynamic bool `json:"dynamic,string"`
 }
 
 type IndexMappingSettings struct {


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR:
- updates the `IndexMapperSettings` struct to parse string while GET request.
- currently `settings.index.mapper.dynamic` is parsed wrongly since the json value is returned as string during GET request. However, during a PUT request this value should be a bool.

/cc @periklis 
/assign @periklis 

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-2463
