### PR TITLE
[release-5.5] Clean up ConsoleExternalLogLink when Kibana resource is deleted

### DIFF
--- a/controllers/logging/kibana_controller.go
+++ b/controllers/logging/kibana_controller.go
@@ -27,6 +27,7 @@ import (
 
 	loggingv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
 	"github.com/openshift/elasticsearch-operator/internal/constants"
+	"github.com/openshift/elasticsearch-operator/internal/manifests/console"
 
 	"github.com/openshift/elasticsearch-operator/internal/elasticsearch"
 	"github.com/openshift/elasticsearch-operator/internal/elasticsearch/esclient"
@@ -62,11 +63,14 @@ func (r *KibanaReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		Namespace: request.Namespace,
 	}
 
-	err := r.Get(context.TODO(), key, kibanaInstance)
+	err := r.Get(ctx, key, kibanaInstance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// the CR no longer exists, since it will be cleaned up by the scheduler we don't want to trigger an event for it
 			unregisterKibanaNamespacedName(r.Log, request)
+			if err := console.DeleteConsoleExternalLogLink(ctx, r.Client); err != nil {
+				r.Log.Error(err, "failed to delete consoleexternalloglink")
+			}
 			return reconcile.Result{}, nil
 		}
 

--- a/internal/kibana/route.go
+++ b/internal/kibana/route.go
@@ -108,7 +108,6 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaConsoleExternalLogLink(
 	}
 
 	consoleExternalLogLink := console.NewConsoleExternalLogLink(
-		"kibana",
 		"Show in Kibana",
 		strings.Join([]string{
 			kibanaURL,

--- a/internal/manifests/console/build.go
+++ b/internal/manifests/console/build.go
@@ -27,14 +27,14 @@ func NewConsoleLink(name, href, text, icon, section string) *consolev1.ConsoleLi
 }
 
 // NewConsoleExternalLogLink returns a new opensnfhit api ConsoleExternalLogLink
-func NewConsoleExternalLogLink(resourceName, consoleText, hrefTemplate string, labels map[string]string) *consolev1.ConsoleExternalLogLink {
+func NewConsoleExternalLogLink(consoleText, hrefTemplate string, labels map[string]string) *consolev1.ConsoleExternalLogLink {
 	return &consolev1.ConsoleExternalLogLink{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConsoleExternalLogLink",
 			APIVersion: consolev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   resourceName,
+			Name:   consoleExternalLogLinkName,
 			Labels: labels,
 		},
 		Spec: consolev1.ConsoleExternalLogLinkSpec{


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

Manual backport of #936  

/cc @periklis 



### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->

- JIRA: [LOG-3053](https://issues.redhat.com/browse/LOG-3053)

