### PR TITLE
LOG-4691: Revert Observability operatorhub category

### DIFF
--- a/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
@@ -98,7 +98,7 @@ metadata:
         }
       ]
     capabilities: Full Lifecycle
-    categories: OpenShift Optional, Logging & Tracing, Observability
+    categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/elasticsearch-operator:latest
     createdAt: "2023-12-06T07:03:48Z"

--- a/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
@@ -84,7 +84,7 @@ metadata:
         }
       ]
     capabilities: Full Lifecycle
-    categories: OpenShift Optional, Logging & Tracing, Observability
+    categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/elasticsearch-operator:latest
     createdAt: "2020-11-04T08:00:00Z"


### PR DESCRIPTION
### Description

Reverts new category introduced by #1003 until we the CVP pipeline allows it.

Replaces #1004 

/cc @xperimental /assign @periklis
