### PR TITLE
Clean up ConsoleExternalLogLink when Kibana resource is deleted

### DIFF
--- a/controllers/logging/kibana_controller.go
+++ b/controllers/logging/kibana_controller.go
@@ -27,6 +27,7 @@ import (
 
 	loggingv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
 	"github.com/openshift/elasticsearch-operator/internal/constants"
+	"github.com/openshift/elasticsearch-operator/internal/manifests/console"
 
 	"github.com/openshift/elasticsearch-operator/internal/elasticsearch"
 	"github.com/openshift/elasticsearch-operator/internal/elasticsearch/esclient"
@@ -67,6 +68,9 @@ func (r *KibanaReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		if errors.IsNotFound(err) {
 			// the CR no longer exists, since it will be cleaned up by the scheduler we don't want to trigger an event for it
 			unregisterKibanaNamespacedName(r.Log, request)
+			if err := console.DeleteConsoleExternalLogLink(context.TODO(), r.Client); err != nil {
+				r.Log.Error(err, "failed to delete consoleexternalloglink")
+			}
 			return reconcile.Result{}, nil
 		}
 

--- a/controllers/logging/kibana_controller.go
+++ b/controllers/logging/kibana_controller.go
@@ -63,12 +63,12 @@ func (r *KibanaReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		Namespace: request.Namespace,
 	}
 
-	err := r.Get(context.TODO(), key, kibanaInstance)
+	err := r.Get(ctx, key, kibanaInstance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// the CR no longer exists, since it will be cleaned up by the scheduler we don't want to trigger an event for it
 			unregisterKibanaNamespacedName(r.Log, request)
-			if err := console.DeleteConsoleExternalLogLink(context.TODO(), r.Client); err != nil {
+			if err := console.DeleteConsoleExternalLogLink(ctx, r.Client); err != nil {
 				r.Log.Error(err, "failed to delete consoleexternalloglink")
 			}
 			return reconcile.Result{}, nil

--- a/internal/kibana/route.go
+++ b/internal/kibana/route.go
@@ -108,7 +108,6 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaConsoleExternalLogLink(
 	}
 
 	consoleExternalLogLink := console.NewConsoleExternalLogLink(
-		console.ConsoleExternalLogLinkName,
 		"Show in Kibana",
 		strings.Join([]string{
 			kibanaURL,

--- a/internal/kibana/route.go
+++ b/internal/kibana/route.go
@@ -108,7 +108,7 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaConsoleExternalLogLink(
 	}
 
 	consoleExternalLogLink := console.NewConsoleExternalLogLink(
-		"kibana",
+		console.ConsoleExternalLogLinkName,
 		"Show in Kibana",
 		strings.Join([]string{
 			kibanaURL,

--- a/internal/manifests/console/build.go
+++ b/internal/manifests/console/build.go
@@ -27,14 +27,14 @@ func NewConsoleLink(name, href, text, icon, section string) *consolev1.ConsoleLi
 }
 
 // NewConsoleExternalLogLink returns a new opensnfhit api ConsoleExternalLogLink
-func NewConsoleExternalLogLink(resourceName, consoleText, hrefTemplate string, labels map[string]string) *consolev1.ConsoleExternalLogLink {
+func NewConsoleExternalLogLink(consoleText, hrefTemplate string, labels map[string]string) *consolev1.ConsoleExternalLogLink {
 	return &consolev1.ConsoleExternalLogLink{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConsoleExternalLogLink",
 			APIVersion: consolev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   resourceName,
+			Name:   consoleExternalLogLinkName,
 			Labels: labels,
 		},
 		Spec: consolev1.ConsoleExternalLogLinkSpec{

--- a/internal/manifests/console/consoleexternalloglink.go
+++ b/internal/manifests/console/consoleexternalloglink.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ViaQ/logerr/v2/kverrors"
 	consolev1 "github.com/openshift/api/console/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -93,13 +94,10 @@ func MutateConsoleExternalLogLink(current, desired *consolev1.ConsoleExternalLog
 }
 
 func DeleteConsoleExternalLogLink(ctx context.Context, c client.Client) error {
-	current := &consolev1.ConsoleExternalLogLink{}
-	key := client.ObjectKey{Name: ConsoleExternalLogLinkName}
-	err := c.Get(ctx, key, current)
-	if err != nil {
-		return kverrors.Wrap(err, "failed to get consoleexternalloglink",
-			"name", ConsoleExternalLogLinkName,
-		)
+	current := &consolev1.ConsoleExternalLogLink{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ConsoleExternalLogLinkName,
+		},
 	}
 
 	if err := c.Delete(ctx, current); err != nil {

--- a/internal/manifests/console/consoleexternalloglink.go
+++ b/internal/manifests/console/consoleexternalloglink.go
@@ -19,7 +19,7 @@ type ConsoleExternalLogLinkEqualityFunc func(current, desired *consolev1.Console
 // by applying the values from the desired consoleexternalloglink.
 type MutateConsoleExternalLogLinkFunc func(current, desired *consolev1.ConsoleExternalLogLink)
 
-const ConsoleExternalLogLinkName = "kibana"
+const consoleExternalLogLinkName = "kibana"
 
 // CreateOrUpdateConsoleExternalLogLink attempts first to get the given consoleexternalloglink. If the
 // consoleexternalloglink does not exist, the consoleexternalloglink will be created. Otherwise,
@@ -96,14 +96,14 @@ func MutateConsoleExternalLogLink(current, desired *consolev1.ConsoleExternalLog
 func DeleteConsoleExternalLogLink(ctx context.Context, c client.Client) error {
 	current := &consolev1.ConsoleExternalLogLink{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: ConsoleExternalLogLinkName,
+			Name: consoleExternalLogLinkName,
 		},
 	}
 
 	if err := c.Delete(ctx, current); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return kverrors.Wrap(err, "failed to delete consoleexternalloglink",
-				"name", ConsoleExternalLogLinkName,
+				"name", consoleExternalLogLinkName,
 			)
 		}
 	}

--- a/internal/manifests/console/consoleexternalloglink.go
+++ b/internal/manifests/console/consoleexternalloglink.go
@@ -18,6 +18,8 @@ type ConsoleExternalLogLinkEqualityFunc func(current, desired *consolev1.Console
 // by applying the values from the desired consoleexternalloglink.
 type MutateConsoleExternalLogLinkFunc func(current, desired *consolev1.ConsoleExternalLogLink)
 
+const ConsoleExternalLogLinkName = "kibana"
+
 // CreateOrUpdateConsoleExternalLogLink attempts first to get the given consoleexternalloglink. If the
 // consoleexternalloglink does not exist, the consoleexternalloglink will be created. Otherwise,
 // if the consoleexternalloglink exists and the provided comparison func detects any changes
@@ -88,4 +90,25 @@ func ConsoleExternalLogLinkEqual(current, desired *consolev1.ConsoleExternalLogL
 func MutateConsoleExternalLogLink(current, desired *consolev1.ConsoleExternalLogLink) {
 	current.Spec.HrefTemplate = desired.Spec.HrefTemplate
 	current.Spec.Text = desired.Spec.Text
+}
+
+func DeleteConsoleExternalLogLink(ctx context.Context, c client.Client) error {
+	current := &consolev1.ConsoleExternalLogLink{}
+	key := client.ObjectKey{Name: ConsoleExternalLogLinkName}
+	err := c.Get(ctx, key, current)
+	if err != nil {
+		return kverrors.Wrap(err, "failed to get consoleexternalloglink",
+			"name", ConsoleExternalLogLinkName,
+		)
+	}
+
+	if err := c.Delete(ctx, current); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return kverrors.Wrap(err, "failed to delete consoleexternalloglink",
+				"name", ConsoleExternalLogLinkName,
+			)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR adds a manual deletion of the `consoleexternalloglinks.console.openshift.io/kibana` resource when the `Kibana` resource is deleted.

/cc @periklis 
/assign @xperimental 


### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-2993
