### PR TITLE
LOG-2924: Adding valid subscription annotation to metadata

### DIFF
--- a/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
@@ -116,6 +116,8 @@ metadata:
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
+      Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     support: AOS Cluster Logging, Jaeger

--- a/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
@@ -102,6 +102,8 @@ metadata:
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
+      Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     support: AOS Cluster Logging, Jaeger


### PR DESCRIPTION
### Description
This PR adds the `operators.openshift.io/valid-subscription` annotation to the operator metadata.

/cc @xperimental 
/assign @periklis 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2924
