### PR TITLE
LOG-3148: Update to Go 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ### This is a generated file from Dockerfile.in ###
-#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.18)
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS builder
-
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.19)
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,6 @@
 ### This is a generated file from Dockerfile.in ###
-#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.18)
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
-
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.19)
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12 AS builder
 
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,6 +1,5 @@
-#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.18)
-FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.17.5-202202101345.el8.gb1a57e0 AS builder
-
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.19)
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.19.1-202210051256.el8.g8ad7c79 AS builder
 
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}

--- a/dev-meta.yaml
+++ b/dev-meta.yaml
@@ -1,6 +1,6 @@
 from:
 - source: registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder\:v(?:[\.0-9\-]*).*
-  target: registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
+  target: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12 AS builder
 - source: registry.redhat.io/ubi8:8.(\d)-([\.0-9])*
   target: docker.io/centos:8 AS centos
 env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/elasticsearch-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/ViaQ/logerr/v2 v2.0.0

--- a/origin-meta.yaml
+++ b/origin-meta.yaml
@@ -1,6 +1,6 @@
 from:
 - source: registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder\:v(?:[\.0-9\-]*).*
-  target: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS builder
+  target: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 - source: registry.redhat.io/ubi8:8.(\d)-([\.0-9])*
   target: registry.ci.openshift.org/ocp/4.8:base
 env:


### PR DESCRIPTION
### Description

Updates Go version used for building to 1.19.

Not really sure about the different image repository used for `Dockerfile` (`registry.ci.openshift.org/ocp/builder`) and `Dockerfile.dev` (`registry.ci.openshift.org/openshift/release`). The images seem to be different as well.

### Links

- JIRA: [LOG-3148](https://issues.redhat.com//browse/LOG-3148)
