### PR TITLE
Upgrade operator-sdk to v1.24.1

### DIFF
--- a/.bingo/Variables.mk
+++ b/.bingo/Variables.mk
@@ -65,11 +65,11 @@ $(KUSTOMIZE): $(BINGO_DIR)/kustomize.mod
 	@echo "(re)installing $(GOBIN)/kustomize-v4.5.7"
 	@cd $(BINGO_DIR) && $(GO) build -mod=mod -modfile=kustomize.mod -o=$(GOBIN)/kustomize-v4.5.7 "sigs.k8s.io/kustomize/kustomize/v4"
 
-OPERATOR_SDK := $(GOBIN)/operator-sdk-v1.24.0
+OPERATOR_SDK := $(GOBIN)/operator-sdk-v1.24.1
 $(OPERATOR_SDK): $(BINGO_DIR)/operator-sdk.mod
 	@# Install binary/ries using Go 1.14+ build command. This is using bwplotka/bingo-controlled, separate go module with pinned dependencies.
-	@echo "(re)installing $(GOBIN)/operator-sdk-v1.24.0"
-	@cd $(BINGO_DIR) && $(GO) build -mod=mod -modfile=operator-sdk.mod -o=$(GOBIN)/operator-sdk-v1.24.0 "github.com/operator-framework/operator-sdk/cmd/operator-sdk"
+	@echo "(re)installing $(GOBIN)/operator-sdk-v1.24.1"
+	@cd $(BINGO_DIR) && $(GO) build -mod=mod -modfile=operator-sdk.mod -o=$(GOBIN)/operator-sdk-v1.24.1 "github.com/operator-framework/operator-sdk/cmd/operator-sdk"
 
 OPM := $(GOBIN)/opm-v1.23.0
 $(OPM): $(BINGO_DIR)/opm.mod

--- a/.bingo/operator-sdk.mod
+++ b/.bingo/operator-sdk.mod
@@ -8,4 +8,4 @@ replace github.com/docker/distribution => github.com/docker/distribution v0.0.0-
 
 replace github.com/mattn/go-sqlite3 => github.com/mattn/go-sqlite3 v1.10.0
 
-require github.com/operator-framework/operator-sdk v1.24.0 // cmd/operator-sdk
+require github.com/operator-framework/operator-sdk v1.24.1 // cmd/operator-sdk

--- a/.bingo/operator-sdk.sum
+++ b/.bingo/operator-sdk.sum
@@ -170,6 +170,8 @@ github.com/operator-framework/operator-sdk v1.23.0 h1:pn8cBzkqdjT6RaPtn/umBcJiYg
 github.com/operator-framework/operator-sdk v1.23.0/go.mod h1:4cHbH4YwFNXKEa/LzwhC3VjoCKJ381xctIpSdq61ZZM=
 github.com/operator-framework/operator-sdk v1.24.0 h1:TolUfgiamUrznCfP5m+88Wj8Bq/TgVq1qtQyN47q+7Y=
 github.com/operator-framework/operator-sdk v1.24.0/go.mod h1:ABeI+hU/bPfO1u09f7Vranx5GHcwdFnAa21IZjTTKxo=
+github.com/operator-framework/operator-sdk v1.24.1 h1:exm5snGUOPSysHF0z1p/APrTn/Fl0kfzIl4/NPfP12s=
+github.com/operator-framework/operator-sdk v1.24.1/go.mod h1:ABeI+hU/bPfO1u09f7Vranx5GHcwdFnAa21IZjTTKxo=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=

--- a/.bingo/variables.env
+++ b/.bingo/variables.env
@@ -24,7 +24,7 @@ JUNITREPORT="${GOBIN}/junitreport-v0.0.0-20201103082000-d8009dcf7503"
 
 KUSTOMIZE="${GOBIN}/kustomize-v4.5.7"
 
-OPERATOR_SDK="${GOBIN}/operator-sdk-v1.24.0"
+OPERATOR_SDK="${GOBIN}/operator-sdk-v1.24.1"
 
 OPM="${GOBIN}/opm-v1.23.0"
 


### PR DESCRIPTION
### Description
Upgrade local tool operator-sdk to v1.24.1 to fix `make olm-deploy` install the temporary registry on OCP 4.12 with restricted PSA applied.

/cc @xperimental 
