### PR TITLE
allow changing deploy channel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ export GOFLAGS=
 export GO111MODULE=on
 
 export LOGGING_VERSION=5.6
+DEPLOY_CHANNEL?=$LOGGING_VERSION
 
 export APP_NAME=elasticsearch-operator
 

--- a/olm_deploy/scripts/operator-install.sh
+++ b/olm_deploy/scripts/operator-install.sh
@@ -22,7 +22,7 @@ echo "##################"
 oc create -n ${ELASTICSEARCH_OPERATOR_NAMESPACE} -f olm_deploy/subscription/operator-group.yaml
 
 # create the subscription
-export OPERATOR_PACKAGE_CHANNEL="\"${LOGGING_VERSION}\""
+export OPERATOR_PACKAGE_CHANNEL="\"${DEPLOY_CHANNEL:-$LOGGING_VERSION}\""
 subscription=$(envsubst < olm_deploy/subscription/subscription.yaml)
 echo "Creating:"
 echo "$subscription"


### PR DESCRIPTION
This PR:
* allows the deploy channel to be passed in.  Motivation is we should make master 'stable' and during branch cut it "should" facilitate the transition between the 2 branches 