### PR TITLE
LOG-2661: Remove CA certificate from Kibana Route

### DIFF
--- a/internal/kibana/route.go
+++ b/internal/kibana/route.go
@@ -58,7 +58,6 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaRoute() error {
 			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 			DestinationCACertificate:      string(caCert),
 		}).
-		//WithCA(caCert).
 		Build()
 
 	utils.AddOwnerRefToObject(rt, getOwnerRef(cluster))

--- a/internal/kibana/route.go
+++ b/internal/kibana/route.go
@@ -56,8 +56,9 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaRoute() error {
 		WithTLSConfig(&routev1.TLSConfig{
 			Termination:                   routev1.TLSTerminationReencrypt,
 			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+			DestinationCACertificate:      string(caCert),
 		}).
-		WithCA(caCert).
+		//WithCA(caCert).
 		Build()
 
 	utils.AddOwnerRefToObject(rt, getOwnerRef(cluster))


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR removes the CA certificate from the Kibana Route as it seems unnecessary. This change comes as a result of the following user reported issue [LOG-2661](https://issues.redhat.com/browse/LOG-2661)



/cc @xperimental  
/assign @periklis 



### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->

- JIRA: [LOG-2661](https://issues.redhat.com/browse/LOG-2661)
