### PR TITLE
[release-5.4] LOG-2154: Check attributes of subject for component certificates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2
 	k8s.io/client-go v12.0.0+incompatible
-	k8s.io/utils v0.0.0-20210527160623-6fdb442a123b
+	k8s.io/utils v0.0.0-20211116205334-6203023598ed
 	sigs.k8s.io/controller-runtime v0.9.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1230,8 +1230,9 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20210527160623-6fdb442a123b h1:MSqsVQ3pZvPGTqCjptfimO2WjG7A9un2zcpiHkA6M/s=
 k8s.io/utils v0.0.0-20210527160623-6fdb442a123b/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20211116205334-6203023598ed h1:ck1fRPWPJWsMd8ZRFsWc6mh/zHp5fZ/shhbrgPUxDAE=
+k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/internal/elasticsearch/certificates.go
+++ b/internal/elasticsearch/certificates.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -356,7 +357,7 @@ func (cr *CertificateRequest) EnsureCert(componentName string, cert *certificate
 	}
 
 	// validate that the cert isn't expired and is signed correctly
-	if !isValidCert(cert.x509Cert, cert.privKey, componentName) || !isSignedCorrectly {
+	if !isValidCert(cert.x509Cert, cert.privKey, componentName, true) || !isSignedCorrectly {
 		err := cr.generateCert(componentName, cert, ca)
 		if err != nil {
 			return err
@@ -586,7 +587,7 @@ func unmarshalCert(cert, key []byte, unmarshalledCert *certificate) error {
 	return nil
 }
 
-func isValidCert(x509Cert *x509.Certificate, rsaPrivKey *rsa.PrivateKey, commonName string) bool {
+func isValidCert(x509Cert *x509.Certificate, rsaPrivKey *rsa.PrivateKey, commonName string, isComponent bool) bool {
 	if x509Cert == nil {
 		return false
 	}
@@ -612,8 +613,22 @@ func isValidCert(x509Cert *x509.Certificate, rsaPrivKey *rsa.PrivateKey, commonN
 		return false
 	}
 
-	if x509Cert.Subject.CommonName != commonName {
+	subject := x509Cert.Subject
+	if subject.CommonName != commonName {
 		return false
+	}
+
+	if isComponent {
+		// We currently only check these for the "component" certificates and not the CA.
+		// This is because only the DNs of the client certificates are used for authentication
+		// and also checking this for the CA would mean re-creating the whole PKI.
+		if !slices.Equal(subject.Organization, certOrganization) {
+			return false
+		}
+
+		if !slices.Equal(subject.OrganizationalUnit, componentOrganizationUnit) {
+			return false
+		}
 	}
 
 	return true
@@ -673,7 +688,7 @@ func genCA() (*certCA, error) {
 }
 
 func isValidCA(x509Cert *x509.Certificate, rsaPrivKey *rsa.PrivateKey) bool {
-	if !isValidCert(x509Cert, rsaPrivKey, caCN) {
+	if !isValidCert(x509Cert, rsaPrivKey, caCN, false) {
 		return false
 	}
 

--- a/vendor/k8s.io/utils/pointer/pointer.go
+++ b/vendor/k8s.io/utils/pointer/pointer.go
@@ -46,6 +46,24 @@ func AllPtrFieldsNil(obj interface{}) bool {
 	return true
 }
 
+// Int returns a pointer to an int
+func Int(i int) *int {
+	return &i
+}
+
+var IntPtr = Int // for back-compat
+
+// IntDeref dereferences the int ptr and returns it if not nil, or else
+// returns def.
+func IntDeref(ptr *int, def int) int {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
+}
+
+var IntPtrDerefOr = IntDeref // for back-compat
+
 // Int32 returns a pointer to an int32.
 func Int32(i int32) *int32 {
 	return &i

--- a/vendor/k8s.io/utils/strings/slices/slices.go
+++ b/vendor/k8s.io/utils/strings/slices/slices.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package slices defines various functions useful with slices of string type.
+// The goal is to be as close as possible to
+// https://github.com/golang/go/issues/45955. Ideal would be if we can just
+// replace "stringslices" if the "slices" package becomes standard.
+package slices
+
+// Equal reports whether two slices are equal: the same length and all
+// elements equal. If the lengths are different, Equal returns false.
+// Otherwise, the elements are compared in index order, and the
+// comparison stops at the first unequal pair.
+func Equal(s1, s2 []string) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	for i, n := range s1 {
+		if n != s2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Filter appends to d each element e of s for which keep(e) returns true.
+// It returns the modified d. d may be s[:0], in which case the kept
+// elements will be stored in the same slice.
+// if the slices overlap in some other way, the results are unspecified.
+// To create a new slice with the filtered results, pass nil for d.
+func Filter(d, s []string, keep func(string) bool) []string {
+	for _, n := range s {
+		if keep(n) {
+			d = append(d, n)
+		}
+	}
+	return d
+}
+
+// Contains reports whether v is present in s.
+func Contains(s []string, v string) bool {
+	return Index(s, v) >= 0
+}
+
+// Index returns the index of the first occurrence of v in s, or -1 if
+// not present.
+func Index(s []string, v string) int {
+	// "Contains" may be replaced with "Index(s, v) >= 0":
+	// https://github.com/golang/go/issues/45955#issuecomment-873377947
+	for i, n := range s {
+		if n == v {
+			return i
+		}
+	}
+	return -1
+}
+
+// Functions below are not in https://github.com/golang/go/issues/45955
+
+// Clone returns a new clone of s.
+func Clone(s []string) []string {
+	// https://github.com/go101/go101/wiki/There-is-not-a-perfect-way-to-clone-slices-in-Go
+	if s == nil {
+		return nil
+	}
+	c := make([]string, len(s))
+	copy(c, s)
+	return c
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -498,11 +498,12 @@ k8s.io/component-base/config/v1alpha1
 k8s.io/klog/v2
 # k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
 k8s.io/kube-openapi/pkg/util/proto
-# k8s.io/utils v0.0.0-20210527160623-6fdb442a123b
+# k8s.io/utils v0.0.0-20211116205334-6203023598ed
 ## explicit
 k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
+k8s.io/utils/strings/slices
 k8s.io/utils/trace
 # sigs.k8s.io/controller-runtime v0.9.2
 ## explicit


### PR DESCRIPTION
Cherry-pick of #884 with additional dependency update. Supersedes #886.

The dependency is updated to the same version as used in `master`.