### PR TITLE
LOG-2732: Fix ES servicemonitor for user-workload-monitoring

### DIFF
--- a/internal/elasticsearch/common.go
+++ b/internal/elasticsearch/common.go
@@ -47,6 +47,18 @@ var defaultResources = map[string]v1.ResourceRequirements{
 	},
 }
 
+func serviceMonitorServiceAccountName(dplName string) string {
+	return fmt.Sprintf("%s-metrics", dplName)
+}
+
+func serviceMonitorServiceAccountTokenName(dplName string) string {
+	return fmt.Sprintf("%s-token", serviceMonitorServiceAccountName(dplName))
+}
+
+func serviceCABundleName(dplName string) string {
+	return fmt.Sprintf("%s-ca-bundle", dplName)
+}
+
 func getESImage() string {
 	return utils.LookupEnvWithDefault("RELATED_IMAGE_ELASTICSEARCH", constants.ElasticsearchDefaultImage)
 }
@@ -239,7 +251,7 @@ func newProxyContainer(imageName, clusterName, namespace string, logConfig LogCo
 			"--upstream-ca=/etc/proxy/elasticsearch/admin-ca",
 			"--cache-expiry=60s",
 			`--auth-backend-role=admin_reader={"namespace": "default", "verb": "get", "resource": "pods/log"}`,
-			`--auth-backend-role=prometheus={"verb": "get", "resource": "/metrics"}`,
+			fmt.Sprintf(`--auth-backend-role=prometheus={"namespace":"%s", "verb": "get", "resource": "metrics", "resourceAPIGroup": "elasticsearch.openshift.io"}`, namespace),
 			`--auth-backend-role=jaeger={"verb": "get", "resource": "/jaeger", "resourceAPIGroup": "elasticsearch.jaegertracing.io"}`,
 			`--auth-backend-role=elasticsearch-operator={"namespace": "*", "verb": "*", "resource": "*", "resourceAPIGroup": "logging.openshift.io"}`,
 			fmt.Sprintf("--auth-backend-role=index-management={\"namespace\":\"%s\", \"verb\": \"*\", \"resource\": \"indices\", \"resourceAPIGroup\": \"elasticsearch.openshift.io\"}", namespace),

--- a/internal/elasticsearch/configmaps.go
+++ b/internal/elasticsearch/configmaps.go
@@ -88,6 +88,19 @@ func (er *ElasticsearchRequest) CreateOrUpdateConfigMaps() error {
 		}
 	}
 
+	cm = configmap.New(serviceCABundleName(dpl.Name), dpl.Namespace, dpl.Labels, nil)
+	cm.Annotations = map[string]string{
+		"service.beta.openshift.io/inject-cabundle": "true",
+	}
+
+	_, err = configmap.CreateOrUpdate(context.TODO(), er.client, cm, configmap.AnnotationsEqual, configmap.MutateAnnotationsOnly)
+	if err != nil {
+		return kverrors.Wrap(err, "failed to create or update elasticsearch ca-bundle configmap",
+			"cluster", er.cluster.Name,
+			"namespace", er.cluster.Namespace,
+		)
+	}
+
 	return nil
 }
 

--- a/internal/elasticsearch/reconciler.go
+++ b/internal/elasticsearch/reconciler.go
@@ -154,8 +154,13 @@ func Reconcile(log logr.Logger, requestCluster *elasticsearchv1.Elasticsearch, r
 	}
 
 	// Ensure existence of servicesaccount
-	if err := elasticsearchRequest.CreateOrUpdateServiceAccount(); err != nil {
+	if err := elasticsearchRequest.CreateOrUpdateServiceAccounts(); err != nil {
 		return kverrors.Wrap(err, "Failed to reconcile ServiceAccount for Elasticsearch cluster")
+	}
+
+	// Ensure existence of serviceaccount token secret
+	if err := elasticsearchRequest.CreateOrUpdateServiceAccountTokenSecret(); err != nil {
+		return kverrors.Wrap(err, "Failed to reconcile ServiceAccount Token Secret for Elasticsearch cluster metrics")
 	}
 
 	// Ensure existence of roles, rolebindings, clusterroles and clusterrolebindings

--- a/internal/elasticsearch/service_monitor_test.go
+++ b/internal/elasticsearch/service_monitor_test.go
@@ -9,26 +9,44 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func TestCreateOrUpdateServiceMonitor(t *testing.T) {
-	scheme := apiruntime.NewScheme()
+	scheme := scheme.Scheme
 	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 
 	tests := []struct {
 		desc    string
+		objs    []runtime.Object
 		cluster *loggingv1.Elasticsearch
 		want    *monitoringv1.ServiceMonitor
 	}{
 		{
 			desc: "default labels",
+			objs: []runtime.Object{
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "elasticsearch-metrics",
+						Namespace: "openshift-logging",
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "elasticsearch-metrics-token",
+						Namespace: "openshift-logging",
+					},
+					Type: corev1.SecretTypeServiceAccountToken,
+				},
+			},
 			cluster: &loggingv1.Elasticsearch{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "elasticsearch",
@@ -53,27 +71,51 @@ func TestCreateOrUpdateServiceMonitor(t *testing.T) {
 					JobLabel: "monitor-elasticsearch",
 					Endpoints: []monitoringv1.Endpoint{
 						{
-							Port:            "elasticsearch",
-							Path:            "/metrics",
-							Scheme:          "https",
-							BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+							Port:   "elasticsearch",
+							Path:   "/metrics",
+							Scheme: "https",
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
+									CA: monitoringv1.SecretOrConfigMap{
+										ConfigMap: &corev1.ConfigMapKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "elasticsearch-ca-bundle",
+											},
+											Key: prometheusCAFile,
+										},
+									},
 									ServerName: "elasticsearch-metrics.openshift-logging.svc",
 								},
-								CAFile: prometheusCAFile,
+							},
+							BearerTokenSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "elasticsearch-metrics-token",
+								},
+								Key: "token",
 							},
 						},
 						{
-							Port:            "elasticsearch",
-							Path:            "/_prometheus/metrics",
-							Scheme:          "https",
-							BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+							Port:   "elasticsearch",
+							Path:   "/_prometheus/metrics",
+							Scheme: "https",
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
+									CA: monitoringv1.SecretOrConfigMap{
+										ConfigMap: &corev1.ConfigMapKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "elasticsearch-ca-bundle",
+											},
+											Key: prometheusCAFile,
+										},
+									},
 									ServerName: "elasticsearch-metrics.openshift-logging.svc",
 								},
-								CAFile: prometheusCAFile,
+							},
+							BearerTokenSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "elasticsearch-metrics-token",
+								},
+								Key: "token",
 							},
 						},
 					},
@@ -91,6 +133,21 @@ func TestCreateOrUpdateServiceMonitor(t *testing.T) {
 		},
 		{
 			desc: "default labels with cr labels",
+			objs: []runtime.Object{
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "elasticsearch-metrics",
+						Namespace: "openshift-logging",
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "elasticsearch-metrics-token",
+						Namespace: "openshift-logging",
+					},
+					Type: corev1.SecretTypeServiceAccountToken,
+				},
+			},
 			cluster: &loggingv1.Elasticsearch{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "elasticsearch",
@@ -125,27 +182,51 @@ func TestCreateOrUpdateServiceMonitor(t *testing.T) {
 					JobLabel: "monitor-elasticsearch",
 					Endpoints: []monitoringv1.Endpoint{
 						{
-							Port:            "elasticsearch",
-							Path:            "/metrics",
-							Scheme:          "https",
-							BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+							Port:   "elasticsearch",
+							Path:   "/metrics",
+							Scheme: "https",
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
+									CA: monitoringv1.SecretOrConfigMap{
+										ConfigMap: &corev1.ConfigMapKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "elasticsearch-ca-bundle",
+											},
+											Key: prometheusCAFile,
+										},
+									},
 									ServerName: "elasticsearch-metrics.openshift-logging.svc",
 								},
-								CAFile: prometheusCAFile,
+							},
+							BearerTokenSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "elasticsearch-metrics-token",
+								},
+								Key: "token",
 							},
 						},
 						{
-							Port:            "elasticsearch",
-							Path:            "/_prometheus/metrics",
-							Scheme:          "https",
-							BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+							Port:   "elasticsearch",
+							Path:   "/_prometheus/metrics",
+							Scheme: "https",
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
+									CA: monitoringv1.SecretOrConfigMap{
+										ConfigMap: &corev1.ConfigMapKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "elasticsearch-ca-bundle",
+											},
+											Key: prometheusCAFile,
+										},
+									},
 									ServerName: "elasticsearch-metrics.openshift-logging.svc",
 								},
-								CAFile: prometheusCAFile,
+							},
+							BearerTokenSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "elasticsearch-metrics-token",
+								},
+								Key: "token",
 							},
 						},
 					},
@@ -167,7 +248,7 @@ func TestCreateOrUpdateServiceMonitor(t *testing.T) {
 		test := test
 
 		t.Run(test.desc, func(t *testing.T) {
-			client := fake.NewFakeClientWithScheme(scheme)
+			client := fake.NewFakeClientWithScheme(scheme, test.objs...)
 
 			req := &ElasticsearchRequest{
 				client:  client,

--- a/internal/elasticsearch/serviceaccount.go
+++ b/internal/elasticsearch/serviceaccount.go
@@ -4,11 +4,18 @@ import (
 	"context"
 
 	"github.com/ViaQ/logerr/v2/kverrors"
+	"github.com/openshift/elasticsearch-operator/internal/manifests/secret"
 	"github.com/openshift/elasticsearch-operator/internal/manifests/serviceaccount"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-// CreateOrUpdateServiceAccount ensures the existence of the serviceaccount for Elasticsearch cluster
-func (er *ElasticsearchRequest) CreateOrUpdateServiceAccount() error {
+// CreateOrUpdateServiceAccounts ensures the existence of the following serviceaccounts for Elasticsearch cluster:
+// - elasticsearch: For mounting and using the custom SecurityContextConstraint to the elasticsearch pods
+// - elasticsearch-metrics: For allowing Prometheus ServiceMonitor (ClusterMonitoring and User-Workload-Monitoring) to scrape logs
+func (er *ElasticsearchRequest) CreateOrUpdateServiceAccounts() error {
 	dpl := er.cluster
 
 	sa := serviceaccount.New(dpl.Name, dpl.Namespace, map[string]string{})
@@ -17,6 +24,79 @@ func (er *ElasticsearchRequest) CreateOrUpdateServiceAccount() error {
 	err := serviceaccount.CreateOrUpdate(context.TODO(), er.client, sa, serviceaccount.AnnotationsEqual, serviceaccount.MutateAnnotationsOnly)
 	if err != nil {
 		return kverrors.Wrap(err, "failed to create or update elasticsearch serviceaccount",
+			"cluster", dpl.Name,
+			"namespace", dpl.Namespace,
+		)
+	}
+
+	sa = serviceaccount.New(serviceMonitorServiceAccountName(dpl.Name), dpl.Namespace, map[string]string{})
+	er.cluster.AddOwnerRefTo(sa)
+
+	err = serviceaccount.CreateOrUpdate(context.TODO(), er.client, sa, serviceaccount.AnnotationsEqual, serviceaccount.MutateAnnotationsOnly)
+	if err != nil {
+		return kverrors.Wrap(err, "failed to create or update elasticsearch-mertrics serviceaccount",
+			"cluster", dpl.Name,
+			"namespace", dpl.Namespace,
+		)
+	}
+
+	return nil
+}
+
+// CreateOrUpdateServiceAccountTokenSecret ensures the existence of the following secrets
+// of type `kubernetes.io/service-account-token` for the serviceaccount `elasticsearch-metrics`.
+func (er *ElasticsearchRequest) CreateOrUpdateServiceAccountTokenSecret() error {
+	dpl := er.cluster
+
+	saName := serviceMonitorServiceAccountName(dpl.Name)
+
+	key := client.ObjectKey{Name: saName, Namespace: dpl.Namespace}
+	sa, err := serviceaccount.Get(context.TODO(), er.client, key)
+	if err != nil {
+		return kverrors.Wrap(err, "failed to get the service monitor serviceaccount",
+			"cluster", dpl.Name,
+			"namespace", dpl.Namespace,
+		)
+	}
+
+	saTokenName := serviceMonitorServiceAccountTokenName(dpl.Name)
+	s := secret.New(saTokenName, dpl.Namespace, nil)
+	s.Annotations = map[string]string{
+		corev1.ServiceAccountNameKey: sa.Name,
+		corev1.ServiceAccountUIDKey:  string(sa.UID),
+	}
+	s.Type = corev1.SecretTypeServiceAccountToken
+	er.cluster.AddOwnerRefTo(s)
+
+	key = client.ObjectKeyFromObject(s)
+	current, err := secret.Get(context.TODO(), er.client, key)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return kverrors.Wrap(err, "failed to get existing serviceaccount token secret for service monitor serviceaccount",
+				"cluster", dpl.Name,
+				"namespace", dpl.Namespace,
+			)
+		}
+	}
+
+	accountName := s.Annotations[corev1.ServiceAccountNameKey]
+	accountUID := s.Annotations[corev1.ServiceAccountUIDKey]
+	if accountName != sa.Name || accountUID != string(sa.UID) {
+		key = client.ObjectKeyFromObject(current)
+
+		if err := secret.Delete(context.TODO(), er.client, key); err != nil {
+			return kverrors.Wrap(err, "failed to delete stale serviceaccount token secret for service monitor serviceaccount",
+				"cluster", dpl.Name,
+				"namespace", dpl.Namespace,
+				"name", current.Name,
+				"uid", current.UID,
+			)
+		}
+	}
+
+	err = secret.CreateOrUpdate(context.TODO(), er.client, s, secret.AnnotationsAndDataEqual, secret.MutateAnnotationsAndDataOnly)
+	if err != nil {
+		return kverrors.Wrap(err, "failed to create or update serviceacccount token secret for service monitor serviceaccount",
 			"cluster", dpl.Name,
 			"namespace", dpl.Namespace,
 		)

--- a/internal/manifests/configmap/configmap.go
+++ b/internal/manifests/configmap/configmap.go
@@ -154,9 +154,21 @@ func LabelEqual(current, desired *corev1.ConfigMap) bool {
 	return equality.Semantic.DeepEqual(current.Labels, desired.Labels)
 }
 
+// AnnotationsEqual return only true if the configmaps have equal annotations sections only.
+func AnnotationsEqual(current, desired *corev1.ConfigMap) bool {
+	return equality.Semantic.DeepEqual(current.Annotations, desired.Annotations)
+}
+
 // MutateDataOnly is a default mutate function implementation
 // that copies only the data section from desired to current
 // configmap.
 func MutateDataOnly(current, desired *corev1.ConfigMap) {
 	current.Data = desired.Data
+}
+
+// MutateAnnotationsOnly is a default mutate function implementation
+// that copies only the annotations section from desired to current
+// configmap.
+func MutateAnnotationsOnly(current, desired *corev1.ConfigMap) {
+	current.Annotations = desired.Annotations
 }

--- a/internal/manifests/secret/secret.go
+++ b/internal/manifests/secret/secret.go
@@ -121,12 +121,40 @@ func CreateOrUpdate(ctx context.Context, c client.Client, s *corev1.Secret, equa
 	return nil
 }
 
+// Delete attempts to delete a k8s secret if existing or returns an error.
+func Delete(ctx context.Context, c client.Client, key client.ObjectKey) error {
+	s := New(key.Name, key.Namespace, nil)
+
+	if err := c.Delete(ctx, s, &client.DeleteOptions{}); err != nil {
+		return kverrors.Wrap(err, "failed to delete secret",
+			"name", s.Name,
+			"namespace", s.Namespace,
+		)
+	}
+
+	return nil
+}
+
+// AnnotationsAndDataEqual returns true if the annotations and data of the current
+// and desired are exactly same.
+func AnnotationsAndDataEqual(current, desired *corev1.Secret) bool {
+	return equality.Semantic.DeepEqual(current.Annotations, desired.Annotations) &&
+		equality.Semantic.DeepEqual(current.Data, desired.Data)
+}
+
 // DataEqual returns true only if the data of current and desird are exactly same.
 func DataEqual(current, desired *corev1.Secret) bool {
 	return equality.Semantic.DeepEqual(current.Data, desired.Data)
 }
 
-// MutateDataOnly is a default mutation function for services
+// MutateDataOnly is a  mutation function for secrets that copies
+// the annoations and data fields from desired to current.
+func MutateAnnotationsAndDataOnly(current, desired *corev1.Secret) {
+	current.Annotations = desired.Annotations
+	current.Data = desired.Data
+}
+
+// MutateDataOnly is a default mutation function for secrets
 // that copies only the data field from desired to current.
 func MutateDataOnly(current, desired *corev1.Secret) {
 	current.Data = desired.Data

--- a/internal/manifests/serviceaccount/serviceaccount.go
+++ b/internal/manifests/serviceaccount/serviceaccount.go
@@ -19,6 +19,20 @@ type EqualityFunc func(current, desired *corev1.ServiceAccount) bool
 // by applying the values from the desired serviceaccount.
 type MutateFunc func(current, desired *corev1.ServiceAccount)
 
+// Get returns the k8s serviceacount for the given object key or an error.
+func Get(ctx context.Context, c client.Client, key client.ObjectKey) (*corev1.ServiceAccount, error) {
+	s := New(key.Name, key.Namespace, map[string]string{})
+
+	if err := c.Get(ctx, key, s); err != nil {
+		return s, kverrors.Wrap(err, "failed to get serviceaccount",
+			"name", s.Name,
+			"namespace", s.Namespace,
+		)
+	}
+
+	return s, nil
+}
+
 // CreateOrUpdate attempts first to get the given serviceaccount. If the
 // serviceaccount does not exist, the serviceaccount will be created. Otherwise,
 // if the serviceaccount exists and the provided comparison func detects any changes

--- a/test/e2e/elasticsearch_metric_test.go
+++ b/test/e2e/elasticsearch_metric_test.go
@@ -206,8 +206,9 @@ func newClusterRole(t *testing.T, client client.Client, name string) {
 		},
 		Rules: []rbac.PolicyRule{
 			{
-				NonResourceURLs: []string{"/metrics"},
-				Verbs:           []string{"get"},
+				APIGroups: []string{"elasticsearch.openshift.io"},
+				Resources: []string{"metrics"},
+				Verbs:     []string{"get"},
 			},
 		},
 	}


### PR DESCRIPTION
### Description
For legacy reasons the elasticsearch-operator assumes that `Elasticsearch` and owned `ServiceMonitor` resources installed **only** on `openshift-` namespaces or those annotated with `openshift.io/cluster-monitoring: true`. In both case the cluster-monitoring stack takes responsibility to reconcile the `ServiceMonitor` resources for the cluster-monitoring Prometheus. In detail ServiceMonitor endpoints used the `prometheus-k8s`'s serviceaccount token to scrape metrics from elasticsearch and elasticsearch-proxy. This is the legacy and nowadays not-recommended practice that is still sustained in OCP's cluster-monitoring for compatibility reason (i.e. prometheus CR `ArbitraryFSAccessThroughSMsConfig.Deny: false`)

Moving forward in time with the addition of [User Workload Monitoring]() in OCP (since 4.8) the monitoring stack is amended by a second instance of prometheus-operator where `ArbitraryFSAccessThroughSMsConfig.Deny: true` is applied by default. In turn this means that the following fields in ServiceMonitor's are not allowed for use any more: 
- `Spec.Endpoints[].TLSConfig.CAFile`: Certificate Authority file for verifying server-side certificates when scraping metrics.
- `Spec.Endpoints[].BearerTokenFile`: Bearer Token file for authorizing against server-side when scraping metrics.

In summary this PR makes `ServiceMonitor` resources compliant with `ArbitraryFSAccessThroughSMsConfig.Deny: true` and in turn extends the support of monitoring Elasticsearch from cluster-monitoring only to cluster-monitoring and user-workload-monitoring. In detail the denied fields for `CAFile` and `BearerTokenFile` are replaced by:
- Instead of `CAFile` the endpoints use a local object reference to a configmap annotated with `service.beta.openshift.io/inject-cabundle: true`
- Instead of `BearerTokenFile` the endpoints use a local object reference to the serviceaccount token secret of the `elasticsearch-metrics` serviceaccount.

#### Notes for reviewer

To make the above settings work in parallel with cluster-monitoring (i.e. openshift-logging) and user-workload-monitoring (i.e. openshift distributed tracing platform), the PR changes the elasticsearch-proxy backend role mapping from using a cluster-scoped non-resource-url (i.e. `/metrics`) to a custom virtual namespace scoped resource (i.e. `elasticsearch.openshift.io/metrics`). This simplifies RBAC by providing for each stack a serviceaccount (`elasticsearch-metrics`) and a pair of Role/Rolebinding. 

/cc @xperimental 

/cherry-pick release-5.4

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2732
