### PR TITLE
LOG-3161: Do not overwrite token secret data

### DIFF
--- a/internal/elasticsearch/serviceaccount.go
+++ b/internal/elasticsearch/serviceaccount.go
@@ -94,7 +94,7 @@ func (er *ElasticsearchRequest) CreateOrUpdateServiceAccountTokenSecret() error 
 		}
 	}
 
-	err = secret.CreateOrUpdate(context.TODO(), er.client, s, secret.AnnotationsAndDataEqual, secret.MutateAnnotationsAndDataOnly)
+	err = secret.CreateOrUpdate(context.TODO(), er.client, s, secret.AnnotationsEqual, secret.MutateAnnotationsOnly)
 	if err != nil {
 		return kverrors.Wrap(err, "failed to create or update serviceacccount token secret for service monitor serviceaccount",
 			"cluster", dpl.Name,

--- a/internal/manifests/secret/secret.go
+++ b/internal/manifests/secret/secret.go
@@ -135,23 +135,20 @@ func Delete(ctx context.Context, c client.Client, key client.ObjectKey) error {
 	return nil
 }
 
-// AnnotationsAndDataEqual returns true if the annotations and data of the current
-// and desired are exactly same.
-func AnnotationsAndDataEqual(current, desired *corev1.Secret) bool {
-	return equality.Semantic.DeepEqual(current.Annotations, desired.Annotations) &&
-		equality.Semantic.DeepEqual(current.Data, desired.Data)
+// AnnotationsEqual returns true if the annotations of the two resources are the same.
+func AnnotationsEqual(current, desired *corev1.Secret) bool {
+	return equality.Semantic.DeepEqual(current.Annotations, desired.Annotations)
 }
 
-// DataEqual returns true only if the data of current and desird are exactly same.
+// DataEqual returns true only if the data of current and desired are exactly same.
 func DataEqual(current, desired *corev1.Secret) bool {
 	return equality.Semantic.DeepEqual(current.Data, desired.Data)
 }
 
-// MutateDataOnly is a  mutation function for secrets that copies
-// the annoations and data fields from desired to current.
-func MutateAnnotationsAndDataOnly(current, desired *corev1.Secret) {
+// MutateAnnotationsOnly is a mutation function for secrets that
+// only copies the annotations from desired to current.
+func MutateAnnotationsOnly(current, desired *corev1.Secret) {
 	current.Annotations = desired.Annotations
-	current.Data = desired.Data
 }
 
 // MutateDataOnly is a default mutation function for secrets


### PR DESCRIPTION
### Description

The reconciliation for the `elasticsearch-metrics-token` secret currently overwrites both annotations and data for the secret. Because the secret data is not generated by the operator but by Kubernetes itself, this results in the operator deleting the data and Kubernetes adding the data again in an endless cycle (approximately 1Hz :wink:).

This PR updates the reconciliation code to only look at the annotations of the secret.

This is a port of #946 .

### Links

- JIRA: [LOG-3161](https://issues.redhat.com//browse/LOG-3161)
