### PR TITLE
[release-5.8] LOG-5776: Skip overriding annotations provided by other controllers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ViaQ/logerr/v2 v2.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9
+	github.com/imdario/mergo v0.3.12
 	github.com/inhies/go-bytesize v0.0.0-20151001220322-5990f52c6ad6
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.24.1
@@ -37,7 +38,6 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
-	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect


### PR DESCRIPTION
### Description
Fix continuously generating secrets in the Elasticsearch, Kibana instance namespace on OCP 4.16

/cc @xperimental @JoaoBraveCoding 

### Links
- JIRA: [LOG-5776](https://issues.redhat.com//browse/LOG-5776)
