### PR TITLE
Bump max openshift version 4.18

### DIFF
--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.16
+    value: 4.18


### PR DESCRIPTION
### Description

Follow-up on #1015 to support installs for related products up to OCP cluster upgrades to 4.18

/cc @xperimental @JoaoBraveCoding 
