### PR TITLE
[release-5.7] Bump bundle OCP max version property to 4.15

### DIFF
--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.12
+    value: 4.15


### PR DESCRIPTION
### Description
 The current main branch reflects also the next OpenShift Logging 5.7 release. This release will support up to OCP 4.15 based on our support policy.

/cc @xperimental @jcantrill 

### Links
- JIRA: LOG-3584
