### PR TITLE
LOG-3837: Update skipRange to allow updating from 5.4 onwards

### DIFF
--- a/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
@@ -112,7 +112,7 @@ metadata:
       set of OCP nodes may not be large enough to support the Elasticsearch cluster.  Additional OCP nodes must be added
       to the OCP cluster if you desire to run with the recommended (or better) memory. Each ES node can operate with a
       lower memory setting though this is not recommended for production deployments.
-    olm.skipRange: '>=4.6.0-0 <5.6.0'
+    olm.skipRange: '>=5.4.0-0 <5.6.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'

--- a/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
@@ -98,7 +98,7 @@ metadata:
       set of OCP nodes may not be large enough to support the Elasticsearch cluster.  Additional OCP nodes must be added
       to the OCP cluster if you desire to run with the recommended (or better) memory. Each ES node can operate with a
       lower memory setting though this is not recommended for production deployments.
-    olm.skipRange: '>=4.6.0-0 <5.6.0'
+    olm.skipRange: '>=5.4.0-0 <5.6.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'


### PR DESCRIPTION
### Description

This changes the generated bundle to include a skipRange attribute that limits direct updates to only be able from 5.4 onwards.

### Links

- JIRA: LOG-3837
