### PR TITLE
LOG 2147: Removing stable annotation

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,8 +4,8 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: elasticsearch-operator
-  operators.operatorframework.io.bundle.channels.v1: stable,stable-5.4
-  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable-5.4
+  operators.operatorframework.io.bundle.channel.default.v1: stable-5.4
   operators.operatorframework.io.metrics.builder: operator-sdk-unknown
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3


### PR DESCRIPTION
This PR removes the stable annotation from the 5.4 release.

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2147
