### PR TITLE
Fix support statement until catalog removal date

### DIFF
--- a/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
@@ -101,7 +101,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/elasticsearch-operator:latest
-    createdAt: "2024-08-01T13:01:04Z"
+    createdAt: "2024-09-17T14:18:55Z"
     description: |
       The Elasticsearch Operator for OCP provides a means for configuring and managing an Elasticsearch cluster for tracing and cluster logging.
       ## Prerequisites and Requirements
@@ -288,17 +288,17 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podStatuses
       version: v1
-  description: "### ONLY FOR OCP 4.16 \n\nELASTICSEARCH IS ONLY SUPPORTED FOR **SERVICEMESH,
-    TRACING, AND KIALI**, AND THIS OPERATOR **WILL BE REMOVED FROM THE OPENSHIFT OPERATOR
-    CATALOG IN NOVEMBER 2025**.  ELASTICSEARCH IS **NO LONGER SUPPORTED FOR LOG STORAGE**.
-    **KIBANA IS NO LONGER SUPPORTED** IN OCP 4.16 AND FORWARD. \n\n### About \n\nThe
-    Elasticsearch Operator for OCP provides a means for configuring and managing an
-    Elasticsearch cluster for use in tracing \nand cluster logging as well as a Kibana
-    instance to connect to it.\nThis operator only supports OCP Cluster Logging and
-    Jaeger.  It is tightly coupled to each and is not currently capable of\nbeing
-    used as a general purpose manager of Elasticsearch clusters running on OCP.\n\nPlease
-    note: For a general purpose Elasticsearch operator, please use Elastic's Elasticsearch
-    (ECK) Operator [here](https://catalog.redhat.com/software/containers/elastic/eck-operator/5fabf6d1ecb52450895164be?container-tabs=gti)\n\nIt
+  description: "### IN OCP 4.16 AND FORWARD \n\nELASTICSEARCH IS ONLY SUPPORTED FOR
+    **SERVICEMESH, TRACING, AND KIALI**, AND THIS OPERATOR **WILL BE REMOVED FROM
+    THE OPENSHIFT OPERATOR CATALOG IN NOVEMBER 2025**.  ELASTICSEARCH IS **NO LONGER
+    SUPPORTED FOR LOG STORAGE**. **KIBANA IS NO LONGER SUPPORTED** IN OCP 4.16 AND
+    FORWARD. \n\n### About \n\nThe Elasticsearch Operator for OCP provides a means
+    for configuring and managing an Elasticsearch cluster for use in tracing \nand
+    cluster logging as well as a Kibana instance to connect to it.\nThis operator
+    only supports OCP Cluster Logging and Jaeger.  It is tightly coupled to each and
+    is not currently capable of\nbeing used as a general purpose manager of Elasticsearch
+    clusters running on OCP.\n\nPlease note: For a general purpose Elasticsearch operator,
+    please use Elastic's Elasticsearch (ECK) Operator [here](https://catalog.redhat.com/software/containers/elastic/eck-operator/5fabf6d1ecb52450895164be?container-tabs=gti)\n\nIt
     is recommended that this operator be installed in the `openshift-operators-redhat`
     namespace to \nproperly support the Cluster Logging and Jaeger use cases.\n\nOnce
     installed, the operator provides the following features for **Elasticsearch**:\n*

--- a/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
@@ -274,17 +274,17 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podStatuses
       version: v1
-  description: "### ONLY FOR OCP 4.16 \n\nELASTICSEARCH IS ONLY SUPPORTED FOR **SERVICEMESH,
-    TRACING, AND KIALI**, AND THIS OPERATOR **WILL BE REMOVED FROM THE OPENSHIFT OPERATOR
-    CATALOG IN NOVEMBER 2025**.  ELASTICSEARCH IS **NO LONGER SUPPORTED FOR LOG STORAGE**.
-    **KIBANA IS NO LONGER SUPPORTED** IN OCP 4.16 AND FORWARD. \n\n### About \n\nThe
-    Elasticsearch Operator for OCP provides a means for configuring and managing an
-    Elasticsearch cluster for use in tracing \nand cluster logging as well as a Kibana
-    instance to connect to it.\nThis operator only supports OCP Cluster Logging and
-    Jaeger.  It is tightly coupled to each and is not currently capable of\nbeing
-    used as a general purpose manager of Elasticsearch clusters running on OCP.\n\nPlease
-    note: For a general purpose Elasticsearch operator, please use Elastic's Elasticsearch
-    (ECK) Operator [here](https://catalog.redhat.com/software/containers/elastic/eck-operator/5fabf6d1ecb52450895164be?container-tabs=gti)\n\nIt
+  description: "### IN OCP 4.16 AND FORWARD \n\nELASTICSEARCH IS ONLY SUPPORTED FOR
+    **SERVICEMESH, TRACING, AND KIALI**, AND THIS OPERATOR **WILL BE REMOVED FROM
+    THE OPENSHIFT OPERATOR CATALOG IN NOVEMBER 2025**.  ELASTICSEARCH IS **NO LONGER
+    SUPPORTED FOR LOG STORAGE**. **KIBANA IS NO LONGER SUPPORTED** IN OCP 4.16 AND
+    FORWARD. \n\n### About \n\nThe Elasticsearch Operator for OCP provides a means
+    for configuring and managing an Elasticsearch cluster for use in tracing \nand
+    cluster logging as well as a Kibana instance to connect to it.\nThis operator
+    only supports OCP Cluster Logging and Jaeger.  It is tightly coupled to each and
+    is not currently capable of\nbeing used as a general purpose manager of Elasticsearch
+    clusters running on OCP.\n\nPlease note: For a general purpose Elasticsearch operator,
+    please use Elastic's Elasticsearch (ECK) Operator [here](https://catalog.redhat.com/software/containers/elastic/eck-operator/5fabf6d1ecb52450895164be?container-tabs=gti)\n\nIt
     is recommended that this operator be installed in the `openshift-operators-redhat`
     namespace to \nproperly support the Cluster Logging and Jaeger use cases.\n\nOnce
     installed, the operator provides the following features for **Elasticsearch**:\n*


### PR DESCRIPTION
### Description

Adapt support statement to make it clear that OCP Elasticsearch Operator will be available on all supported OCP versions until November 2025.

![image](https://github.com/user-attachments/assets/abd30a3e-8684-4f14-af89-3f766a67ab2c)

/cc @xperimental @JoaoBraveCoding 