### PR TITLE
LOG-2679: Fix Elasticsearch operator not respecting referencePolicy when selecting oauth-proxy image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,16 @@ deploy-image: image ## Push operator image to cluster registry.
 deploy-example: # Create an example Elasticsearch custom resource.
 	@oc create -n $(DEPLOYMENT_NAMESPACE) -f hack/cr.yaml
 
+.PHONY: deploy-kibana
+deploy-kibana: # Create an example Kibana custom resource.
+	@oc create -n $(DEPLOYMENT_NAMESPACE) -f hack/kibana-cr.yaml
+
+.PHONY: deploy-all
+deploy-all:
+	$(MAKE) deploy
+	$(MAKE) deploy-example
+	$(MAKE) deploy-kibana
+
 .PHONY: scale-cvo
 scale-cvo:
 	@oc -n openshift-cluster-version scale deployment/cluster-version-operator --replicas=$(REPLICAS)

--- a/Makefile
+++ b/Makefile
@@ -234,9 +234,7 @@ deploy-kibana: # Create an example Kibana custom resource.
 
 .PHONY: deploy-all
 deploy-all:
-	$(MAKE) deploy
-	$(MAKE) deploy-example
-	$(MAKE) deploy-kibana
+	$(MAKE) deploy deploy-example deploy-kibana
 
 .PHONY: scale-cvo
 scale-cvo:

--- a/internal/kibana/kibana_test.go
+++ b/internal/kibana/kibana_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/openshift/elasticsearch-operator/internal/elasticsearch/esclient"
 	"github.com/openshift/elasticsearch-operator/test/helpers"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -305,18 +304,18 @@ var _ = Describe("Reconciling", func() {
 				Expect(dpl.Spec.Template.Spec.Containers[1].VolumeMounts).To(ContainElement(trustedCABundleVolumeMount))
 			})
 
-			It("should create a deployment with the correct kibana proxy image", func() {
+			It("should create a deployment with the source kibana proxy image", func() {
 				Expect(Reconcile(logger, cluster, client, esClient, proxy, false, metav1.OwnerReference{})).Should(Succeed())
 
 				key := types.NamespacedName{Name: "kibana", Namespace: cluster.GetNamespace()}
-				depl := &v1.Deployment{}
+				depl := &appsv1.Deployment{}
 
 				err := client.Get(context.TODO(), key, depl)
 				Expect(err).To(BeNil())
 				Expect(depl.Spec.Template.Spec.Containers[1].Image).To(Equal(proxySourceImage.Status.Tags[0].Items[0].DockerImageReference))
 			})
 
-			It("should create a deployment with the correct kibana proxy image", func() {
+			It("should create a deployment with the local kibana proxy image", func() {
 				client = fake.NewFakeClient(
 					cluster,
 					kibanaCABundle,
@@ -329,7 +328,7 @@ var _ = Describe("Reconciling", func() {
 				Expect(Reconcile(logger, cluster, client, esClient, proxy, false, metav1.OwnerReference{})).Should(Succeed())
 
 				key := types.NamespacedName{Name: "kibana", Namespace: cluster.GetNamespace()}
-				depl := &v1.Deployment{}
+				depl := &appsv1.Deployment{}
 
 				err := client.Get(context.TODO(), key, depl)
 				Expect(err).To(BeNil())

--- a/internal/kibana/kibana_test.go
+++ b/internal/kibana/kibana_test.go
@@ -2,6 +2,7 @@ package kibana
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ViaQ/logerr/v2/log"
 	. "github.com/onsi/ginkgo"
@@ -15,6 +16,7 @@ import (
 	"github.com/openshift/elasticsearch-operator/internal/elasticsearch/esclient"
 	"github.com/openshift/elasticsearch-operator/test/helpers"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -85,10 +87,44 @@ var _ = Describe("Reconciling", func() {
 				},
 			},
 		}
-		proxyImage = &imagev1.ImageStream{
+		proxySourceImage = &imagev1.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "oauth-proxy",
 				Namespace: "openshift",
+			},
+			Spec: imagev1.ImageStreamSpec{
+				Tags: []imagev1.TagReference{
+					{
+						Name:            "v4.4",
+						ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.SourceTagReferencePolicy},
+					},
+				},
+			},
+			Status: imagev1.ImageStreamStatus{
+				Tags: []imagev1.NamedTagEventList{
+					{
+						Tag: "v4.4",
+						Items: []imagev1.TagEvent{
+							{
+								DockerImageReference: "image-ref",
+							},
+						},
+					},
+				},
+			},
+		}
+		proxyLocalImage = &imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oauth-proxy",
+				Namespace: "openshift",
+			},
+			Spec: imagev1.ImageStreamSpec{
+				Tags: []imagev1.TagReference{
+					{
+						Name:            "v4.4",
+						ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},
+					},
+				},
 			},
 			Status: imagev1.ImageStreamStatus{
 				DockerImageRepository: "image-registry",
@@ -163,7 +199,7 @@ var _ = Describe("Reconciling", func() {
 					kibanaCABundle,
 					kibanaSecret,
 					kibanaProxySecret,
-					proxyImage,
+					proxySourceImage,
 				)
 				esClient = newFakeEsClient(client, fakeResponses)
 			})
@@ -219,7 +255,7 @@ var _ = Describe("Reconciling", func() {
 					kibanaCABundle,
 					kibanaSecret,
 					kibanaProxySecret,
-					proxyImage,
+					proxySourceImage,
 				)
 				esClient = newFakeEsClient(client, fakeResponses)
 			})
@@ -268,6 +304,38 @@ var _ = Describe("Reconciling", func() {
 				Expect(dpl.Spec.Template.Spec.Volumes).To(ContainElement(trustedCABundleVolume))
 				Expect(dpl.Spec.Template.Spec.Containers[1].VolumeMounts).To(ContainElement(trustedCABundleVolumeMount))
 			})
+
+			It("should create a deployment with the correct kibana proxy image", func() {
+				Expect(Reconcile(logger, cluster, client, esClient, proxy, false, metav1.OwnerReference{})).Should(Succeed())
+
+				key := types.NamespacedName{Name: "kibana", Namespace: cluster.GetNamespace()}
+				depl := &v1.Deployment{}
+
+				err := client.Get(context.TODO(), key, depl)
+				Expect(err).To(BeNil())
+				Expect(depl.Spec.Template.Spec.Containers[1].Image).To(Equal(proxySourceImage.Status.Tags[0].Items[0].DockerImageReference))
+			})
+
+			It("should create a deployment with the correct kibana proxy image", func() {
+				client = fake.NewFakeClient(
+					cluster,
+					kibanaCABundle,
+					kibanaSecret,
+					kibanaProxySecret,
+					proxyLocalImage,
+				)
+				esClient = newFakeEsClient(client, fakeResponses)
+
+				Expect(Reconcile(logger, cluster, client, esClient, proxy, false, metav1.OwnerReference{})).Should(Succeed())
+
+				key := types.NamespacedName{Name: "kibana", Namespace: cluster.GetNamespace()}
+				depl := &v1.Deployment{}
+
+				err := client.Get(context.TODO(), key, depl)
+				Expect(err).To(BeNil())
+				Expect(depl.Spec.Template.Spec.Containers[1].Image).To(Equal(fmt.Sprintf("%s@%s", proxyLocalImage.Status.DockerImageRepository, proxyLocalImage.Status.Tags[0].Items[0].Image)))
+			})
+
 		})
 	})
 })

--- a/internal/kibana/reconciler.go
+++ b/internal/kibana/reconciler.go
@@ -466,14 +466,8 @@ func getProxyImage(ctx context.Context, c client.Client) (string, error) {
 	tagItem := tag.Items[0]
 
 	policy := findTagReferencePolicy(is.Spec.Tags, oauthProxyTag)
-	if policy == nil {
-		return "", kverrors.New("ImageStream TagReferencePolicy not found",
-			"name", key.Name,
-			"namespace", key.Namespace,
-			"tag", oauthProxyTag)
-	}
 
-	switch policy.Type {
+	switch policy {
 	case imagev1.SourceTagReferencePolicy:
 		return tagItem.DockerImageReference, nil
 	case imagev1.LocalTagReferencePolicy:
@@ -482,7 +476,7 @@ func getProxyImage(ctx context.Context, c client.Client) (string, error) {
 		return "", kverrors.New("Unknown TagReferencePolicy type",
 			"name", key.Name,
 			"namespace", key.Namespace,
-			"policy", policy.Type,
+			"policy", policy,
 			"tag", oauthProxyTag)
 	}
 }
@@ -497,14 +491,14 @@ func findImageStreamStatusTag(tags []imagev1.NamedTagEventList, name string) *im
 	return nil
 }
 
-func findTagReferencePolicy(tags []imagev1.TagReference, name string) *imagev1.TagReferencePolicy {
+func findTagReferencePolicy(tags []imagev1.TagReference, name string) imagev1.TagReferencePolicyType {
 	for _, t := range tags {
 		if t.Name == name {
-			return &t.ReferencePolicy
+			return t.ReferencePolicy.Type
 		}
 	}
 
-	return nil
+	return ""
 }
 
 func newKibanaPodSpec(cluster *KibanaRequest, elasticsearchName string, proxyConfig *configv1.Proxy,

--- a/internal/kibana/reconciler.go
+++ b/internal/kibana/reconciler.go
@@ -473,13 +473,11 @@ func getProxyImage(ctx context.Context, c client.Client) (string, error) {
 			"tag", oauthProxyTag)
 	}
 
-	var image string
-
 	switch policy.Type {
 	case imagev1.SourceTagReferencePolicy:
-		image = tagItem.DockerImageReference
+		return tagItem.DockerImageReference, nil
 	case imagev1.LocalTagReferencePolicy:
-		image = fmt.Sprintf("%s@%s", is.Status.DockerImageRepository, tagItem.Image)
+		return fmt.Sprintf("%s@%s", is.Status.DockerImageRepository, tagItem.Image), nil
 	default:
 		return "", kverrors.New("Unknown TagReferencePolicy type",
 			"name", key.Name,
@@ -487,8 +485,6 @@ func getProxyImage(ctx context.Context, c client.Client) (string, error) {
 			"policy", policy.Type,
 			"tag", oauthProxyTag)
 	}
-
-	return image, nil
 }
 
 func findImageStreamStatusTag(tags []imagev1.NamedTagEventList, name string) *imagev1.NamedTagEventList {


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
The operator uses the ImageStream`openshift/oauth-proxy` to select an image to use for the proxy used in the Kibana deployment.
This PR updates the logic used in selecting the right image for the right context, by including [referencePolicy](https://docs.openshift.com/container-platform/4.10/rest_api/image_apis/imagestream-image-openshift-io-v1.html#spec-tags-referencepolicy) in the decision making.

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: [LOG-2679](https://issues.redhat.com/browse/LOG-2764)
