### PR TITLE
fix IM rollover name generation

### DIFF
--- a/internal/indexmanagement/scripts.go
+++ b/internal/indexmanagement/scripts.go
@@ -440,9 +440,9 @@ function rollover() {
   if [ "$responseRollover" == False ] ; then
     # already in bad state
     echo "Calculating next write index based on current write index..."
-
-    indexGeneration="$(echo $writeIndex | cut -d'-' -f2)"
-    writeBase="$(echo $writeIndex | cut -d'-' -f1)"
+    
+    indexGeneration="$(echo ${writeIndex##*-})"
+    writeBase="$(echo ${writeIndex%-*})"
 
     # if we don't strip off the leading 0s it does math wrong...
     generation="$(echo $indexGeneration | sed 's/^0*//')"


### PR DESCRIPTION
### Description
This PR addresses the issue where rollover jobs cannot create new indices that have more than one hyphen`-` character in their names.

/assign @periklis 

### Links
- Github issue: https://github.com/openshift/elasticsearch-operator/issues/859
- JIRA: [LOG-2644](https://issues.redhat.com/browse/LOG-2644)
