### PR TITLE
Fix invalid CA certificate rotation on expiry

### DIFF
--- a/internal/elasticsearch/certificates.go
+++ b/internal/elasticsearch/certificates.go
@@ -742,9 +742,6 @@ func validateCASecret(secret *v1.Secret) (*certCA, error) {
 		return nil, err
 	}
 
-	if !isValidCA(x509Cert, rsaKey) {
-		return nil, fmt.Errorf("invalid CA")
-	}
 	return &certCA{
 		certificate{
 			certBytes,


### PR DESCRIPTION
### Description
Removes a duplicate CA validation check when expired that blocked CA certificate rotation.

/cc @xperimental 

### Links

- JIRA: LOG-4303
