### PR TITLE
LOG-3129: Fix kibana oauth cookie expiration issue

### DIFF
--- a/apis/logging/v1/groupversion_info.go
+++ b/apis/logging/v1/groupversion_info.go
@@ -32,7 +32,7 @@ var (
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews;subjectaccessreviews,verbs=create
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=*
-// +kubebuilder:rbac:groups=config.openshift.io,resources=proxies,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=proxies;oauths,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete
 // +kubebuilder:rbac:groups=apps,resourceNames=elasticsearch-operator,resources=deployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update

--- a/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
@@ -362,6 +362,7 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - oauths
           - proxies
           verbs:
           - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -48,6 +48,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - oauths
   - proxies
   verbs:
   - get

--- a/controllers/logging/kibana_controller.go
+++ b/controllers/logging/kibana_controller.go
@@ -295,6 +295,14 @@ func (r *KibanaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
 
+	// Watch for updates to the global oauth config only
+	oauthPred := predicate.Funcs{
+		UpdateFunc:  func(e event.UpdateEvent) bool { return true },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
+		CreateFunc:  func(e event.CreateEvent) bool { return true },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+
 	// TODO: replace the watches with For and Own
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("kibana-controller").
@@ -308,5 +316,6 @@ func (r *KibanaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			IsController: true,
 		}, builder.WithPredicates(routePred)).
 		Watches(&source.Kind{Type: &imagev1.ImageStream{}}, globalMapHandler, builder.WithPredicates(isPred)).
+		Watches(&source.Kind{Type: &configv1.OAuth{}}, globalMapHandler, builder.WithPredicates(oauthPred)).
 		Complete(r)
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -4,6 +4,7 @@ import "github.com/openshift/elasticsearch-operator/internal/utils"
 
 const (
 	ProxyName                   = "cluster"
+	OAuthName                   = "cluster"
 	TrustedCABundleKey          = "ca-bundle.crt"
 	TrustedCABundleMountDir     = "/etc/pki/ca-trust/extracted/pem/"
 	TrustedCABundleMountFile    = "tls-ca-bundle.pem"

--- a/internal/elasticsearch/common.go
+++ b/internal/elasticsearch/common.go
@@ -659,19 +659,22 @@ func newVolumeSource(ctx context.Context, logger logr.Logger, clusterName, nodeN
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: restricted-es-access
+
+	name: restricted-es-access
+
 spec:
-  podSelector:
-    matchLabels:
-      component: elasticsearch
-  ingress:
-  - from:
-    - podSelector:
-        matchLabels:
-          name: elasticsearch-operator
-    ports:
-    - protocol: TCP
-      port: 9200
+
+	podSelector:
+	  matchLabels:
+	    component: elasticsearch
+	ingress:
+	- from:
+	  - podSelector:
+	      matchLabels:
+	        name: elasticsearch-operator
+	  ports:
+	  - protocol: TCP
+	    port: 9200
 */
 func newNetworkPolicy(namespace string) networking.NetworkPolicy {
 	protocol := v1.ProtocolTCP

--- a/internal/kibana/kibana_test.go
+++ b/internal/kibana/kibana_test.go
@@ -32,6 +32,7 @@ var _ = Describe("Reconciling", func() {
 	_ = consolev1.AddToScheme(scheme.Scheme)
 	_ = loggingv1.SchemeBuilder.AddToScheme(scheme.Scheme)
 	_ = imagev1.AddToScheme(scheme.Scheme)
+	_ = configv1.AddToScheme(scheme.Scheme)
 
 	var (
 		logger  = log.NewLogger("kibana-testing")
@@ -140,6 +141,7 @@ var _ = Describe("Reconciling", func() {
 				},
 			},
 		}
+		oauth = &configv1.OAuth{}
 	)
 
 	Describe("Kibana", func() {
@@ -220,6 +222,7 @@ var _ = Describe("Reconciling", func() {
 					kibanaSecret,
 					kibanaProxySecret,
 					proxySourceImage,
+					oauth,
 				)
 				esClient = newFakeEsClient(client, fakeResponses)
 			})

--- a/internal/kibana/reconciler.go
+++ b/internal/kibana/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	kibana "github.com/openshift/elasticsearch-operator/apis/logging/v1"
 	"github.com/openshift/elasticsearch-operator/internal/constants"
@@ -38,6 +39,7 @@ const (
 	oauthProxyImageName          = "oauth-proxy"
 	oauthProxyNamespace          = "openshift"
 	oauthProxyTag                = "v4.4"
+	oauthTimeout                 = 24 * time.Hour
 )
 
 var kibanaServiceAccountAnnotations = map[string]string{
@@ -101,6 +103,19 @@ func Reconcile(log logr.Logger, requestCluster *kibana.Kibana, requestClient cli
 	}
 
 	return clusterKibanaRequest.UpdateStatus()
+}
+
+func getOAuthConfig(r client.Client) (*configv1.OAuth, error) {
+	oauthNamespacedName := types.NamespacedName{Name: constants.OAuthName}
+	oauthConfig := &configv1.OAuth{}
+	if err := r.Get(context.TODO(), oauthNamespacedName, oauthConfig); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, kverrors.Wrap(err, "encountered unexpected error getting oauth",
+				"oauth", oauthNamespacedName,
+			)
+		}
+	}
+	return oauthConfig, nil
 }
 
 func GetProxyConfig(r client.Client) (*configv1.Proxy, error) {
@@ -228,10 +243,21 @@ func (clusterRequest *KibanaRequest) createOrUpdateKibanaDeployment(proxyConfig 
 		return kverrors.Wrap(err, "Failed to get oauth-proxy image")
 	}
 
+	oauthConfig, err := getOAuthConfig(clusterRequest.client)
+	if err != nil {
+		return kverrors.Wrap(err, "Failed to get oauth config")
+	}
+
+	cookieTimeout := oauthTimeout
+	if oauthConfig != nil && oauthConfig.Spec.TokenConfig.AccessTokenInactivityTimeout != nil {
+		cookieTimeout = oauthConfig.Spec.TokenConfig.AccessTokenInactivityTimeout.Duration
+	}
+
 	kibanaPodSpec := newKibanaPodSpec(
 		clusterRequest,
 		fmt.Sprintf("%s.%s.svc", clusterName, clusterRequest.cluster.Namespace),
 		proxyConfig,
+		cookieTimeout,
 		kibanaTrustBundle,
 		oauthProxyImage,
 	)
@@ -501,7 +527,7 @@ func findTagReferencePolicy(tags []imagev1.TagReference, name string) imagev1.Ta
 	return ""
 }
 
-func newKibanaPodSpec(cluster *KibanaRequest, elasticsearchName string, proxyConfig *configv1.Proxy,
+func newKibanaPodSpec(cluster *KibanaRequest, elasticsearchName string, proxyConfig *configv1.Proxy, oauthTimeout time.Duration,
 	trustedCABundleCM *v1.ConfigMap, oauthProxyImage string) v1.PodSpec {
 	visSpec := kibana.KibanaSpec{}
 	if cluster.cluster != nil {
@@ -584,7 +610,7 @@ func newKibanaPodSpec(cluster *KibanaRequest, elasticsearchName string, proxyCon
 		fmt.Sprintf("-client-id=system:serviceaccount:%s:kibana", cluster.cluster.Namespace),
 		"-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token",
 		"-cookie-secret-file=/secret/session-secret",
-		"-cookie-expire=24h",
+		fmt.Sprintf("-cookie-expire=%s", oauthTimeout),
 		"-skip-provider-button",
 		"-skip-auth-regex=^/api/status$",
 		"-upstream=http://localhost:5601",

--- a/internal/utils/comparators/envvars.go
+++ b/internal/utils/comparators/envvars.go
@@ -6,12 +6,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-/**
+/*
+*
 EnvValueEqual - check if 2 EnvValues are equal or not
 Notes:
 - reflect.DeepEqual does not return expected results if the to-be-compared value is a pointer.
 - needs to adjust with k8s.io/api/core/v#/types.go when the types are updated.
-**/
+*
+*/
 func EnvValueEqual(lhs, rhs []v1.EnvVar) bool {
 	if len(lhs) != len(rhs) {
 		return false

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -179,12 +179,14 @@ func RemoveString(slice []string, s string) (result []string) {
 	return
 }
 
-/**
+/*
+*
 EnvValueEqual - check if 2 EnvValues are equal or not
 Notes:
 - reflect.DeepEqual does not return expected results if the to-be-compared value is a pointer.
 - needs to adjust with k8s.io/api/core/v#/types.go when the types are updated.
-**/
+*
+*/
 func EnvValueEqual(env1, env2 []corev1.EnvVar) bool {
 	var found bool
 	if len(env1) != len(env2) {


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR fixes the Kibana Oauth authentication expiration by synchronizing the Kibana authentication cookie expiration time with the OCP OAuth's `accessTokenInactivityTimeout`.

/cc @periklis 
/assign @jcantrill 

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: [LOG-3129](https://issues.redhat.com/browse/LOG-3129)
