### PR TITLE
LOG-2656: Fix csv owned resources to point to batchv1 cronjob

### DIFF
--- a/apis/logging/v1/elasticsearch_types.go
+++ b/apis/logging/v1/elasticsearch_types.go
@@ -24,7 +24,7 @@ const (
 // +kubebuilder:printcolumn:name="Index Management",JSONPath=".status.indexManagement.State",type=string
 //
 // An Elasticsearch cluster instance
-// +operator-sdk:csv:customresourcedefinitions:displayName="Elasticsearch",resources={{Pod,v1},{Deployment,v1},{StatefulSet,v1},{ReplicaSet,v1},{ConfigMap,v1},{Service,v1},{Route,v1},{CronJob,v1beta1},{PrometheusRule,v1},{Role,v1},{RoleBinding,v1},{ServiceAccount,v1},{ServiceMonitor,v1},{persistentvolumeclaims,v1}}
+// +operator-sdk:csv:customresourcedefinitions:displayName="Elasticsearch",resources={{Pod,v1},{Deployment,v1},{StatefulSet,v1},{ReplicaSet,v1},{ConfigMap,v1},{Service,v1},{Route,v1},{CronJob,v1},{PrometheusRule,v1},{Role,v1},{RoleBinding,v1},{ServiceAccount,v1},{ServiceMonitor,v1},{persistentvolumeclaims,v1}}
 type Elasticsearch struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
@@ -140,7 +140,7 @@ spec:
         version: v1
       - kind: CronJob
         name: ""
-        version: v1beta1
+        version: v1
       - kind: Deployment
         name: ""
         version: v1

--- a/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
@@ -126,7 +126,7 @@ spec:
         version: v1
       - kind: CronJob
         name: ""
-        version: v1beta1
+        version: v1
       - kind: Deployment
         name: ""
         version: v1

--- a/internal/manifests/cronjob/cronjob.go
+++ b/internal/manifests/cronjob/cronjob.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/ViaQ/logerr/v2/kverrors"
-	batchv1beta1 "k8s.io/api/batch/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
@@ -13,19 +13,19 @@ import (
 
 // EqualityFunc is the type for functions that compare two cronjobs.
 // Return true if two cronjobs are equal.
-type EqualityFunc func(current, desired *batchv1beta1.CronJob) bool
+type EqualityFunc func(current, desired *batchv1.CronJob) bool
 
 // MutateFunc is the type for functions that mutate the current cronjob
 // by applying the values from the desired cronjob.
-type MutateFunc func(current, desired *batchv1beta1.CronJob)
+type MutateFunc func(current, desired *batchv1.CronJob)
 
 // CreateOrUpdate attempts first to get the given cronjob. If the
 // cronjob does not exist, the cronjob will be created. Otherwise,
 // if the cronjob exists and the provided comparison func detects any changes
 // an update is attempted. Updates are retried with backoff (See retry.DefaultRetry).
 // Returns on failure an non-nil error.
-func CreateOrUpdate(ctx context.Context, c client.Client, cj *batchv1beta1.CronJob, equal EqualityFunc, mutate MutateFunc) error {
-	current := &batchv1beta1.CronJob{}
+func CreateOrUpdate(ctx context.Context, c client.Client, cj *batchv1.CronJob, equal EqualityFunc, mutate MutateFunc) error {
+	current := &batchv1.CronJob{}
 	key := client.ObjectKey{Name: cj.Name, Namespace: cj.Namespace}
 	err := c.Get(ctx, key, current)
 	if err != nil {
@@ -90,8 +90,8 @@ func Delete(ctx context.Context, c client.Client, key client.ObjectKey) error {
 }
 
 // List returns a list of deployments that match the given selector.
-func List(ctx context.Context, c client.Client, namespace string, selector map[string]string) ([]batchv1beta1.CronJob, error) {
-	list := &batchv1beta1.CronJobList{}
+func List(ctx context.Context, c client.Client, namespace string, selector map[string]string) ([]batchv1.CronJob, error) {
+	list := &batchv1.CronJobList{}
 	opts := []client.ListOption{
 		client.InNamespace(namespace),
 		client.MatchingLabels(selector),
@@ -106,12 +106,12 @@ func List(ctx context.Context, c client.Client, namespace string, selector map[s
 }
 
 // Equal return only true if the cronjob are equal
-func Equal(current, desired *batchv1beta1.CronJob) bool {
+func Equal(current, desired *batchv1.CronJob) bool {
 	return equality.Semantic.DeepEqual(current, desired)
 }
 
 // Mutate is a default mutation function for cronjobs
 // that copies only mutable fields from desired to current.
-func Mutate(current, desired *batchv1beta1.CronJob) {
+func Mutate(current, desired *batchv1.CronJob) {
 	current.Spec = desired.Spec
 }


### PR DESCRIPTION
### Description
The present ClusterServiceVersion is still pointing that the Elasticsearch custom resources owns resources from the deprecated API group `batchv1beta1` namely `Cronjob`. However in #813 we switched from `batchv1beta1` to `batchv1`. This PR complements the missing bits in the ClusterServiceVersion.

__Note__: Requires manual backport to release-5.4.

/cc @Red-GV 

### Links
- JIRA: [LOG-2656](https://issues.redhat.com/browse/LOG-2656) and [LOG-2618](https://issues.redhat.com/browse/LOG-2618)
