### PR TITLE
Add missing owner for ca bundle configmap

### DIFF
--- a/internal/elasticsearch/configmaps.go
+++ b/internal/elasticsearch/configmaps.go
@@ -93,6 +93,8 @@ func (er *ElasticsearchRequest) CreateOrUpdateConfigMaps() error {
 		"service.beta.openshift.io/inject-cabundle": "true",
 	}
 
+	dpl.AddOwnerRefTo(cm)
+
 	_, err = configmap.CreateOrUpdate(context.TODO(), er.client, cm, configmap.AnnotationsEqual, configmap.MutateAnnotationsOnly)
 	if err != nil {
 		return kverrors.Wrap(err, "failed to create or update elasticsearch ca-bundle configmap",


### PR DESCRIPTION
### Description
Small amendment to #903 to allow deleting the configmap when ES CR gets deleted

/cc @xperimental 

/cherry-pick release-5.4
