### PR TITLE
LOG-4243: Bump ES default http.max_header_size to 512kb

### DIFF
--- a/internal/elasticsearch/configmaps_test.go
+++ b/internal/elasticsearch/configmaps_test.go
@@ -149,7 +149,7 @@ prometheus:
   query.metrics: true
 
 # increase the max header size above 8kb default
-http.max_header_size: 128kb
+http.max_header_size: 512kb
 
 opendistro_security:
   authcz.admin_dn:

--- a/internal/elasticsearch/configuration_tmpl.go
+++ b/internal/elasticsearch/configuration_tmpl.go
@@ -37,7 +37,7 @@ prometheus:
   query.metrics: true
 
 # increase the max header size above 8kb default
-http.max_header_size: 128kb
+http.max_header_size: 512kb
 
 opendistro_security:
   authcz.admin_dn:


### PR DESCRIPTION
### Description
Follow-up on [LOG-1899](https://issues.redhat.com//browse/LOG-1899) to increase the header size to allow operating on customer clusters with a huge amount of namespaces (>8000).

/cc @xperimental 

