### PR TITLE
Switched base image to ubi 8.7 to get FIPS to work

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -24,7 +24,7 @@ ADD ${REMOTE_SOURCE}/Makefile ${REMOTE_SOURCE}/main.go ${REMOTE_SOURCE}/go.mod $
 RUN make build
 
 #@follow_tag(registry.redhat.io/ubi8:latest)
-FROM docker.io/centos:8 AS centos
+FROM registry.redhat.io/ubi8/ubi:8.7-929
 LABEL \
         io.k8s.display-name="OpenShift elasticsearch-operator" \
         io.k8s.description="This is the component that manages an Elasticsearch cluster on a kubernetes based platform" \

--- a/dev-meta.yaml
+++ b/dev-meta.yaml
@@ -2,7 +2,7 @@ from:
 - source: registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder\:v(?:[\.0-9\-]*).*
   target: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12 AS builder
 - source: registry.redhat.io/ubi8:8.(\d)-([\.0-9])*
-  target: docker.io/centos:8 AS centos
+  target: registry.redhat.io/ubi8/ubi:8.7-929
 env:
 - source: RUNBOOK_BASE_URL=.*
   target: RUNBOOK_BASE_URL="https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md"


### PR DESCRIPTION
### Description
https://issues.redhat.com/browse/LOG-3220 describes a situation where OCP Logging fails to operate in a FIPS OCP cluster.
This change fixes a half of the failure. The other half is in the base image of the elasticsearch-proxy.

/cc @xperimental
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-3220
