### PR TITLE
LOG-4041: Update skipRange to allow updating from 5.5 onwards

### DIFF
--- a/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
@@ -101,7 +101,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/elasticsearch-operator:latest
-    createdAt: "2023-03-14T15:12:58Z"
+    createdAt: "2023-05-04T16:19:19Z"
     description: |
       The Elasticsearch Operator for OCP provides a means for configuring and managing an Elasticsearch cluster for tracing and cluster logging.
       ## Prerequisites and Requirements
@@ -112,7 +112,7 @@ metadata:
       set of OCP nodes may not be large enough to support the Elasticsearch cluster.  Additional OCP nodes must be added
       to the OCP cluster if you desire to run with the recommended (or better) memory. Each ES node can operate with a
       lower memory setting though this is not recommended for production deployments.
-    olm.skipRange: '>=4.6.0-0 <5.7.0'
+    olm.skipRange: '>=5.5.0-0 <5.7.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'

--- a/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
@@ -98,7 +98,7 @@ metadata:
       set of OCP nodes may not be large enough to support the Elasticsearch cluster.  Additional OCP nodes must be added
       to the OCP cluster if you desire to run with the recommended (or better) memory. Each ES node can operate with a
       lower memory setting though this is not recommended for production deployments.
-    olm.skipRange: '>=4.6.0-0 <5.7.0'
+    olm.skipRange: '>=5.5.0-0 <5.7.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'


### PR DESCRIPTION
### Description

This changes the generated bundle to include a `skipRange` attribute that limits direct updates to only be able from 5.5 onwards.

### Links

- JIRA: [LOG-4041](https://issues.redhat.com//browse/LOG-4041)
