### PR TITLE
LOG-2737: Add security context to operands

### DIFF
--- a/internal/elasticsearch/common.go
+++ b/internal/elasticsearch/common.go
@@ -184,10 +184,8 @@ func newElasticsearchContainer(imageName string, envVars []v1.EnvVar, resourceRe
 				MountPath: elasticsearchCertsPath,
 			},
 		},
-		Resources: resourceRequirements,
-		SecurityContext: &v1.SecurityContext{
-			AllowPrivilegeEscalation: pointer.BoolPtr(false),
-		},
+		Resources:       resourceRequirements,
+		SecurityContext: utils.ContainerSecurityContext(),
 	}
 }
 
@@ -248,12 +246,12 @@ func newProxyContainer(imageName, clusterName, namespace string, logConfig LogCo
 			"--auth-admin-role=admin_reader",
 			"--auth-default-role=project_user",
 		},
-		Resources: resourceRequirements,
-		SecurityContext: &v1.SecurityContext{
-			ReadOnlyRootFilesystem:   pointer.BoolPtr(true),
-			AllowPrivilegeEscalation: pointer.BoolPtr(false),
-		},
+		Resources:       resourceRequirements,
+		SecurityContext: utils.ContainerSecurityContext(),
 	}
+
+	container.SecurityContext.ReadOnlyRootFilesystem = pointer.BoolPtr(true)
+
 	return container
 }
 
@@ -384,6 +382,7 @@ func newPodTemplateSpec(ctx context.Context, logger logr.Logger, nodeName, clust
 		WithAffinity(newAffinity(roleMap)).
 		WithNodeSelectors(selectors).
 		WithTolerations(tolerations...).
+		WithSecurityContext(utils.PodSecurityContext()).
 		Build()
 
 	return v1.PodTemplateSpec{

--- a/internal/indexmanagement/reconcile.go
+++ b/internal/indexmanagement/reconcile.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openshift/elasticsearch-operator/internal/manifests/rbac"
 	"github.com/openshift/elasticsearch-operator/internal/metrics"
 	esapi "github.com/openshift/elasticsearch-operator/internal/types/elasticsearch"
+	"github.com/openshift/elasticsearch-operator/internal/utils"
 	"github.com/openshift/elasticsearch-operator/internal/utils/comparators"
 )
 
@@ -532,6 +533,7 @@ func newContainer(clusterName, name, image, scriptPath string, envvars []corev1.
 			{Name: "certs", ReadOnly: true, MountPath: "/etc/indexmanagement/keys"},
 			{Name: "scripts", ReadOnly: false, MountPath: workingDir},
 		},
+		SecurityContext: utils.ContainerSecurityContext(),
 	}
 
 	return container
@@ -570,6 +572,7 @@ func newCronJob(clusterName, namespace, name, schedule, script string, nodeSelec
 		WithRestartPolicy(corev1.RestartPolicyNever).
 		WithRestartPolicy(corev1.RestartPolicyNever).
 		WithTerminationGracePeriodSeconds(300 * time.Second).
+		WithSecurityContext(utils.PodSecurityContext()).
 		Build()
 
 	return cronjob.New(name, namespace, imLabels).

--- a/internal/kibana/kibana_test.go
+++ b/internal/kibana/kibana_test.go
@@ -334,7 +334,6 @@ var _ = Describe("Reconciling", func() {
 				Expect(err).To(BeNil())
 				Expect(depl.Spec.Template.Spec.Containers[1].Image).To(Equal(fmt.Sprintf("%s@%s", proxyLocalImage.Status.DockerImageRepository, proxyLocalImage.Status.Tags[0].Items[0].Image)))
 			})
-
 		})
 	})
 })

--- a/internal/kibana/reconciler.go
+++ b/internal/kibana/reconciler.go
@@ -655,6 +655,7 @@ func newKibanaPodSpec(cluster *KibanaRequest, elasticsearchName string, proxyCon
 	).
 		WithNodeSelectors(visSpec.NodeSelector).
 		WithTolerations(visSpec.Tolerations...).
+		WithSecurityContext(utils.PodSecurityContext()).
 		Build()
 
 	if addTrustedCAVolume {
@@ -719,5 +720,6 @@ func NewContainer(containerName string, imageName string, pullPolicy v1.PullPoli
 		Image:           imageName,
 		ImagePullPolicy: pullPolicy,
 		Resources:       resources,
+		SecurityContext: utils.ContainerSecurityContext(),
 	}
 }

--- a/internal/manifests/pod/build.go
+++ b/internal/manifests/pod/build.go
@@ -61,3 +61,9 @@ func (b *Builder) WithTerminationGracePeriodSeconds(p time.Duration) *Builder {
 	b.spec.TerminationGracePeriodSeconds = &d
 	return b
 }
+
+// WithSecurityContext sets the security context for the podspec
+func (b *Builder) WithSecurityContext(sc corev1.PodSecurityContext) *Builder {
+	b.spec.SecurityContext = &sc
+	return b
+}


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR adds security contexts to ES operands' pods and containers, so as to be compliant with the [PSA](https://kubernetes.io/docs/concepts/security/pod-security-admission/)'s `restricted` policy

/cc @xperimental 
/assign @periklis 

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->

- JIRA: [LOG-2737](https://issues.redhat.com/browse/LOG-2737)

