### PR TITLE
LOG-2728: Allow blackbox availability healthchecks for Kibana

### DIFF
--- a/internal/kibana/reconciler.go
+++ b/internal/kibana/reconciler.go
@@ -567,6 +567,7 @@ func newKibanaPodSpec(cluster *KibanaRequest, elasticsearchName string, proxyCon
 		"-cookie-secret-file=/secret/session-secret",
 		"-cookie-expire=24h",
 		"-skip-provider-button",
+		"-skip-auth-regex=^/api/status$",
 		"-upstream=http://localhost:5601",
 		"-scope=user:info user:check-access user:list-projects",
 		"--tls-cert=/secret/server-cert",


### PR DESCRIPTION
### Description
The following PR enables availability healthchecks of Kibana using for example prometheus blackbox exporter.

/cc @xperimental 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2728
