### PR TITLE
[release-5.6] Bump bundle OCP max version property to 4.14

### DIFF
--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.12
+    value: 4.14


### PR DESCRIPTION
### Description
 The `release-5.6` branch will support up to and including OCP 4.13 based on our support policy.

/cc @xperimental @jcantrill 

### Links
- JIRA: [LOG-3584](https://issues.redhat.com//browse/LOG-3584)
